### PR TITLE
Implement remote volume provider blacklist

### DIFF
--- a/app/Http/Requests/StoreVolume.php
+++ b/app/Http/Requests/StoreVolume.php
@@ -50,7 +50,6 @@ class StoreVolume extends FormRequest
             'files' => [
                 'required',
                 'array',
-                new VolumeFiles($this->input('url'), $this->input('media_type_id')),
             ],
             'doi' => 'max:512',
             'metadata_csv' => 'file|mimetypes:text/plain,text/csv',
@@ -61,6 +60,27 @@ class StoreVolume extends FormRequest
             // this leads to a request timeout when the rule is expanded for a huge
             // number of files.
         ];
+    }
+
+    /**
+     * Configure the validator instance.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return void
+     */
+    public function withValidator($validator)
+    {
+        if ($validator->fails()) {
+            return;
+        }
+
+        // Only validate sample volume files after all other fields have been validated.
+        $validator->after(function ($validator) {
+            $rule = new VolumeFiles($this->input('url'), $this->input('media_type_id'));
+            if (!$rule->passes('files', $this->input('files'))) {
+                $validator->errors()->add('files', $rule->message());
+            }
+        });
     }
 
     /**

--- a/app/Rules/VolumeUrl.php
+++ b/app/Rules/VolumeUrl.php
@@ -149,10 +149,10 @@ class VolumeUrl implements Rule
     {
         foreach (self::PROVIDER_BLACKLIST_REGEX as $regex) {
             if (preg_match("/{$regex}/i", $value) === 1) {
-                return false;
+                return true;
             }
         }
 
-        return true;
+        return false;
     }
 }

--- a/tests/php/Http/Controllers/Api/ProjectVolumeControllerTest.php
+++ b/tests/php/Http/Controllers/Api/ProjectVolumeControllerTest.php
@@ -485,6 +485,33 @@ class ProjectVolumeControllerTest extends ApiTestCase
         });
     }
 
+    public function testStoreProviderBlacklist()
+    {
+        $id = $this->project()->id;
+        $this->beAdmin();
+        $this->postJson("/api/v1/projects/{$id}/volumes", [
+                'name' => 'my volume no. 1',
+                'url' => 'https://dropbox.com',
+                'media_type' => 'image',
+                'files' => ['1.jpg', '2.jpg'],
+            ])
+            ->assertStatus(422);
+        $this->postJson("/api/v1/projects/{$id}/volumes", [
+                'name' => 'my volume no. 1',
+                'url' => 'https://onedrive.com',
+                'media_type' => 'image',
+                'files' => ['1.jpg', '2.jpg'],
+            ])
+            ->assertStatus(422);
+        $this->postJson("/api/v1/projects/{$id}/volumes", [
+                'name' => 'my volume no. 1',
+                'url' => 'https://drive.google.com',
+                'media_type' => 'image',
+                'files' => ['1.jpg', '2.jpg'],
+            ])
+            ->assertStatus(422);
+    }
+
     public function testAttach()
     {
         $tid = $this->volume->id;

--- a/tests/php/Http/Controllers/Api/ProjectVolumeControllerTest.php
+++ b/tests/php/Http/Controllers/Api/ProjectVolumeControllerTest.php
@@ -496,20 +496,6 @@ class ProjectVolumeControllerTest extends ApiTestCase
                 'files' => ['1.jpg', '2.jpg'],
             ])
             ->assertStatus(422);
-        $this->postJson("/api/v1/projects/{$id}/volumes", [
-                'name' => 'my volume no. 1',
-                'url' => 'https://onedrive.com',
-                'media_type' => 'image',
-                'files' => ['1.jpg', '2.jpg'],
-            ])
-            ->assertStatus(422);
-        $this->postJson("/api/v1/projects/{$id}/volumes", [
-                'name' => 'my volume no. 1',
-                'url' => 'https://drive.google.com',
-                'media_type' => 'image',
-                'files' => ['1.jpg', '2.jpg'],
-            ])
-            ->assertStatus(422);
     }
 
     public function testAttach()

--- a/tests/php/Http/Controllers/Api/ProjectVolumeControllerTest.php
+++ b/tests/php/Http/Controllers/Api/ProjectVolumeControllerTest.php
@@ -287,6 +287,8 @@ class ProjectVolumeControllerTest extends ApiTestCase
 
     public function testStoreFilesExistException()
     {
+        Storage::disk('test')->makeDirectory('images');
+        Storage::disk('test')->put('images/1.jpg', 'abc');
         $id = $this->project()->id;
         $this->beAdmin();
         FileCache::shouldReceive('exists')

--- a/tests/php/Http/Controllers/Api/VolumeControllerTest.php
+++ b/tests/php/Http/Controllers/Api/VolumeControllerTest.php
@@ -131,6 +131,14 @@ class VolumeControllerTest extends ApiTestCase
         $this->assertEquals('test://volumes', $this->volume()->fresh()->url);
     }
 
+    public function testUpdateUrlProviderBlacklist()
+    {
+        $this->beAdmin();
+        $this->json('PUT', '/api/v1/volumes/'.$this->volume()->id, [
+            'url' => 'https://dropbox.com',
+        ])->assertStatus(422);
+    }
+
     public function testUpdateGlobalAdmin()
     {
         $this->beGlobalAdmin();

--- a/tests/php/Rules/VolumeUrlTest.php
+++ b/tests/php/Rules/VolumeUrlTest.php
@@ -116,4 +116,18 @@ class VolumeUrlTest extends TestCase
         $this->assertFalse($validator->passes(null, 'http://localhost'));
         $this->assertStringContainsString("disk 'http' does not exist", $validator->message());
     }
+
+    public function testRemoteProviderBlacklist()
+    {
+        $validator = new VolumeUrl;
+        $this->assertFalse($validator->passes(null, 'http://dropbox.com'));
+        $this->assertStringContainsString('are not supported as remote locations', $validator->message());
+        $this->assertFalse($validator->passes(null, 'https://dropbox.com'));
+        $this->assertFalse($validator->passes(null, 'http://www.dropbox.com'));
+        $this->assertFalse($validator->passes(null, 'https://www.dropbox.com'));
+        $this->assertFalse($validator->passes(null, 'http://onedrive.com'));
+        $this->assertFalse($validator->passes(null, 'https://onedrive.com'));
+        $this->assertFalse($validator->passes(null, 'http://drive.google.com'));
+        $this->assertFalse($validator->passes(null, 'https://drive.google.com'));
+    }
 }


### PR DESCRIPTION
- [x] Make sure that the `files` are validated only after the `url` in the `StoreVolume` request. 
- [x] Add tests for the `VolumeController`
- [x] Add tests for the `VolumeUrl` rule

Resolves #373