### PR TITLE
Fix API-Documentation {id}/files/filter/annotation-user/{id2}

### DIFF
--- a/app/Http/Controllers/Api/Annotations/Filters/AnnotationUserController.php
+++ b/app/Http/Controllers/Api/Annotations/Filters/AnnotationUserController.php
@@ -13,7 +13,7 @@ class AnnotationUserController extends Controller
     /**
      * List the IDs of images having one or more annotations of the specified user.
      *
-     * @api {get} volumes/:tid/images/filter/annotation-user/:uid Get all images having annotations of a user
+     * @api {get} volumes/:tid/files/filter/annotation-user/:uid Get all images having annotations of a user
      * @apiGroup Volumes
      * @apiName VolumeImagesHasUser
      * @apiPermission projectMember


### PR DESCRIPTION
Fix documentation for API-call to get all images having annotations of a user