### PR TITLE
allow external tls proxy for nossl nginx config

### DIFF
--- a/.docker/vhost-no-ssl.conf
+++ b/.docker/vhost-no-ssl.conf
@@ -36,8 +36,10 @@ server {
         fastcgi_pass            app:9000;
         fastcgi_index           index.php;
         include                 fastcgi_params;
-        fastcgi_param           HTTPS $fastcgi_param_https_variable if_not_empty;
         fastcgi_param           SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param           PATH_INFO $fastcgi_path_info;
+        # Pass on HTTPS protocol if this instance runs behind a proxy that terminates
+        # the TLS connection.
+        fastcgi_param           HTTPS $fastcgi_param_https_variable if_not_empty;
     }
 }

--- a/.docker/worker.dockerfile
+++ b/.docker/worker.dockerfile
@@ -146,7 +146,7 @@ RUN apk add --no-cache --virtual .build-deps \
 RUN [ -z "$HTTP_PROXY" ] || pear config-set http_proxy ""
 
 # Other Python dependencies are added with the OpenCV build above.
-RUN apk add --no-cache py3-scipy py3-scikit-learn py3-matplotlib
+RUN apk add --no-cache py3-scipy py3-scikit-learn py3-matplotlib py3-shapely
 
 # Set this library path so the Python modules are linked correctly.
 # See: https://github.com/python-pillow/Pillow/issues/1763#issuecomment-204252397

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scikit-learn
 matplotlib==3.5.2
 PyExcelerate==0.6.7
 Pillow==9.0.*
+Shapely==1.8.1


### PR DESCRIPTION
Hi, 

I ran into this small problem while setting up biigle - we have multiple websites on a server and a single nginx is terminating tls in front of docker. This pull request passes the headers on to PHP and allows using biigle with TLS even if no certificates are configured. Everything should still work without any ssl. 

Example nginx configuration outside of docker: 

``` 
server { 
  
    listen 443 ssl; 
    ssl_certificate /etc/letsencrypt/live/foo.bar.baz/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/foo.bar.baz/privkey.pem; 
    include /etc/letsencrypt/options-ssl-nginx.conf; 

   server_name foo.bar.baz;

  location / {
    proxy_set_header Host $http_host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Host $host;
    proxy_pass http://127.0.0.1:8099;
  }
} 
``` 

`docker-compose.yml` can be used like in the no-ssl documentation: 

``` 
  web:
    image: biigle/web-dist
    restart: always
    depends_on:
      - app
    volumes:
      - type: bind
        source: ./certificate
        target: /etc/letsencrypt/live/example.com
        read_only: true
      - type: bind
        source: ./storage
        target: /var/www/storage
        read_only: true
    ports:
      - 127.0.0.1:8099:80
    # Uncomment to use the webserver without SSL:
    command: nginx -g 'daemon off;' -c /etc/nginx/nginx-no-ssl.conf
``` 

maybe it's useful. 

