### PR TITLE
Fix bulk annotation API validation

### DIFF
--- a/tests/php/Http/Controllers/Api/ImageAnnotationBulkControllerTest.php
+++ b/tests/php/Http/Controllers/Api/ImageAnnotationBulkControllerTest.php
@@ -186,6 +186,15 @@ class ImageAnnotationBulkControllerTest extends ApiTestCase
             ->assertStatus(422);
 
         $this->assertEquals(1, $this->annotation->image->annotations()->count());
+
+        $this->postJson($url, [[
+                'image_id' => $this->annotation->image_id + 0.9,
+                'shape_id' => Shape::pointId(),
+                'points' => [100, 100],
+                'label_id' => $this->labelRoot()->id,
+                'confidence' => 999,
+            ]])
+            ->assertStatus(422);
     }
 
     public function testStoreLimit()

--- a/tests/php/Http/Controllers/Api/ImageAnnotationBulkControllerTest.php
+++ b/tests/php/Http/Controllers/Api/ImageAnnotationBulkControllerTest.php
@@ -195,6 +195,15 @@ class ImageAnnotationBulkControllerTest extends ApiTestCase
                 'confidence' => 999,
             ]])
             ->assertStatus(422);
+
+        $this->postJson($url, [[
+                'image_id' => $this->annotation->image_id,
+                'shape_id' => Shape::pointId(),
+                'points' => [100, 100],
+                'label_id' => $this->labelRoot()->id + 0.9,
+                'confidence' => 999,
+            ]])
+            ->assertStatus(422);
     }
 
     public function testStoreLimit()


### PR DESCRIPTION
The API endpoint does not validate the image IDs.