### PR TITLE
Add a migration to fix volume URLs with trailing slash

### DIFF
--- a/database/migrations/2023_06_02_101511_fix_volume_url_trailing_slash.php
+++ b/database/migrations/2023_06_02_101511_fix_volume_url_trailing_slash.php
@@ -1,0 +1,33 @@
+<?php
+
+use Biigle\Volume;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Volume::where('url', 'like', '%/')->eachById(function ($volume) {
+            // This will strip trailing slashes where necessary.
+            $volume->url = $volume->url;
+            $volume->save();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+};


### PR DESCRIPTION
See: 1a86a6d9988fdbb5c73212eff29ddf1c45d77cfa
See: e88c00c13db65f6b157225eaf4b7e9de39f905bd