### PR TITLE
Fix multiple projects dropdown in image annotation tool

### DIFF
--- a/resources/assets/sass/annotations/main.scss
+++ b/resources/assets/sass/annotations/main.scss
@@ -22,7 +22,7 @@
 }
 
 // Assign dropdown an own css class due to bug #583
-.annotations-project-dd{
+.annotations-project-dd {
     display: inline-block;
     vertical-align: bottom;
     white-space: nowrap;

--- a/resources/assets/sass/annotations/main.scss
+++ b/resources/assets/sass/annotations/main.scss
@@ -21,6 +21,13 @@
     vertical-align: bottom;
 }
 
+// Assign dropdown an own css class due to bug #583
+.annotations-project-dd{
+    display: inline-block;
+    vertical-align: bottom;
+    white-space: nowrap;
+}
+
 .sidebar-tab__section {
     padding-bottom: 10px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);

--- a/resources/views/annotations/show.blade.php
+++ b/resources/views/annotations/show.blade.php
@@ -30,8 +30,10 @@
 
 @section('navbar')
 <div class="navbar-text">
-    <div class="annotations-breadcrumb">
+    <div class="annotations-project-dd">
         @include('volumes.partials.projectsBreadcrumb', ['projects' => $volume->projects]) /
+    </div>
+    <div class="annotations-breadcrumb">
         <a href="{{route('volume', $volume->id)}}" class="navbar-link" title="Show volume {{$volume->name}}">{{$volume->name}}</a> /
         <span id="annotations-navbar">
             <breadcrumb


### PR DESCRIPTION
Css class 'annotations-breadcrumb' prevents displaying project dropdown because of 'overflow: hidden;' property.

Move `@include(...)` line for dropdown outside the css class scope and wrap it in own div element with own css class.