### PR TITLE
Fix the server error caused by attaching a label to an existing video annotation

### DIFF
--- a/app/Http/Controllers/Api/VideoAnnotationLabelController.php
+++ b/app/Http/Controllers/Api/VideoAnnotationLabelController.php
@@ -6,6 +6,8 @@ use Biigle\Http\Controllers\Api\Controller;
 use Biigle\Http\Requests\DestroyVideoAnnotationLabel;
 use Biigle\Http\Requests\StoreVideoAnnotationLabel;
 use Biigle\VideoAnnotationLabel;
+use Illuminate\Database\QueryException;
+use Str;
 
 class VideoAnnotationLabelController extends Controller
 {


### PR DESCRIPTION
Attaching a label to an existing video annotation can cause a sever error when using the double click. Use the same strategy as in ImageAnnotationLabelController to fix that bug.

Resolves #410 