### PR TITLE
WoRMS errors are caught and handled

### DIFF
--- a/app/Http/Controllers/Api/LabelSourceController.php
+++ b/app/Http/Controllers/Api/LabelSourceController.php
@@ -4,8 +4,6 @@ namespace Biigle\Http\Controllers\Api;
 
 use Biigle\LabelSource;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
-use SoapFault;
 
 class LabelSourceController extends Controller
 {
@@ -29,12 +27,6 @@ class LabelSourceController extends Controller
         $source = LabelSource::findOrFail($id);
         $this->validate($request, ['query' => 'required']);
 
-        // Catch SoapFault exception, if WoRMS server is not available due to maintenance, etc...
-        try {
-            $result = $source->getAdapter()->find($request);
-        } catch (SoapFault $sf) {
-            $result = response(['message' => 'The label source is currently unavailable.'], Response::HTTP_SERVICE_UNAVAILABLE);
-        }
-        return $result;
+        return $source->getAdapter()->find($request);
     }
 }

--- a/app/Http/Controllers/Api/LabelSourceController.php
+++ b/app/Http/Controllers/Api/LabelSourceController.php
@@ -4,8 +4,6 @@ namespace Biigle\Http\Controllers\Api;
 
 use Biigle\LabelSource;
 use Illuminate\Http\Request;
-use \Illuminate\Http\Response;
-use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 class LabelSourceController extends Controller
 {
@@ -29,14 +27,7 @@ class LabelSourceController extends Controller
         $source = LabelSource::findOrFail($id);
         $this->validate($request, ['query' => 'required']);
 
-        try{
-        $response = $source->getAdapter()->find($request);
-        } catch(ServiceUnavailableHttpException $suhe){
-            // getMessage() is not implemented for Symfony ServiceUnavailableHttpException
-            $message = $suhe->getHeaders()['Retry-After'];
-            $response = response(['message' => $suhe->getMessage()], Response::HTTP_SERVICE_UNAVAILABLE);
+        return $source->getAdapter()->find($request);
 
-        }
-        return $response;
     }
 }

--- a/app/Http/Controllers/Api/LabelSourceController.php
+++ b/app/Http/Controllers/Api/LabelSourceController.php
@@ -4,6 +4,8 @@ namespace Biigle\Http\Controllers\Api;
 
 use Biigle\LabelSource;
 use Illuminate\Http\Request;
+use \Illuminate\Http\Response;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 class LabelSourceController extends Controller
 {
@@ -27,6 +29,14 @@ class LabelSourceController extends Controller
         $source = LabelSource::findOrFail($id);
         $this->validate($request, ['query' => 'required']);
 
-        return $source->getAdapter()->find($request);
+        try{
+        $response = $source->getAdapter()->find($request);
+        } catch(ServiceUnavailableHttpException $suhe){
+            // getMessage() is not implemented for Symfony ServiceUnavailableHttpException
+            $message = $suhe->getHeaders()['Retry-After'];
+            $response = response(['message' => $suhe->getMessage()], Response::HTTP_SERVICE_UNAVAILABLE);
+
+        }
+        return $response;
     }
 }

--- a/app/Services/LabelSourceAdapters/WormsAdapter.php
+++ b/app/Services/LabelSourceAdapters/WormsAdapter.php
@@ -101,17 +101,17 @@ class WormsAdapter implements LabelSourceAdapterContract
                 $offset += 50;
             } while (count($currentResults) === 50 && $offset < self::MAX_RESULTS);
 
-        } catch(\SoapFault $sf) {
+        } catch (\SoapFault $sf) {
             throw new ServiceUnavailableHttpException(message: 'The WoRMS server is currently unavailable.');
         }
 
-            if (!$request->input('unaccepted', false)) {
-                // use array_values because array_filter retains the keys and this might
-                // produce a JSON object output and no array output in the HTTP response
-                $results = array_values(array_filter($results, [$this, 'filterUnaccepted']));
-            }
+        if (!$request->input('unaccepted', false)) {
+            // use array_values because array_filter retains the keys and this might
+            // produce a JSON object output and no array output in the HTTP response
+            $results = array_values(array_filter($results, [$this, 'filterUnaccepted']));
+        }
 
-            return array_map([$this, 'parseItem'], $results);
+        return array_map([$this, 'parseItem'], $results);
     }
 
     /**
@@ -168,11 +168,11 @@ class WormsAdapter implements LabelSourceAdapterContract
                 return $this->createRecursiveLabels($attributes);
             }
 
-        } catch(\SoapFault $sf) {
+        } catch (\SoapFault $sf) {
             throw new ServiceUnavailableHttpException(message: 'The WoRMS server is currently unavailable.');
         }
 
-            return [$this->createSingleLabel($attributes)];
+        return [$this->createSingleLabel($attributes)];
     
     }
 

--- a/app/Services/LabelSourceAdapters/WormsAdapter.php
+++ b/app/Services/LabelSourceAdapters/WormsAdapter.php
@@ -173,7 +173,6 @@ class WormsAdapter implements LabelSourceAdapterContract
         }
 
         return [$this->createSingleLabel($attributes)];
-    
     }
 
     /**

--- a/app/Services/LabelSourceAdapters/WormsAdapter.php
+++ b/app/Services/LabelSourceAdapters/WormsAdapter.php
@@ -9,6 +9,8 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Ramsey\Uuid\Uuid;
 use SoapClient;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
+use \Illuminate\Http\Response;
 
 /**
  * WoRMS label source adapter.
@@ -77,32 +79,39 @@ class WormsAdapter implements LabelSourceAdapterContract
             return [];
         }
 
-        $client = $this->getSoapClient();
+        try {
+            $client = $this->getSoapClient();
 
-        // WoRMS returns a maximum of 50 results per request. We use a loop to get more
-        // results but take care to stop it if it runs too often.
-        do {
-            // Method signature is:
-            // string $like Add a '%'-sign added after the ScientificName (SQL LIKE function). Default=true
-            // bool $like (deprecated)
-            // bool $fuzzy (deprecated)
-            // bool $marine_only Limit to marine taxa. Default=true
-            // int $offset Starting recordnumber, when retrieving next chunk of (50) records. Default=1
-            $currentResults = $client->getAphiaRecords("%{$query}%", null, null, true, $offset);
-            if (!is_array($currentResults)) {
-                break;
-            }
-            $results = array_merge($results, $currentResults);
-            $offset += 50;
-        } while (count($currentResults) === 50 && $offset < self::MAX_RESULTS);
+            // WoRMS returns a maximum of 50 results per request. We use a loop to get more
+            // results but take care to stop it if it runs too often.
+            do {
+                // Method signature is:
+                // string $like Add a '%'-sign added after the ScientificName (SQL LIKE function). Default=true
+                // bool $like (deprecated)
+                // bool $fuzzy (deprecated)
+                // bool $marine_only Limit to marine taxa. Default=true
+                // int $offset Starting recordnumber, when retrieving next chunk of (50) records. Default=1
+            
+                $currentResults = $client->getAphiaRecords("%{$query}%", null, null, true, $offset);
+            
+                if (!is_array($currentResults)) {
+                    break;
+                }
+                $results = array_merge($results, $currentResults);
+                $offset += 50;
+            } while (count($currentResults) === 50 && $offset < self::MAX_RESULTS);
 
-        if (!$request->input('unaccepted', false)) {
-            // use array_values because array_filter retains the keys and this might
-            // produce a JSON object output and no array output in the HTTP response
-            $results = array_values(array_filter($results, [$this, 'filterUnaccepted']));
+        } catch(\SoapFault $sf) {
+            throw new ServiceUnavailableHttpException(Response::HTTP_SERVICE_UNAVAILABLE,'The label source WoRMS is currently unavailable.');
         }
 
-        return array_map([$this, 'parseItem'], $results);
+            if (!$request->input('unaccepted', false)) {
+                // use array_values because array_filter retains the keys and this might
+                // produce a JSON object output and no array output in the HTTP response
+                $results = array_values(array_filter($results, [$this, 'filterUnaccepted']));
+            }
+
+            return array_map([$this, 'parseItem'], $results);
     }
 
     /**
@@ -137,27 +146,34 @@ class WormsAdapter implements LabelSourceAdapterContract
 
         $attributes['parent_id'] = $request->input('parent_id');
         $attributes['label_tree_id'] = $id;
-        $client = $this->getSoapClient();
 
-        if ($client->getAphiaNameByID($attributes['source_id']) === null) {
-            throw ValidationException::withMessages([
-                'source_id' => ['The AphiaID does not exist.'],
-            ]);
-        }
-
-        $recursive = $request->input('recursive', 'false');
-
-        if ($recursive === 'true') {
-            if ($request->has('parent_id')) {
+        try {
+            $client = $this->getSoapClient();
+        
+            if ($client->getAphiaNameByID($attributes['source_id']) === null) {
                 throw ValidationException::withMessages([
-                    'parent_id' => ['The label must not have a parent if it should be created recursively.'],
+                    'source_id' => ['The AphiaID does not exist.'],
                 ]);
             }
 
-            return $this->createRecursiveLabels($attributes);
+            $recursive = $request->input('recursive', 'false');
+
+            if ($recursive === 'true') {
+                if ($request->has('parent_id')) {
+                    throw ValidationException::withMessages([
+                        'parent_id' => ['The label must not have a parent if it should be created recursively.'],
+                    ]);
+                }
+
+                return $this->createRecursiveLabels($attributes);
+            }
+
+        } catch(\SoapFault $sf) {
+            throw new ServiceUnavailableHttpException(Response::HTTP_SERVICE_UNAVAILABLE,'The label source WoRMS is currently unavailable.');
         }
 
-        return [$this->createSingleLabel($attributes)];
+            return [$this->createSingleLabel($attributes)];
+    
     }
 
     /**

--- a/app/Services/LabelSourceAdapters/WormsAdapter.php
+++ b/app/Services/LabelSourceAdapters/WormsAdapter.php
@@ -2,6 +2,7 @@
 
 namespace Biigle\Services\LabelSourceAdapters;
 
+use \Illuminate\Http\Response;
 use Arr;
 use Biigle\Contracts\LabelSourceAdapterContract;
 use Biigle\Label;
@@ -10,7 +11,6 @@ use Illuminate\Validation\ValidationException;
 use Ramsey\Uuid\Uuid;
 use SoapClient;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
-use \Illuminate\Http\Response;
 
 /**
  * WoRMS label source adapter.
@@ -102,7 +102,7 @@ class WormsAdapter implements LabelSourceAdapterContract
             } while (count($currentResults) === 50 && $offset < self::MAX_RESULTS);
 
         } catch(\SoapFault $sf) {
-            throw new ServiceUnavailableHttpException(Response::HTTP_SERVICE_UNAVAILABLE,'The label source WoRMS is currently unavailable.');
+            throw new ServiceUnavailableHttpException(message: 'The WoRMS server is currently unavailable.');
         }
 
             if (!$request->input('unaccepted', false)) {
@@ -169,7 +169,7 @@ class WormsAdapter implements LabelSourceAdapterContract
             }
 
         } catch(\SoapFault $sf) {
-            throw new ServiceUnavailableHttpException(Response::HTTP_SERVICE_UNAVAILABLE,'The label source WoRMS is currently unavailable.');
+            throw new ServiceUnavailableHttpException(message: 'The WoRMS server is currently unavailable.');
         }
 
             return [$this->createSingleLabel($attributes)];

--- a/tests/php/Http/Controllers/Api/LabelSourceControllerTest.php
+++ b/tests/php/Http/Controllers/Api/LabelSourceControllerTest.php
@@ -8,7 +8,6 @@ use Biigle\Tests\LabelSourceTest;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Mockery;
-use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 class LabelSourceControllerTest extends ApiTestCase
 {

--- a/tests/php/Http/Controllers/Api/LabelSourceControllerTest.php
+++ b/tests/php/Http/Controllers/Api/LabelSourceControllerTest.php
@@ -8,6 +8,7 @@ use Biigle\Tests\LabelSourceTest;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Mockery;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 class LabelSourceControllerTest extends ApiTestCase
 {
@@ -40,14 +41,14 @@ class LabelSourceControllerTest extends ApiTestCase
         $response->assertExactJson([['name' => 'My Query Label']]);
     }
 
-    public function testFindWithException()
+    public function testFindThrowException()
     {
         $source = LabelSourceTest::create(['name' => 'my_source']);
 
         $mock = Mockery::mock();
         $mock->shouldReceive('find')
             ->once()
-            ->andThrow(new \SoapFault('test', 'test')); // faultcode and faultstring parameter must to be set
+            ->andThrow(new ServiceUnavailableHttpException(Response::HTTP_SERVICE_UNAVAILABLE, 'test'));
 
         App::singleton('Biigle\Services\LabelSourceAdapters\MySourceAdapter', function () use ($mock) {
             return $mock;
@@ -59,8 +60,7 @@ class LabelSourceControllerTest extends ApiTestCase
             'query' => 'my query',
         ]);
         $response->assertStatus(Response::HTTP_SERVICE_UNAVAILABLE);
-
-
+        $response->assertContent('{"message":"test"}');
 
     }
 }

--- a/tests/php/Http/Controllers/Api/LabelSourceControllerTest.php
+++ b/tests/php/Http/Controllers/Api/LabelSourceControllerTest.php
@@ -40,27 +40,4 @@ class LabelSourceControllerTest extends ApiTestCase
         $response->assertStatus(200);
         $response->assertExactJson([['name' => 'My Query Label']]);
     }
-
-    public function testFindThrowException()
-    {
-        $source = LabelSourceTest::create(['name' => 'my_source']);
-
-        $mock = Mockery::mock();
-        $mock->shouldReceive('find')
-            ->once()
-            ->andThrow(new ServiceUnavailableHttpException(Response::HTTP_SERVICE_UNAVAILABLE, 'test'));
-
-        App::singleton('Biigle\Services\LabelSourceAdapters\MySourceAdapter', function () use ($mock) {
-            return $mock;
-        });
-
-        $this->beGuest();
-
-        $response = $this->json('GET', "/api/v1/label-sources/{$source->id}/find", [
-            'query' => 'my query',
-        ]);
-        $response->assertStatus(Response::HTTP_SERVICE_UNAVAILABLE);
-        $response->assertContent('{"message":"test"}');
-
-    }
 }

--- a/tests/php/Services/LabelSourceAdapters/WormsAdapterTest.php
+++ b/tests/php/Services/LabelSourceAdapters/WormsAdapterTest.php
@@ -127,7 +127,7 @@ class WormsAdapterTest extends TestCase
         $mock = Mockery::mock(SoapClient::class);
         $mock->shouldReceive('getAphiaRecords')
             ->once()
-            ->andThrow(new ServiceUnavailableHttpException(Response::HTTP_SERVICE_UNAVAILABLE, 'test'));
+            ->andThrow(new \SoapFault(code: Response::HTTP_SERVICE_UNAVAILABLE, string: 'test'));
 
         $adapter = new WormsAdapter;
         $adapter->setSoapClient($mock);
@@ -137,9 +137,9 @@ class WormsAdapterTest extends TestCase
 
         try {
             $adapter->find($request);
-        } catch(ServiceUnavailableHttpException $e) {
+        } catch (ServiceUnavailableHttpException $e) {
             $this->assertEquals(Response::HTTP_SERVICE_UNAVAILABLE, $e->getStatusCode());
-            $this->assertEquals('test', $e->getMessage());
+            $this->assertEquals('The WoRMS server is currently unavailable.', $e->getMessage());
         }
     }
 
@@ -201,20 +201,20 @@ class WormsAdapterTest extends TestCase
         $mock = Mockery::mock(SoapClient::class);
         $mock->shouldReceive('getAphiaNameByID')
             ->once()
-            ->andThrow(new ServiceUnavailableHttpException(Response::HTTP_SERVICE_UNAVAILABLE, 'test'));
+            ->andThrow(new \SoapFault(code: Response::HTTP_SERVICE_UNAVAILABLE, string: 'test'));
 
         $adapter = new WormsAdapter;
         $adapter->setSoapClient($mock);
 
         $request = new Request;
         $request->merge(['query' => 'Kolga',
-                        'source_id' => 124731000,]);
+                        'source_id' => 124731000]);
 
         try {
             $adapter->create($tree->id, $request);
-        } catch(ServiceUnavailableHttpException $e) {
+        } catch (ServiceUnavailableHttpException $e) {
             $this->assertEquals(Response::HTTP_SERVICE_UNAVAILABLE, $e->getStatusCode());
-            $this->assertEquals('test', $e->getMessage());
+            $this->assertEquals('The WoRMS server is currently unavailable.', $e->getMessage());
         }
     }
 

--- a/tests/php/Services/LabelSourceAdapters/WormsAdapterTest.php
+++ b/tests/php/Services/LabelSourceAdapters/WormsAdapterTest.php
@@ -127,7 +127,7 @@ class WormsAdapterTest extends TestCase
         $mock = Mockery::mock(SoapClient::class);
         $mock->shouldReceive('getAphiaRecords')
             ->once()
-            ->andThrow(new \SoapFault);
+            ->andThrow(new \SoapFault(1, 'test'));
 
         $adapter = new WormsAdapter;
         $adapter->setSoapClient($mock);
@@ -201,7 +201,7 @@ class WormsAdapterTest extends TestCase
         $mock = Mockery::mock(SoapClient::class);
         $mock->shouldReceive('getAphiaNameByID')
             ->once()
-            ->andThrow(new \SoapFault);
+            ->andThrow(new \SoapFault(1, 'test'));
 
         $adapter = new WormsAdapter;
         $adapter->setSoapClient($mock);

--- a/tests/php/Services/LabelSourceAdapters/WormsAdapterTest.php
+++ b/tests/php/Services/LabelSourceAdapters/WormsAdapterTest.php
@@ -127,7 +127,7 @@ class WormsAdapterTest extends TestCase
         $mock = Mockery::mock(SoapClient::class);
         $mock->shouldReceive('getAphiaRecords')
             ->once()
-            ->andThrow(new \SoapFault(Response::HTTP_SERVICE_UNAVAILABLE, 'test'));
+            ->andThrow(new \SoapFault);
 
         $adapter = new WormsAdapter;
         $adapter->setSoapClient($mock);
@@ -201,7 +201,7 @@ class WormsAdapterTest extends TestCase
         $mock = Mockery::mock(SoapClient::class);
         $mock->shouldReceive('getAphiaNameByID')
             ->once()
-            ->andThrow(new \SoapFault(Response::HTTP_SERVICE_UNAVAILABLE, 'test'));
+            ->andThrow(new \SoapFault);
 
         $adapter = new WormsAdapter;
         $adapter->setSoapClient($mock);

--- a/tests/php/Services/LabelSourceAdapters/WormsAdapterTest.php
+++ b/tests/php/Services/LabelSourceAdapters/WormsAdapterTest.php
@@ -127,7 +127,7 @@ class WormsAdapterTest extends TestCase
         $mock = Mockery::mock(SoapClient::class);
         $mock->shouldReceive('getAphiaRecords')
             ->once()
-            ->andThrow(new \SoapFault(code: Response::HTTP_SERVICE_UNAVAILABLE, string: 'test'));
+            ->andThrow(new \SoapFault(Response::HTTP_SERVICE_UNAVAILABLE, 'test'));
 
         $adapter = new WormsAdapter;
         $adapter->setSoapClient($mock);
@@ -137,8 +137,8 @@ class WormsAdapterTest extends TestCase
 
         try {
             $adapter->find($request);
+            $this->assertFalse(true);
         } catch (ServiceUnavailableHttpException $e) {
-            $this->assertEquals(Response::HTTP_SERVICE_UNAVAILABLE, $e->getStatusCode());
             $this->assertEquals('The WoRMS server is currently unavailable.', $e->getMessage());
         }
     }
@@ -201,19 +201,19 @@ class WormsAdapterTest extends TestCase
         $mock = Mockery::mock(SoapClient::class);
         $mock->shouldReceive('getAphiaNameByID')
             ->once()
-            ->andThrow(new \SoapFault(code: Response::HTTP_SERVICE_UNAVAILABLE, string: 'test'));
+            ->andThrow(new \SoapFault(Response::HTTP_SERVICE_UNAVAILABLE, 'test'));
 
         $adapter = new WormsAdapter;
         $adapter->setSoapClient($mock);
 
         $request = new Request;
         $request->merge(['query' => 'Kolga',
-                        'source_id' => 124731000]);
+            'source_id' => 124731000]);
 
         try {
             $adapter->create($tree->id, $request);
+            $this->assertFalse(true);
         } catch (ServiceUnavailableHttpException $e) {
-            $this->assertEquals(Response::HTTP_SERVICE_UNAVAILABLE, $e->getStatusCode());
             $this->assertEquals('The WoRMS server is currently unavailable.', $e->getMessage());
         }
     }


### PR DESCRIPTION
Resolves #441.
SoapFault exception is caught in WormsAdapter and ServiceUnavailableHttpException is thrown instead. Tests were added to WormsAdapterTest.