### PR TITLE
Use fetch() to request images in the image annotation tool

### DIFF
--- a/resources/views/manual/tutorials/volumes/remote-locations.blade.php
+++ b/resources/views/manual/tutorials/volumes/remote-locations.blade.php
@@ -51,7 +51,6 @@
         </p>
 <pre>
 Access-Control-Allow-Origin "*"
-Access-Control-Allow-Headers "x-requested-with"
 </pre>
         <p>
             In addition to that, you have to use a secure HTTP connection (<code>https://</code>) to access the files.

--- a/resources/views/manual/tutorials/volumes/remote-locations.blade.php
+++ b/resources/views/manual/tutorials/volumes/remote-locations.blade.php
@@ -50,7 +50,7 @@
             To set up CORS for the files of your remote source, you have to update the configuration of the webserver that serves the files. Some cloud storage services specifically provide configuration options for CORS. The webserver has to add the following HTTP headers to any <code>GET</code> or <code>OPTIONS</code> HTTP request for a file:
         </p>
 <pre>
-Access-Control-Allow-Origin "*"
+Access-Control-Allow-Origin "{{url('/')}}"
 </pre>
         <p>
             In addition to that, you have to use a secure HTTP connection (<code>https://</code>) to access the files.


### PR DESCRIPTION
The previous method Vue.http.get() injected the "x-requested-with" header and in combination with Laravel Echo also the "x-socket-id" header which can be problematic with CORS.