### PR TITLE
Fix regression with annotation focussing

### DIFF
--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -689,7 +689,11 @@ export default {
                 let annotations = this.annotations;
                 for (let i = annotations.length - 1; i >= 0; i--) {
                     if (annotations[i].id === id) {
-                        this.selectAndFocusAnnotation(annotations[i]);
+                        // Use $nextTick so the annotationCanvas component has time to
+                        // render the image.
+                        this.$nextTick(
+                            () => this.selectAndFocusAnnotation(annotations[i])
+                        );
                         return;
                     }
                 }


### PR DESCRIPTION
The regression was introduced in #611.

Somehow the async/await function works differently than the promise chain before. The image.changed event was dispatched before the annotationCanvas could render the image.