### PR TITLE
Fix bug with unchanged label color after swap

### DIFF
--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -354,7 +354,7 @@ export default {
             if (this.isEditor) {
                 if (annotation.labels.length > 1) {
                     AnnotationsStore.detachLabel(annotation, annotationLabel)
-                        .then(() => this.refreshAnnotation(annotation))
+                        .then(() => this.refreshSingleAnnotation(annotation))
                         .catch(handleErrorResponse);
                 } else if (confirm('Detaching the last label of an annotation deletes the whole annotation. Do you want to delete the annotation?')) {
                     this.handleDeleteAnnotation(annotation);
@@ -450,8 +450,8 @@ export default {
                     .catch(handleErrorResponse);
             }
         },
-        refreshAnnotation(annotation){
-            this.$refs.canvas.refreshAnnotation(annotation);
+        refreshSingleAnnotation(annotation){
+            this.$refs.canvas.refreshSingleAnnotation(annotation);
         },
         handleAttachAllSelected() {
             this.selectedAnnotations.forEach(this.handleAttachLabel);

--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -353,10 +353,11 @@ export default {
         handleDetachAnnotationLabel(annotation, annotationLabel) {
             if (this.isEditor) {
                 if (annotation.labels.length > 1) {
-                    return AnnotationsStore.detachLabel(annotation, annotationLabel)
+                    AnnotationsStore.detachLabel(annotation, annotationLabel)
+                        .then(() => this.refreshAnnotation(annotation))
                         .catch(handleErrorResponse);
                 } else if (confirm('Detaching the last label of an annotation deletes the whole annotation. Do you want to delete the annotation?')) {
-                    return this.handleDeleteAnnotation(annotation);
+                    this.handleDeleteAnnotation(annotation);
                 }
             }
         },
@@ -370,7 +371,7 @@ export default {
             // Mark for deletion so the annotation is immediately removed from
             // the canvas. See https://github.com/biigle/annotations/issues/70
             Vue.set(annotation, 'markedForDeletion', true);
-            return AnnotationsStore.delete(annotation)
+            AnnotationsStore.delete(annotation)
                 .catch(function (response) {
                     annotation.markedForDeletion = false;
                     handleErrorResponse(response);
@@ -443,10 +444,7 @@ export default {
                 this.handleAttachLabel(annotation, label)
                     .then(() => {
                         if (lastLabel) {
-                            this.handleDetachAnnotationLabel(annotation, lastLabel)
-                                .then(() => {
-                                    this.refreshAnnotation(annotation);
-                                });
+                            this.handleDetachAnnotationLabel(annotation, lastLabel);
                         }
                     })
                     .catch(handleErrorResponse);

--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -353,10 +353,10 @@ export default {
         handleDetachAnnotationLabel(annotation, annotationLabel) {
             if (this.isEditor) {
                 if (annotation.labels.length > 1) {
-                    AnnotationsStore.detachLabel(annotation, annotationLabel)
+                    return AnnotationsStore.detachLabel(annotation, annotationLabel)
                         .catch(handleErrorResponse);
                 } else if (confirm('Detaching the last label of an annotation deletes the whole annotation. Do you want to delete the annotation?')) {
-                    this.handleDeleteAnnotation(annotation);
+                    return this.handleDeleteAnnotation(annotation);
                 }
             }
         },
@@ -370,7 +370,7 @@ export default {
             // Mark for deletion so the annotation is immediately removed from
             // the canvas. See https://github.com/biigle/annotations/issues/70
             Vue.set(annotation, 'markedForDeletion', true);
-            AnnotationsStore.delete(annotation)
+            return AnnotationsStore.delete(annotation)
                 .catch(function (response) {
                     annotation.markedForDeletion = false;
                     handleErrorResponse(response);
@@ -443,11 +443,17 @@ export default {
                 this.handleAttachLabel(annotation, label)
                     .then(() => {
                         if (lastLabel) {
-                            this.handleDetachAnnotationLabel(annotation, lastLabel);
+                            this.handleDetachAnnotationLabel(annotation, lastLabel)
+                                .then(() => {
+                                    this.refreshAnnotation(annotation);
+                                });
                         }
                     })
                     .catch(handleErrorResponse);
             }
+        },
+        refreshAnnotation(annotation){
+            this.$refs.canvas.refreshAnnotation(annotation);
         },
         handleAttachAllSelected() {
             this.selectedAnnotations.forEach(this.handleAttachLabel);

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -605,8 +605,6 @@ export default {
             
             source.removeFeature(oldFeature);
             source.addFeature(newFeature);
-            
-        
         },
         refreshAnnotationSource(annotations, source) {
             let annotationsMap = {};

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -597,7 +597,7 @@ export default {
         updateMousePosition(e) {
             this.mousePosition = e.coordinate;
         },
-        refreshAnnotation(annotation) {
+        refreshSingleAnnotation(annotation) {
             let source = this.annotationSource;
 
             let newFeature = this.createFeature(annotation);

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -597,6 +597,17 @@ export default {
         updateMousePosition(e) {
             this.mousePosition = e.coordinate;
         },
+        refreshAnnotation(annotation) {
+            let source = this.annotationSource;
+
+            let newFeature = this.createFeature(annotation);
+            let oldFeature = source.getFeatureById(annotation.id)
+            
+            source.removeFeature(oldFeature);
+            source.addFeature(newFeature);
+            
+        
+        },
         refreshAnnotationSource(annotations, source) {
             let annotationsMap = {};
             annotations.forEach(function (annotation) {

--- a/resources/assets/js/videos/components/videoScreen/annotationPlayback.vue
+++ b/resources/assets/js/videos/components/videoScreen/annotationPlayback.vue
@@ -7,6 +7,7 @@ import Point from '@biigle/ol/geom/Point';
 import Polygon from '@biigle/ol/geom/Polygon';
 import Rectangle from '@biigle/ol/geom/Rectangle';
 import {getRoundToPrecision} from '../../utils';
+import Events from '../../../core/events';
 
 /**
  * Mixin for the videoScreen component that contains logic for the annotation playback.
@@ -125,6 +126,15 @@ export default {
                 this.updateGeometry(feature, time);
             });
         },
+        refreshAnnotation(annotation) {
+            let source = this.annotationSource;
+
+            let newFeature = this.createFeature(annotation);
+            let oldFeature = source.getFeatureById(annotation.id)
+            
+            source.removeFeature(oldFeature);
+            source.addFeature(newFeature);
+        },
         createFeature(annotation) {
             let feature = new Feature(this.getGeometryFromPoints(annotation.shape, annotation.points[0]));
 
@@ -226,6 +236,7 @@ export default {
         },
     },
     created() {
+        Events.$on('video.swap', this.refreshAnnotation);
         this.$on('refresh', this.refreshAnnotations);
         this.$once('map-ready', () => {
             this.$watch('annotationsRevision', () => {

--- a/resources/assets/js/videos/components/videoScreen/annotationPlayback.vue
+++ b/resources/assets/js/videos/components/videoScreen/annotationPlayback.vue
@@ -7,7 +7,6 @@ import Point from '@biigle/ol/geom/Point';
 import Polygon from '@biigle/ol/geom/Polygon';
 import Rectangle from '@biigle/ol/geom/Rectangle';
 import {getRoundToPrecision} from '../../utils';
-import Events from '../../../core/events';
 
 /**
  * Mixin for the videoScreen component that contains logic for the annotation playback.
@@ -236,7 +235,6 @@ export default {
         },
     },
     created() {
-        Events.$on('video.swap', this.refreshAnnotation);
         this.$on('refresh', this.refreshAllAnnotations);
         this.$once('map-ready', () => {
             this.$watch('annotationsRevision', () => {

--- a/resources/assets/js/videos/components/videoScreen/annotationPlayback.vue
+++ b/resources/assets/js/videos/components/videoScreen/annotationPlayback.vue
@@ -49,7 +49,7 @@ export default {
         },
     },
     methods: {
-        refreshAnnotations(time) {
+        refreshAllAnnotations(time) {
             let source = this.annotationSource;
             let selected = this.selectedFeatures;
             let annotations = this.annotationsPreparedToRender;
@@ -126,7 +126,7 @@ export default {
                 this.updateGeometry(feature, time);
             });
         },
-        refreshAnnotation(annotation) {
+        refreshSingleAnnotation(annotation) {
             let source = this.annotationSource;
 
             let newFeature = this.createFeature(annotation);
@@ -237,10 +237,10 @@ export default {
     },
     created() {
         Events.$on('video.swap', this.refreshAnnotation);
-        this.$on('refresh', this.refreshAnnotations);
+        this.$on('refresh', this.refreshAllAnnotations);
         this.$once('map-ready', () => {
             this.$watch('annotationsRevision', () => {
-                this.refreshAnnotations(this.video.currentTime);
+                this.refreshAllAnnotations(this.video.currentTime);
             });
         });
     },

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -402,10 +402,10 @@ export default {
         },
         detachAnnotationLabel(annotation, annotationLabel) {
             if (annotation.labels.length > 1) {
-                annotation.detachAnnotationLabel(annotationLabel)
+                return annotation.detachAnnotationLabel(annotationLabel)
                     .catch(handleErrorResponse);
             } else if (confirm('Detaching the last label of an annotation deletes the whole annotation. Do you want to delete the annotation?')) {
-                annotation.delete()
+                return annotation.delete()
                     .then(() => this.removeAnnotation(annotation))
                     .catch(handleErrorResponse);
             }
@@ -425,7 +425,9 @@ export default {
             this.attachAnnotationLabel(annotation)
                 .then(() => {
                     if (lastLabel) {
-                        this.detachAnnotationLabel(annotation, lastLabel);
+                        this.detachAnnotationLabel(annotation, lastLabel)
+                            .then(Events.$emit('video.swap', annotation));
+
                     }
                 })
                 .catch(handleErrorResponse);

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -432,7 +432,7 @@ export default {
                 .catch(handleErrorResponse);
         },
         refreshSingleAnnotation(annotation) {
-            this.$refs.videoScreen.refreshAnnotation(annotation);
+            this.$refs.videoScreen.refreshSingleAnnotation(annotation);
         },
         initAnnotationFilters() {
             let reverseShapes = {};

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -402,10 +402,11 @@ export default {
         },
         detachAnnotationLabel(annotation, annotationLabel) {
             if (annotation.labels.length > 1) {
-                return annotation.detachAnnotationLabel(annotationLabel)
+                annotation.detachAnnotationLabel(annotationLabel)
+                    .then(() => this.refreshSingleAnnotation(annotation))
                     .catch(handleErrorResponse);
             } else if (confirm('Detaching the last label of an annotation deletes the whole annotation. Do you want to delete the annotation?')) {
-                return annotation.delete()
+                annotation.delete()
                     .then(() => this.removeAnnotation(annotation))
                     .catch(handleErrorResponse);
             }
@@ -425,12 +426,13 @@ export default {
             this.attachAnnotationLabel(annotation)
                 .then(() => {
                     if (lastLabel) {
-                        this.detachAnnotationLabel(annotation, lastLabel)
-                            .then(Events.$emit('video.swap', annotation));
-
+                        this.detachAnnotationLabel(annotation, lastLabel);
                     }
                 })
                 .catch(handleErrorResponse);
+        },
+        refreshSingleAnnotation(annotation) {
+            this.$refs.videoScreen.refreshAnnotation(annotation);
         },
         initAnnotationFilters() {
             let reverseShapes = {};


### PR DESCRIPTION
Annotations were not updated because the annotation watcher was not triggered by the color change. Add a refreshAnnotation method which replaces the old annotation by the new one in the annotationSource.