### PR TITLE
Fix unhandled error for undefinded events

### DIFF
--- a/resources/assets/js/label-trees/components/labelTree.vue
+++ b/resources/assets/js/label-trees/components/labelTree.vue
@@ -200,9 +200,15 @@ export default {
             this.$emit('delete', label);
         },
         conditionSelectSiblings(e) {
+            if (!e) {
+                return false;
+            }
             return this.allowSelectSiblings && e.altKey;
         },
         conditionSelectChildren(e) {
+            if (!e) {
+                return false;
+            }
             return this.allowSelectChildren && e.ctrlKey;
         },
         selectLabel(label, e) {


### PR DESCRIPTION
Catch undefined events for label children/siblings and return false.