### PR TITLE
Dispatch object tracking events synchronously

### DIFF
--- a/app/Events/ObjectTrackingFailed.php
+++ b/app/Events/ObjectTrackingFailed.php
@@ -9,11 +9,11 @@ use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class ObjectTrackingFailed implements ShouldBroadcast
+class ObjectTrackingFailed implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/app/Events/ObjectTrackingSucceeded.php
+++ b/app/Events/ObjectTrackingSucceeded.php
@@ -9,11 +9,11 @@ use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class ObjectTrackingSucceeded implements ShouldBroadcast
+class ObjectTrackingSucceeded implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 


### PR DESCRIPTION
Class shouldBroadcast uses the default queue which can lead to delayed event dispatching when the queue is busy.
Use [shouldBroadcastNow](https://laravel.com/docs/10.x/broadcasting#broadcast-queue) to dispatch events immediately by using the sync queue.