### PR TITLE
Add checks for (non-)simple polygons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@fortawesome/fontawesome-free": "^5.2.0",
         "bootstrap-sass": "^3.3.7",
         "echarts": "^5.3.2",
+        "jsts": "^2.11.0",
         "magic-wand-tool": "^1.1.4",
         "polymorph-js": "^0.2.4",
         "uiv": "^1.2.4",
@@ -6911,6 +6912,14 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsts": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.11.0.tgz",
+      "integrity": "sha512-1++68krnA5CJ8DguYiqNWAtoDJl/4c6yLVKp+DylTKsOY73JERGRXYFT7ncPipHc33lgnjVWReKJO8+gpwm5ag==",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/junk": {
@@ -16676,6 +16685,11 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
+    },
+    "jsts": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.11.0.tgz",
+      "integrity": "sha512-1++68krnA5CJ8DguYiqNWAtoDJl/4c6yLVKp+DylTKsOY73JERGRXYFT7ncPipHc33lgnjVWReKJO8+gpwm5ag=="
     },
     "junk": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@fortawesome/fontawesome-free": "^5.2.0",
     "bootstrap-sass": "^3.3.7",
     "echarts": "^5.3.2",
+    "jsts": "^2.11.0",
     "magic-wand-tool": "^1.1.4",
     "polymorph-js": "^0.2.4",
     "uiv": "^1.2.4",

--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -564,21 +564,8 @@ export default {
         dismissCrossOriginError() {
             this.crossOriginError = false;
         },
-        handleInvalidShape(shape){
-            let vertexCount;
-            switch(shape){
-                case 'Polygon':
-                    vertexCount = 'at least 3';
-                    break;
-                case 'Rectangle':
-                    vertexCount = '4';
-                    break;
-                case 'LineString':
-                    shape = 'Line';
-                    vertexCount = 'at least 2';
-                    break;
-            }
-            Messages.danger(`Invalid Shape. ${shape} needs ${vertexCount} non-overlapping vertices.`);
+        handleInvalidPolygon(){
+            Messages.danger(`Invalid shape. Polygon needs at least 3 non-overlapping vertices.`);
         },
     },
     watch: {

--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -564,6 +564,22 @@ export default {
         dismissCrossOriginError() {
             this.crossOriginError = false;
         },
+        handleInvalidShape(shape){
+            let vertexCount;
+            switch(shape){
+                case 'Polygon':
+                    vertexCount = 'at least 3';
+                    break;
+                case 'Rectangle':
+                    vertexCount = '4';
+                    break;
+                case 'LineString':
+                    shape = 'Line';
+                    vertexCount = 'at least 2';
+                    break;
+            }
+            Messages.danger(`Invalid Shape. ${shape} needs ${vertexCount} non-overlapping vertices.`);
+        },
     },
     watch: {
         async imageId(id) {

--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -564,7 +564,7 @@ export default {
         dismissCrossOriginError() {
             this.crossOriginError = false;
         },
-        handleInvalidPolygon(){
+        handleInvalidPolygon() {
             Messages.danger(`Invalid shape. Polygon needs at least 3 non-overlapping vertices.`);
         },
     },

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -514,8 +514,7 @@ export default {
             if (this.hasSelectedLabel) {
                 let geometry = e.feature.getGeometry();
                 if (geometry.getType() === 'Polygon') {
-                    let polygonValidator = new PolygonValidator(e.feature);
-                    if (polygonValidator.isInvalidPolygon()) {
+                    if (PolygonValidator.isInvalidPolygon(e.feature)) {
                         this.$emit('is-invalid-polygon');
                         this.annotationSource.once('change', () => {
                             if (this.annotationSource.hasFeature(e.feature)) {
@@ -525,7 +524,7 @@ export default {
                         return;
                     }
 
-                    e.feature = polygonValidator.getValidPolygon();
+                    e.feature = PolygonValidator.makePolygonSimple(e.feature);
                 }
 
                 e.feature.set('color', this.selectedLabel.color);

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -531,8 +531,6 @@ export default {
                     shape: geometry.getType(),
                     points: this.getPoints(geometry),
                 }, removeCallback);
-            } else if (validDrawing) {
-                this.annotationSource.removeFeature(e.feature);
             } else {
                 let source = this.annotationSource;
                 source.on('change', (evtChange) => {

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -412,6 +412,7 @@ export default {
                     return this.featureRevisionMap[feature.getId()] !== feature.getRevision();
                 })
                 .map((feature) => {
+                    PolygonValidator.makePolygonSimple(feature);
                     return {
                         id: feature.getId(),
                         image_id: feature.get('annotation').image_id,

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -533,7 +533,7 @@ export default {
                 }, removeCallback);
             } else {
                 let source = this.annotationSource;
-                source.on('change', (evtChange) => {
+                source.once('change', (evtChange) => {
                     if (evtChange.target.getState() === 'ready' && source.hasFeature(e.feature)) {
                         source.removeFeature(e.feature);
                         this.$emit('has-invalid-shape', e.feature.getGeometry().getType());

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -524,7 +524,7 @@ export default {
                         return;
                     }
 
-                    e.feature = PolygonValidator.makePolygonSimple(e.feature);
+                    PolygonValidator.makePolygonSimple(e.feature);
                 }
 
                 e.feature.set('color', this.selectedLabel.color);

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -516,7 +516,7 @@ export default {
                 if (geometry.getType() === 'Polygon') {
                     let polygonValidator = new PolygonValidator(e.feature);
                     if (polygonValidator.isInvalidPolygon()) {
-                        this.$emit('has-invalid-polygon');
+                        this.$emit('is-invalid-polygon');
                         this.annotationSource.once('change', () => {
                             if (this.annotationSource.hasFeature(e.feature)) {
                                 this.annotationSource.removeFeature(e.feature);

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -1,4 +1,5 @@
 <script>
+import * as PolygonValidator from '../ol/PolygonValidator';
 import AnnotationTooltip from './annotationCanvas/annotationTooltip';
 import AttachLabelInteraction from './annotationCanvas/attachLabelInteraction';
 import CanvasSource from '@biigle/ol/source/Canvas';
@@ -40,12 +41,11 @@ import ZoomifySource from '@biigle/ol/source/Zoomify';
 import ZoomLevel from './annotationCanvas/zoomLevel';
 import ZoomToExtentControl from '@biigle/ol/control/ZoomToExtent';
 import ZoomToNativeControl from '../ol/ZoomToNativeControl';
-import * as PolygonValidator from '../ol/PolygonValidator';
-import { click as clickCondition } from '@biigle/ol/events/condition';
-import { defaults as defaultInteractions } from '@biigle/ol/interaction'
-import { getCenter } from '@biigle/ol/extent';
-import { shiftKeyOnly as shiftKeyOnlyCondition } from '@biigle/ol/events/condition';
-import { singleClick as singleClickCondition } from '@biigle/ol/events/condition';
+import {click as clickCondition} from '@biigle/ol/events/condition';
+import {defaults as defaultInteractions} from '@biigle/ol/interaction'
+import {getCenter} from '@biigle/ol/extent';
+import {shiftKeyOnly as shiftKeyOnlyCondition} from '@biigle/ol/events/condition';
+import {singleClick as singleClickCondition} from '@biigle/ol/events/condition';
 
 
 /**
@@ -516,6 +516,8 @@ export default {
                 if (geometry.getType() === 'Polygon') {
                     if (PolygonValidator.isInvalidPolygon(e.feature)) {
                         this.$emit('is-invalid-polygon');
+                        // This must be done in the change event handler.
+                        // Not exactly sure why.
                         this.annotationSource.once('change', () => {
                             if (this.annotationSource.hasFeature(e.feature)) {
                                 this.annotationSource.removeFeature(e.feature);

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -533,13 +533,12 @@ export default {
                 }, removeCallback);
             } else {
                 let source = this.annotationSource;
-                source.once('change', (evtChange) => {
-                    if (evtChange.target.getState() === 'ready' && source.hasFeature(e.feature)) {
+                source.once('change', () => {
+                    if (source.hasFeature(e.feature)) {
                         source.removeFeature(e.feature);
-                        this.$emit('has-invalid-shape', e.feature.getGeometry().getType());
                     }
-
                 });
+                this.$emit('has-invalid-shape', e.feature.getGeometry().getType());
             }
         },
         hasValidPoints(e) {

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -23,10 +23,6 @@ import MousePosition from './annotationCanvas/mousePosition';
 import MouseWheelZoom from '@biigle/ol/interaction/MouseWheelZoom';
 import Point from '@biigle/ol/geom/Point';
 import Polygon from '@biigle/ol/geom/Polygon';
-import MultiPolygon from '@biigle/ol/geom/MultiPolygon';
-import MultiPoint from '@biigle/ol/geom/MultiPoint';
-import LinearRing from '@biigle/ol/geom/LinearRing';
-import MultiLineString from '@biigle/ol/geom/MultiLineString';
 import PolygonBrushInteraction from './annotationCanvas/polygonBrushInteraction';
 import Projection from '@biigle/ol/proj/Projection';
 import Rectangle from '@biigle/ol/geom/Rectangle';
@@ -44,16 +40,12 @@ import ZoomifySource from '@biigle/ol/source/Zoomify';
 import ZoomLevel from './annotationCanvas/zoomLevel';
 import ZoomToExtentControl from '@biigle/ol/control/ZoomToExtent';
 import ZoomToNativeControl from '../ol/ZoomToNativeControl';
+import PolygonValidator from '../ol/PolygonValidator';
 import { click as clickCondition } from '@biigle/ol/events/condition';
 import { defaults as defaultInteractions } from '@biigle/ol/interaction'
 import { getCenter } from '@biigle/ol/extent';
 import { shiftKeyOnly as shiftKeyOnlyCondition } from '@biigle/ol/events/condition';
 import { singleClick as singleClickCondition } from '@biigle/ol/events/condition';
-import JstsPolygon from 'jsts/org/locationtech/jts/geom/Polygon';
-import JstsLinearRing from 'jsts/org/locationtech/jts/geom/LinearRing';
-import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
-import Polygonizer from 'jsts/org/locationtech/jts/operation/polygonize/Polygonizer';
-import Monkey from 'jsts/org/locationtech/jts/monkey';
 
 
 /**
@@ -522,8 +514,8 @@ export default {
             if (this.hasSelectedLabel) {
                 let geometry = e.feature.getGeometry();
                 if (geometry.getType() === 'Polygon') {
-
-                    if (this.isInvalidPolygon(e)) {
+                    let polygonValidator = new PolygonValidator(e.feature);
+                    if (polygonValidator.isInvalidPolygon()) {
                         this.$emit('has-invalid-polygon');
                         this.annotationSource.once('change', () => {
                             if (this.annotationSource.hasFeature(e.feature)) {
@@ -533,30 +525,7 @@ export default {
                         return;
                     }
 
-                    // Check if polygon is self-intersecting
-                    const parser = new OL3Parser();
-                    parser.inject(
-                        Point,
-                        LineString,
-                        LinearRing,
-                        Polygon,
-                        MultiPoint,
-                        MultiLineString,
-                        MultiPolygon
-                    );
-
-                    // translate ol geometry into jsts geometry
-                    let jstsGeom = parser.read(e.feature.getGeometry());
-                    // divide possibly intersecting polygon at cross points 
-                    // in several smaller polygons
-                    let possiblyMultiGeom = parser.write(this.jstsValidate(jstsGeom));
-
-                    if (possiblyMultiGeom.getCoordinates().length > 1) {
-                        // select biggest part of all polygons
-                        let biggestPolygonCoordinates = this.getGreatestPolygon(possiblyMultiGeom);
-                        geometry.setCoordinates(biggestPolygonCoordinates);
-                    }
-
+                    e.feature = polygonValidator.getValidPolygon();
                 }
 
                 e.feature.set('color', this.selectedLabel.color);
@@ -579,116 +548,6 @@ export default {
                 }, removeCallback);
             } else {
                 this.annotationSource.removeFeature(e.feature);
-            }
-        },
-        isInvalidPolygon(e) {
-            let geometry = e.feature.getGeometry();
-            let points = geometry.getCoordinates()[0];
-            return (new Set(points.map(xy => String([xy])))).size < 3;
-            
-        },
-        getGreatestPolygon(multGeom){
-            let coordinateLists = multGeom.getCoordinates();
-            let tmpGeom = multGeom.clone();
-                let areas = coordinateLists.map((l) => {
-                    tmpGeom.setCoordinates([l]);
-                    return tmpGeom.getArea();
-                });
-            let idx = areas.indexOf(Math.max(...areas));
-
-            return coordinateLists[idx];
-
-        },
-        /**
-        * @author Martin Kirk
-        * source: https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon
-        * 
-        * 
-        *  Get / create a valid version of the geometry given. If the geometry is a polygon or multi polygon, self intersections /
-        * inconsistencies are fixed. Otherwise the geometry is returned.
-        *
-        * @param geom
-        * @return a geometry
-        */
-        jstsValidate(geom) {
-            if (geom instanceof JstsPolygon) {
-                if (geom.isValid()) {
-                    geom.normalize(); // validate does not pick up rings in the wrong order - this will fix that
-                    return geom; // If the polygon is valid just return it
-                }
-                var polygonizer = new Polygonizer();
-                this.jstsAddPolygon(geom, polygonizer);
-                return this.jstsToPolygonGeometry(polygonizer.getPolygons(), geom.getFactory());
-            } else {
-                return geom; // In my case, I only care about polygon / multipolygon geometries
-            }
-        },
-
-        /**
-        * @author Martin Kirk
-        * source: https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon
-        * 
-        * 
-        * Add all line strings from the polygon given to the polygonizer given
-        *
-        * @param polygon polygon from which to extract line strings
-        * @param polygonizer polygonizer
-        */
-        jstsAddPolygon(polygon, polygonizer) {
-            this.jstsAddLineString(polygon.getExteriorRing(), polygonizer);
-
-            for (var n = polygon.getNumInteriorRing(); n > 0; n--) {
-                this.jstsAddLineString(polygon.getInteriorRingN(n), polygonizer);
-            }
-        },
-
-        /**
-        * @author Martin Kirk
-        * source: https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon
-        * 
-        * Add the linestring given to the polygonizer
-        *
-        * @param linestring line string
-        * @param polygonizer polygonizer
-        */
-        jstsAddLineString(lineString, polygonizer) {
-
-            if (lineString instanceof JstsLinearRing) {
-                // LinearRings are treated differently to line strings : we need a LineString NOT a LinearRing
-                lineString = lineString.getFactory().createLineString(lineString.getCoordinateSequence());
-            }
-
-            // unioning the linestring with the point makes any self intersections explicit.
-            var point = lineString.getFactory().createPoint(lineString.getCoordinateN(0));
-            var toAdd = lineString.union(point); //geometry
-
-            //Add result to polygonizer
-            polygonizer.add(toAdd);
-        },
-
-        /**
-        * @author Martin Kirk
-        * source: https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon
-        * 
-        * Get a geometry from a collection of polygons.
-        *
-        * @param polygons collection
-        * @return null if there were no polygons, the polygon if there was only one, or a MultiPolygon containing all polygons otherwise
-        */
-        jstsToPolygonGeometry(polygons) {
-            switch (polygons.size()) {
-                case 0:
-                    return null; // No valid polygons!
-                case 1:
-                    return polygons.iterator().next(); // single polygon - no need to wrap
-                default:
-                    //polygons may still overlap! Need to sym difference them
-                    var iter = polygons.iterator();
-                    var ret = iter.next();
-                    while (iter.hasNext()) {
-                        ret = ret.symDifference(iter.next());
-                    }
-                    return ret;
             }
         },
         deleteSelectedAnnotations() {

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -557,7 +557,7 @@ export default {
             }
         },
         getShapeCoordinateSetSize(points){
-            return new Set(points.map(xy => String(xy))).size;
+            return new Set(points.map(xy => String([xy]))).size;
         },
         deleteSelectedAnnotations() {
             if (!this.modifyInProgress && this.hasSelectedAnnotations && confirm('Are you sure you want to delete all selected annotations?')) {

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -540,11 +540,10 @@ export default {
                         // Do nothing in this case.
                     }
                 };
-                let points = this.getPoints(geometry);
 
                 this.$emit('new', {
                     shape: geometry.getType(),
-                    points: points,
+                    points: this.getPoints(geometry),
                 }, removeCallback);
             } else {
                 this.annotationSource.removeFeature(e.feature);

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -50,12 +50,10 @@ import { getCenter } from '@biigle/ol/extent';
 import { shiftKeyOnly as shiftKeyOnlyCondition } from '@biigle/ol/events/condition';
 import { singleClick as singleClickCondition } from '@biigle/ol/events/condition';
 import JstsPolygon from 'jsts/org/locationtech/jts/geom/Polygon';
-import JstsMultiPolygon from 'jsts/org/locationtech/jts/geom/MultiPolygon';
 import JstsLinearRing from 'jsts/org/locationtech/jts/geom/LinearRing';
 import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
 import Polygonizer from 'jsts/org/locationtech/jts/operation/polygonize/Polygonizer';
 import Monkey from 'jsts/org/locationtech/jts/monkey';
-import Geometry from '@biigle/ol/geom/Geometry';
 
 
 /**

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -40,7 +40,7 @@ import ZoomifySource from '@biigle/ol/source/Zoomify';
 import ZoomLevel from './annotationCanvas/zoomLevel';
 import ZoomToExtentControl from '@biigle/ol/control/ZoomToExtent';
 import ZoomToNativeControl from '../ol/ZoomToNativeControl';
-import PolygonValidator from '../ol/PolygonValidator';
+import * as PolygonValidator from '../ol/PolygonValidator';
 import { click as clickCondition } from '@biigle/ol/events/condition';
 import { defaults as defaultInteractions } from '@biigle/ol/interaction'
 import { getCenter } from '@biigle/ol/extent';

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -412,7 +412,7 @@ export default {
                     return this.featureRevisionMap[feature.getId()] !== feature.getRevision();
                 })
                 .map((feature) => {
-                    PolygonValidator.makePolygonSimple(feature);
+                    PolygonValidator.simplifyPolygon(feature);
                     return {
                         id: feature.getId(),
                         image_id: feature.get('annotation').image_id,
@@ -527,7 +527,7 @@ export default {
                         return;
                     }
 
-                    PolygonValidator.makePolygonSimple(e.feature);
+                    PolygonValidator.simplifyPolygon(e.feature);
                 }
 
                 e.feature.set('color', this.selectedLabel.color);

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -524,14 +524,6 @@ export default {
                         });
                         return;
                     }
-
-                    let curatedPointSet = this.removeDuplicatedPoints(points);
-                    if (points.length !== curatedPointSet.length) {
-                        points = curatedPointSet;
-                        // link polygon start and end by adding polygon start at the end
-                        points.push(points[0]); // x coordinate
-                        points.push(points[1]); // y coordinate
-                    }
                 }
 
                 e.feature.set('color', this.selectedLabel.color);
@@ -557,23 +549,9 @@ export default {
         },
         isInvalidPolygon(e) {
             let geometry = e.feature.getGeometry();
-            let points = geometry.getCoordinates();
-            return this.getPointStringSet(points[0]).size < 3;
+            let points = geometry.getCoordinates()[0];
+            return (new Set(points.map(xy => String([xy])))).size < 3;
             
-        },
-        removeDuplicatedPoints(points) {
-            let x = points.filter((_,i) => i%2==0);
-            let y = points.filter((_,i) => i%2==1);
-            let coordinates = x.map((xi,i) => {return [xi,y[i]];});
-
-            let pointStringSet = Array.from(this.getPointStringSet(coordinates));
-            return pointStringSet.map(xy => this.convertStringToPoint(xy)).flat();
-        },
-        getPointStringSet(points) {
-            return new Set(points.map(xy => String([xy])));
-        },
-        convertStringToPoint(xy) {
-            return xy.split(',').map(Number);
         },
         deleteSelectedAnnotations() {
             if (!this.modifyInProgress && this.hasSelectedAnnotations && confirm('Are you sure you want to delete all selected annotations?')) {

--- a/resources/assets/js/annotations/components/annotationCanvas.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas.vue
@@ -550,16 +550,16 @@ export default {
 
             switch (geometry.getType()) {
                 case 'LineString':
-                    return this.getEntrySetSize(points) >= 2;
+                    return this.getShapeCoordinateSetSize(points) >= 2;
                 case 'Rectangle':
-                    return this.getEntrySetSize(points[0]) === 4;
+                    return this.getShapeCoordinateSetSize(points[0]) === 4;
                 case 'Polygon':
-                    return this.getEntrySetSize(points[0]) >= 3;
+                    return this.getShapeCoordinateSetSize(points[0]) >= 3;
                 default:
                     return true;
             }
         },
-        getEntrySetSize(points){
+        getShapeCoordinateSetSize(points){
             return new Set(points.map(xy => String(xy))).size;
         },
         deleteSelectedAnnotations() {

--- a/resources/assets/js/annotations/ol/MagicWandInteraction.js
+++ b/resources/assets/js/annotations/ol/MagicWandInteraction.js
@@ -375,67 +375,6 @@ class MagicWandInteraction extends PointerInteraction {
             }
         }
     }
-
-    /**
-    * Removes duplicated points
-    */
-    removeDuplicatedPoints(points) {
-        let pointStringSet = Array.from(new Set(points.map(xy => String([xy]))));
-        return pointStringSet.map(xy => xy.split(',').map(Number));
-    }
-
-    /*
-    * Removes dangeling lines by deleting middle point of three subsequent points with equal x or y values
-    */
-    removeDangelingLines(coordinates) {
-        // filter by x values
-        let i = 0;
-        let endNotReached = true;
-        while (endNotReached) {
-            try {
-                if (coordinates[i][0] === coordinates[i + 1][0]) {
-                    if (coordinates[i + 1][0] === coordinates[i + 2][0]) {
-                        coordinates.splice(i + 1, 1)
-                        if (coordinates[i + 1][0] !== coordinates[i + 2][0]) {
-                            i++;
-                        }
-                    } else {
-                        i++;
-                    }
-                } else {
-                    i++;
-                }
-            } catch (err) {
-                break;
-            }
-            endNotReached = i < coordinates.length - 2;
-        }
-
-        // filter by y values
-        i = 0;
-        endNotReached = true;
-        while (endNotReached) {
-            try {
-                if (coordinates[i][1] === coordinates[i + 1][1]) {
-                    if (coordinates[i + 1][1] === coordinates[i + 2][1]) {
-                        coordinates.splice(i + 1, 1)
-                        if (coordinates[i + 1][1] !== coordinates[i + 2][1]) {
-                            i++;
-                        }
-                    } else {
-                        i++;
-                    }
-                } else {
-                    i++;
-                }
-            } catch (err) {
-                break;
-            }
-            endNotReached = i < coordinates.length - 2;
-        }
-
-        return coordinates;
-    }
 }
 
 export default MagicWandInteraction;

--- a/resources/assets/js/annotations/ol/MagicWandInteraction.js
+++ b/resources/assets/js/annotations/ol/MagicWandInteraction.js
@@ -195,7 +195,6 @@ class MagicWandInteraction extends PointerInteraction {
         if (this.isShowingCross) {
             this.sketchSource.removeFeature(this.sketchFeature);
         } else {
-            this.filterSketchCoordinates();
             this.dispatchEvent({ type: 'drawend', feature: this.sketchFeature });
         }
 
@@ -375,17 +374,6 @@ class MagicWandInteraction extends PointerInteraction {
                 this.sketchSource.addFeature(this.sketchFeature);
             }
         }
-    }
-
-    /**
-    * Removes duplicated points and dangeling lines
-    */
-    filterSketchCoordinates() {
-        let points = this.sketchFeature.getGeometry().getCoordinates()[0];
-        points = this.removeDuplicatedPoints(points);
-        points = this.removeDangelingLines(points);
-        points.push(points[0]);
-        this.sketchFeature.getGeometry().setCoordinates([points]);
     }
 
     /**

--- a/resources/assets/js/annotations/ol/MagicWandInteraction.js
+++ b/resources/assets/js/annotations/ol/MagicWandInteraction.js
@@ -195,7 +195,7 @@ class MagicWandInteraction extends PointerInteraction {
         if (this.isShowingCross) {
             this.sketchSource.removeFeature(this.sketchFeature);
         } else {
-            this.dispatchEvent({ type: 'drawend', feature: this.sketchFeature });
+            this.dispatchEvent({type: 'drawend', feature: this.sketchFeature});
         }
 
         this.sketchFeature = null;

--- a/resources/assets/js/annotations/ol/PolygonValidator.js
+++ b/resources/assets/js/annotations/ol/PolygonValidator.js
@@ -1,0 +1,167 @@
+import Point from '@biigle/ol/geom/Point';
+import Polygon from '@biigle/ol/geom/Polygon';
+import MultiPolygon from '@biigle/ol/geom/MultiPolygon';
+import MultiPoint from '@biigle/ol/geom/MultiPoint';
+import LinearRing from '@biigle/ol/geom/LinearRing';
+import LineString from '@biigle/ol/geom/LineString';
+import MultiLineString from '@biigle/ol/geom/MultiLineString';
+import JstsPolygon from 'jsts/org/locationtech/jts/geom/Polygon';
+import JstsLinearRing from 'jsts/org/locationtech/jts/geom/LinearRing';
+import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
+import Polygonizer from 'jsts/org/locationtech/jts/operation/polygonize/Polygonizer';
+import Monkey from 'jsts/org/locationtech/jts/monkey';
+
+class PolygonValidator {
+
+    constructor(polygon) {
+        this.polygon = polygon;
+    }
+
+    isInvalidPolygon() {
+        let geometry = this.polygon.getGeometry();
+        let points = geometry.getCoordinates()[0];
+        return (new Set(points.map(xy => String([xy])))).size < 3;
+
+    }
+
+    getValidPolygon() {
+        // Check if polygon is self-intersecting
+        const parser = new OL3Parser();
+        parser.inject(
+            Point,
+            LineString,
+            LinearRing,
+            Polygon,
+            MultiPoint,
+            MultiLineString,
+            MultiPolygon
+        );
+
+        // translate ol geometry into jsts geometry
+        let jstsGeom = parser.read(this.polygon.getGeometry());
+        // divide possibly intersecting polygon at cross points 
+        // in several smaller polygons
+        let possiblyMultiGeom = parser.write(this.jstsValidate(jstsGeom));
+
+        if (possiblyMultiGeom.getCoordinates().length > 1) {
+            // select biggest part
+            let biggestPolygonCoordinates = this.getGreatestPolygonCoordinates(possiblyMultiGeom);
+            this.polygon.getGeometry().setCoordinates(biggestPolygonCoordinates);
+            return this.polygon;
+        }
+
+        return this.polygon;
+
+       
+    }
+
+    /**
+    * @author Martin Kirk
+    * 
+    * @link https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon
+    * 
+    * 
+    *  Get / create a valid version of the geometry given. If the geometry is a polygon or multi polygon, self intersections /
+    * inconsistencies are fixed. Otherwise the geometry is returned.
+    *
+    * @param geom
+    * @return a geometry
+    */
+    jstsValidate(geom) {
+        if (geom instanceof JstsPolygon) {
+            if (geom.isValid()) {
+                geom.normalize(); // validate does not pick up rings in the wrong order - this will fix that
+                return geom; // If the polygon is valid just return it
+            }
+            var polygonizer = new Polygonizer();
+            this.jstsAddPolygon(geom, polygonizer);
+            return this.jstsToPolygonGeometry(polygonizer.getPolygons(), geom.getFactory());
+        } else {
+            return geom; // In my case, I only care about polygon / multipolygon geometries
+        }
+    }
+
+    /**
+    * @author Martin Kirk
+    * 
+    * @link https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon
+    * 
+    * Add all line strings from the polygon given to the polygonizer given
+    *
+    * @param polygon polygon from which to extract line strings
+    * @param polygonizer polygonizer
+    */
+    jstsAddPolygon(polygon, polygonizer) {
+        this.jstsAddLineString(polygon.getExteriorRing(), polygonizer);
+
+        for (var n = polygon.getNumInteriorRing(); n > 0; n--) {
+            this.jstsAddLineString(polygon.getInteriorRingN(n), polygonizer);
+        }
+    }
+
+
+    /**
+    * @author Martin Kirk
+    * 
+    * @link https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon    * 
+    * Add the linestring given to the polygonizer
+    *
+    * @param linestring line string
+    * @param polygonizer polygonizer
+    */
+    jstsAddLineString(lineString, polygonizer) {
+
+        if (lineString instanceof JstsLinearRing) {
+            // LinearRings are treated differently to line strings : we need a LineString NOT a LinearRing
+            lineString = lineString.getFactory().createLineString(lineString.getCoordinateSequence());
+        }
+
+        // unioning the linestring with the point makes any self intersections explicit.
+        var point = lineString.getFactory().createPoint(lineString.getCoordinateN(0));
+        var toAdd = lineString.union(point); //geometry
+
+        //Add result to polygonizer
+        polygonizer.add(toAdd);
+    }
+
+
+    /**
+    * @author Martin Kirk
+    * 
+    * @link https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon    * 
+    * Get a geometry from a collection of polygons.
+    *
+    * @param polygons collection
+    * @return null if there were no polygons, the polygon if there was only one, or a MultiPolygon containing all polygons otherwise
+    */
+    jstsToPolygonGeometry(polygons) {
+        switch (polygons.size()) {
+            case 0:
+                return null; // No valid polygons!
+            case 1:
+                return polygons.iterator().next(); // single polygon - no need to wrap
+            default:
+                //polygons may still overlap! Need to sym difference them
+                var iter = polygons.iterator();
+                var ret = iter.next();
+                while (iter.hasNext()) {
+                    ret = ret.symDifference(iter.next());
+                }
+                return ret;
+        }
+    }
+
+    getGreatestPolygonCoordinates(multGeom) {
+        let coordinateLists = multGeom.getCoordinates();
+        let tmpGeom = multGeom.clone();
+        let areas = coordinateLists.map((l) => {
+            tmpGeom.setCoordinates([l]);
+            return tmpGeom.getArea();
+        });
+        let idx = areas.indexOf(Math.max(...areas));
+
+        return coordinateLists[idx];
+    }
+}
+
+export default PolygonValidator;

--- a/resources/assets/js/annotations/ol/PolygonValidator.js
+++ b/resources/assets/js/annotations/ol/PolygonValidator.js
@@ -1,36 +1,35 @@
-import Point from '@biigle/ol/geom/Point';
-import Polygon from '@biigle/ol/geom/Polygon';
-import MultiPolygon from '@biigle/ol/geom/MultiPolygon';
-import MultiPoint from '@biigle/ol/geom/MultiPoint';
+import JstsLinearRing from 'jsts/org/locationtech/jts/geom/LinearRing';
+import JstsPolygon from 'jsts/org/locationtech/jts/geom/Polygon';
 import LinearRing from '@biigle/ol/geom/LinearRing';
 import LineString from '@biigle/ol/geom/LineString';
-import MultiLineString from '@biigle/ol/geom/MultiLineString';
-import JstsPolygon from 'jsts/org/locationtech/jts/geom/Polygon';
-import JstsLinearRing from 'jsts/org/locationtech/jts/geom/LinearRing';
-import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
-import Polygonizer from 'jsts/org/locationtech/jts/operation/polygonize/Polygonizer';
 import Monkey from 'jsts/org/locationtech/jts/monkey'; // Needed for isValid(), normalize()
+import MultiLineString from '@biigle/ol/geom/MultiLineString';
+import MultiPoint from '@biigle/ol/geom/MultiPoint';
+import MultiPolygon from '@biigle/ol/geom/MultiPolygon';
+import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
+import Point from '@biigle/ol/geom/Point';
+import Polygon from '@biigle/ol/geom/Polygon';
+import Polygonizer from 'jsts/org/locationtech/jts/operation/polygonize/Polygonizer';
 
-
-    /**
-     * Checks if polygon consists of at least 3 unique points
-     * 
-     * @param feature containing the polygon
-     * @returns True if coordinates contains at least 3 unique points, otherwise false
-     * **/
-    export function isInvalidPolygon(feature) {
+/**
+ * Checks if polygon consists of at least 3 unique points
+ *
+ * @param feature containing the polygon
+ * @returns True if coordinates contains at least 3 unique points, otherwise false
+ */
+export function isInvalidPolygon(feature) {
     let polygon = feature.getGeometry();
     let points = polygon.getCoordinates()[0];
     return (new Set(points.map(xy => String([xy])))).size < 3;
 
 }
 
-    /**
-     * Makes non-simple polygon simple
-     * 
-     * @param feature feature containing the (non-simple) polygon
-     * **/
-    export function makePolygonSimple(feature) {
+/**
+ * Makes non-simple polygon simple
+ *
+ * @param feature feature containing the (non-simple) polygon
+ */
+export function makePolygonSimple(feature) {
     // Check if polygon is self-intersecting
     const parser = new OL3Parser();
     parser.inject(
@@ -63,18 +62,17 @@ import Monkey from 'jsts/org/locationtech/jts/monkey'; // Needed for isValid(), 
 }
 
 /**
-    * @author Martin Kirk
-    * 
-    * @link https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon
-    * 
-    * 
-    *  Get / create a valid version of the geometry given. If the geometry is a polygon or multi polygon, self intersections /
-    * inconsistencies are fixed. Otherwise the geometry is returned.
-    *
-    * @param geom
-    * @return a geometry
-    */
-
+ * @author Martin Kirk
+ *
+ * @link https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon
+ *
+ *
+ *  Get / create a valid version of the geometry given. If the geometry is a polygon or multi polygon, self intersections /
+ * inconsistencies are fixed. Otherwise the geometry is returned.
+ *
+ * @param geom
+ * @return a geometry
+ */
 function jstsValidate(geom) {
     if (geom instanceof JstsPolygon) {
         if (geom.isValid()) {

--- a/resources/assets/js/annotations/ol/PolygonValidator.js
+++ b/resources/assets/js/annotations/ol/PolygonValidator.js
@@ -11,7 +11,6 @@ import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
 import Polygonizer from 'jsts/org/locationtech/jts/operation/polygonize/Polygonizer';
 import Monkey from 'jsts/org/locationtech/jts/monkey'; // Needed for isValid(), normalize()
 
-class PolygonValidator {
 
     /**
      * Checks if polygon consists of at least 3 unique points
@@ -19,52 +18,49 @@ class PolygonValidator {
      * @param feature containing the polygon
      * @returns True if coordinates contains at least 3 unique points, otherwise false
      * **/
-    static isInvalidPolygon(feature) {
-        let polygon = feature.getGeometry();
-        let points = polygon.getCoordinates()[0];
-        return (new Set(points.map(xy => String([xy])))).size < 3;
+    export function isInvalidPolygon(feature) {
+    let polygon = feature.getGeometry();
+    let points = polygon.getCoordinates()[0];
+    return (new Set(points.map(xy => String([xy])))).size < 3;
 
-    }
+}
 
     /**
      * Makes non-simple polygon simple
      * 
      * @param feature feature containing the (non-simple) polygon
      * **/
-    static makePolygonSimple(feature) {
-        // Check if polygon is self-intersecting
-        const parser = new OL3Parser();
-        parser.inject(
-            Point,
-            LineString,
-            LinearRing,
-            Polygon,
-            MultiPoint,
-            MultiLineString,
-            MultiPolygon
-        );
+    export function makePolygonSimple(feature) {
+    // Check if polygon is self-intersecting
+    const parser = new OL3Parser();
+    parser.inject(
+        Point,
+        LineString,
+        LinearRing,
+        Polygon,
+        MultiPoint,
+        MultiLineString,
+        MultiPolygon
+    );
 
-        // Translate ol geometry into jsts geometry
-        let jstsPolygon = parser.read(feature.getGeometry());
+    // Translate ol geometry into jsts geometry
+    let jstsPolygon = parser.read(feature.getGeometry());
 
-        if (jstsPolygon.isSimple()) {
-            return feature;
-        }
+    if (jstsPolygon.isSimple()) {
+        return feature;
+    }
 
-        // Divide non-simple polygon at cross points into several smaller polygons
-        // and translate back to ol geometry
-        let polygons = jstsValidate(jstsPolygon)['array'].map(p => parser.write(p));
+    // Divide non-simple polygon at cross points into several smaller polygons
+    // and translate back to ol geometry
+    let polygons = jstsValidate(jstsPolygon)['array'].map(p => parser.write(p));
 
-        if (polygons.length > 1) {
-            // Select biggest part
-            let greatestPolygon = getGreatestPolygon(polygons);
-            // Only change coordinates because object references are in use
-            feature.getGeometry().setCoordinates(greatestPolygon.getCoordinates());
-        }
+    if (polygons.length > 1) {
+        // Select biggest part
+        let greatestPolygon = getGreatestPolygon(polygons);
+        // Only change coordinates because object references are in use
+        feature.getGeometry().setCoordinates(greatestPolygon.getCoordinates());
     }
 }
-
-export default PolygonValidator;
 
 /**
     * @author Martin Kirk
@@ -78,7 +74,7 @@ export default PolygonValidator;
     * @param geom
     * @return a geometry
     */
-   
+
 function jstsValidate(geom) {
     if (geom instanceof JstsPolygon) {
         if (geom.isValid()) {

--- a/resources/assets/js/annotations/ol/PolygonValidator.js
+++ b/resources/assets/js/annotations/ol/PolygonValidator.js
@@ -1,8 +1,8 @@
+import 'jsts/org/locationtech/jts/monkey'; // This monkey patches jsts prototypes.
 import JstsLinearRing from 'jsts/org/locationtech/jts/geom/LinearRing';
 import JstsPolygon from 'jsts/org/locationtech/jts/geom/Polygon';
 import LinearRing from '@biigle/ol/geom/LinearRing';
 import LineString from '@biigle/ol/geom/LineString';
-import Monkey from 'jsts/org/locationtech/jts/monkey'; // Needed for isValid(), normalize()
 import MultiLineString from '@biigle/ol/geom/MultiLineString';
 import MultiPoint from '@biigle/ol/geom/MultiPoint';
 import MultiPolygon from '@biigle/ol/geom/MultiPolygon';
@@ -20,8 +20,8 @@ import Polygonizer from 'jsts/org/locationtech/jts/operation/polygonize/Polygoni
 export function isInvalidPolygon(feature) {
     let polygon = feature.getGeometry();
     let points = polygon.getCoordinates()[0];
-    return (new Set(points.map(xy => String([xy])))).size < 3;
 
+    return (new Set(points.map(xy => String([xy])))).size < 3;
 }
 
 /**
@@ -30,6 +30,10 @@ export function isInvalidPolygon(feature) {
  * @param feature feature containing the (non-simple) polygon
  */
 export function makePolygonSimple(feature) {
+    if (feature.getGeometry().getType() !== 'Polygon') {
+        throw new Error("Only polygon geometries are supported.");
+    }
+
     // Check if polygon is self-intersecting
     const parser = new OL3Parser();
     parser.inject(
@@ -81,6 +85,7 @@ function jstsValidate(geom) {
         }
         var polygonizer = new Polygonizer();
         jstsAddPolygon(geom, polygonizer);
+
         return polygonizer.getPolygons();
     } else {
         return geom;
@@ -138,5 +143,6 @@ function jstsAddLineString(lineString, polygonizer) {
 function getGreatestPolygon(polygonList) {
     let areas = polygonList.map(p => p.getArea());
     let idx = areas.indexOf(Math.max(...areas));
+
     return polygonList[idx];
 }

--- a/resources/assets/js/annotations/ol/PolygonValidator.js
+++ b/resources/assets/js/annotations/ol/PolygonValidator.js
@@ -6,7 +6,6 @@ import LinearRing from '@biigle/ol/geom/LinearRing';
 import LineString from '@biigle/ol/geom/LineString';
 import MultiLineString from '@biigle/ol/geom/MultiLineString';
 import JstsPolygon from 'jsts/org/locationtech/jts/geom/Polygon';
-import JstsMultiPolygon from 'jsts/org/locationtech/jts/geom/MultiPolygon';
 import JstsLinearRing from 'jsts/org/locationtech/jts/geom/LinearRing';
 import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
 import Polygonizer from 'jsts/org/locationtech/jts/operation/polygonize/Polygonizer';

--- a/resources/assets/js/annotations/ol/PolygonValidator.js
+++ b/resources/assets/js/annotations/ol/PolygonValidator.js
@@ -30,7 +30,6 @@ class PolygonValidator {
      * Makes non-simple polygon simple
      * 
      * @param feature feature containing the (non-simple) polygon
-     * @returns simple Polygon
      * **/
     static makePolygonSimple(feature) {
         // Check if polygon is self-intersecting
@@ -62,8 +61,6 @@ class PolygonValidator {
             // Only change coordinates because object references are in use
             feature.getGeometry().setCoordinates(greatestPolygon.getCoordinates());
         }
-
-        return feature;
     }
 }
 

--- a/resources/assets/js/annotations/ol/PolygonValidator.js
+++ b/resources/assets/js/annotations/ol/PolygonValidator.js
@@ -53,7 +53,7 @@ export function simplifyPolygon(feature) {
     }
 
     // Divide non-simple polygon at cross points into several smaller polygons,
-    // translate back to ol geometry and remove dupliate coordinate sets (polish)
+    // translate back to ol geometry and remove duplicated coordinate sets (polish)
     let polygons = polishPolygons(jstsValidate(jstsPolygon).array.map(p => parser.write(p)));
 
     if (polygons.length > 1) {
@@ -108,7 +108,7 @@ function jstsAddPolygon(polygon, polygonizer) {
         for (var n = polygon.getNumInteriorRing(); n > 0; n--) {
             jstsAddLineString(polygon.getInteriorRingN(n), polygonizer);
         }
-}
+    }
 }
 
 /**
@@ -136,8 +136,8 @@ function jstsAddLineString(lineString, polygonizer) {
 }
 
 /**
- * Removes duplicated subpolygon's coordinate set which can be still included in some polygons.
- * These polygons need to be "cleaned up", otherwise polygons are still intersecting.
+ * Removes duplicated subpolygon's coordinate sets which can be still included in some polygons (from magic wand tool).
+ * These polygons need to be "cleaned up", otherwise polygons can still have intersections.
  * 
  * Example: 
  * pg1 = [ [[1,0],[1,1],[1,2]], [[1,3],[1,4]] ]
@@ -147,14 +147,14 @@ function jstsAddLineString(lineString, polygonizer) {
  * pg2 = [ [1,3],[1,4] ]
  *
  * @param polygons List of polygons
- * @returns List of polygons with unique coordinate sets
+ * @returns List of polygons with coordinate sets ocurring only once
  *
  * **/
 function polishPolygons(polygons) {
-    // Filter all polygons that contain two or more coordinate lists
+    // Filter all polygons that contain two or more coordinate sets
     let multipleCoordSetPolygon = polygons.filter(p => p.getCoordinates().length > 1);
 
-    // If all coordinate sets ocurring once, return polygons
+    // If all coordinate sets ocurring once, return polygons unchanged
     if (multipleCoordSetPolygon.length === 0) {
         return polygons;
     }

--- a/resources/assets/js/annotations/ol/PolygonValidator.js
+++ b/resources/assets/js/annotations/ol/PolygonValidator.js
@@ -138,6 +138,7 @@ function jstsAddLineString(lineString, polygonizer) {
  *
  * **/
 function polishPolygons(polygons) {
+    // Filter all multipolygons that contain two or more coordinate lists
     let multiPolygons = polygons.filter(p => p.getCoordinates().length > 1);
 
     if (multiPolygons.length === 0) {
@@ -149,8 +150,9 @@ function polishPolygons(polygons) {
         for (let i = 0; i < polygons.length; i++) {
             let otherP = polygons[i]
             if (p !== otherP) {
+                // subCoords can contain only one coordinate list
                 let subCoords = pCoords.filter(coords => areEqual(coords, otherP.getCoordinates()[0]));
-                // if subpolygon's coordinates are duplicates, remove them
+                // If subpolygon's coordinates are duplicates, remove them
                 if (subCoords.length > 0) {
                     pCoords.splice(pCoords.indexOf(subCoords[0]), 1);
                     p.setCoordinates(pCoords);

--- a/resources/assets/js/annotations/ol/PolygonValidator.js
+++ b/resources/assets/js/annotations/ol/PolygonValidator.js
@@ -103,7 +103,7 @@ class PolygonValidator {
     /**
     * @author Martin Kirk
     * 
-    * @link https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon    * 
+    * @link https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon 
     * Add the linestring given to the polygonizer
     *
     * @param linestring line string
@@ -128,7 +128,7 @@ class PolygonValidator {
     /**
     * @author Martin Kirk
     * 
-    * @link https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon    * 
+    * @link https://stackoverflow.com/questions/36118883/using-jsts-buffer-to-identify-a-self-intersecting-polygon 
     * Get a geometry from a collection of polygons.
     *
     * @param polygons collection
@@ -145,7 +145,13 @@ class PolygonValidator {
                 var iter = polygons.iterator();
                 var ret = iter.next();
                 while (iter.hasNext()) {
-                    ret = ret.symDifference(iter.next());
+                    let next = iter.next();
+                    let symDiff = ret.symDifference(next);
+                    let diff = ret.difference(next);
+                    // ignore nested geometry parts
+                    if(symDiff.getCoordinates().length !== diff.getCoordinates().length){
+                        ret = symDiff;
+                    }
                 }
                 return ret;
         }

--- a/resources/assets/js/annotations/ol/PolygonValidator.js
+++ b/resources/assets/js/annotations/ol/PolygonValidator.js
@@ -100,10 +100,15 @@ function jstsValidate(geom) {
 function jstsAddPolygon(polygon, polygonizer) {
     jstsAddLineString(polygon.getExteriorRing(), polygonizer);
 
-    for (var n = polygon.getNumInteriorRing(); n > 0; n--) {
-        n = polygon.getNumInteriorRing() === 1 ? 0 : n;
-        jstsAddLineString(polygon.getInteriorRingN(n), polygonizer);
-    }
+    // If only one interior ring exists, access ring directly.
+    // Otherwise loop will cause out of bounds error
+    if (polygon.getNumInteriorRing() === 1) {
+        jstsAddLineString(polygon.getInteriorRingN(0), polygonizer);
+    } else {
+        for (var n = polygon.getNumInteriorRing(); n > 0; n--) {
+            jstsAddLineString(polygon.getInteriorRingN(n), polygonizer);
+        }
+}
 }
 
 /**

--- a/resources/assets/js/annotations/ol/PolygonValidator.js
+++ b/resources/assets/js/annotations/ol/PolygonValidator.js
@@ -1,6 +1,5 @@
 import 'jsts/org/locationtech/jts/monkey'; // This monkey patches jsts prototypes.
 import JstsLinearRing from 'jsts/org/locationtech/jts/geom/LinearRing';
-import JstsPolygon from 'jsts/org/locationtech/jts/geom/Polygon';
 import LinearRing from '@biigle/ol/geom/LinearRing';
 import LineString from '@biigle/ol/geom/LineString';
 import MultiLineString from '@biigle/ol/geom/MultiLineString';
@@ -78,18 +77,14 @@ export function makePolygonSimple(feature) {
  * @return a geometry
  */
 function jstsValidate(geom) {
-    if (geom instanceof JstsPolygon) {
-        if (geom.isValid()) {
-            geom.normalize(); // validate does not pick up rings in the wrong order - this will fix that
-            return geom; // If the polygon is valid just return it
-        }
-        var polygonizer = new Polygonizer();
-        jstsAddPolygon(geom, polygonizer);
-
-        return polygonizer.getPolygons();
-    } else {
-        return geom;
+    if (geom.isValid()) {
+        geom.normalize(); // validate does not pick up rings in the wrong order - this will fix that
+        return geom; // If the polygon is valid just return it
     }
+    var polygonizer = new Polygonizer();
+    jstsAddPolygon(geom, polygonizer);
+
+    return polygonizer.getPolygons();
 }
 
 /**

--- a/resources/assets/js/annotations/ol/PolygonValidator.js
+++ b/resources/assets/js/annotations/ol/PolygonValidator.js
@@ -52,7 +52,7 @@ class PolygonValidator {
 
         return this.polygon;
 
-       
+
     }
 
     /**
@@ -149,7 +149,7 @@ class PolygonValidator {
                     let symDiff = ret.symDifference(next);
                     let diff = ret.difference(next);
                     // ignore nested geometry parts
-                    if(symDiff.getCoordinates().length !== diff.getCoordinates().length){
+                    if (symDiff.getCoordinates().length !== diff.getCoordinates().length) {
                         ret = symDiff;
                     }
                 }

--- a/resources/assets/js/videos/components/videoScreen/drawInteractions.vue
+++ b/resources/assets/js/videos/components/videoScreen/drawInteractions.vue
@@ -176,7 +176,7 @@ export default {
                 }
 
                 // If polygon is self-intersecting, create simple polygon
-                PolygonValidator.makePolygonSimple(e.feature);
+                PolygonValidator.simplifyPolygon(e.feature);
             }
 
             let lastFrame = this.pendingAnnotation.frames[this.pendingAnnotation.frames.length - 1];

--- a/resources/assets/js/videos/components/videoScreen/drawInteractions.vue
+++ b/resources/assets/js/videos/components/videoScreen/drawInteractions.vue
@@ -5,8 +5,6 @@ import Styles from '../../../annotations/stores/styles';
 import VectorLayer from '@biigle/ol/layer/Vector';
 import VectorSource from '@biigle/ol/source/Vector';
 import PolygonValidator from '../../../annotations/ol/PolygonValidator';
-import Feature from '@biigle/ol/Feature';
-import Polygon from '@biigle/ol/geom/Polygon';
 
 /**
  * Mixin for the videoScreen component that contains logic for the draw interactions.
@@ -201,13 +199,6 @@ export default {
             }
 
             this.$emit('pending-annotation', this.pendingAnnotation);
-        },
-        getFeatureFromAnnotation(annotation){
-            let points = annotation.points;
-            let xValues = points[0].filter((_,i) => {return i%2===0;});
-            let yValues = points[0].filter((_,i) => {return i%2===1;});
-            let coords = xValues.map((x,i) => [x,yValues[i]]);
-            return new Feature({geometry: new Polygon([coords])});
         },
     },
     created() {

--- a/resources/assets/js/videos/components/videoScreen/drawInteractions.vue
+++ b/resources/assets/js/videos/components/videoScreen/drawInteractions.vue
@@ -5,6 +5,8 @@ import Styles from '../../../annotations/stores/styles';
 import VectorLayer from '@biigle/ol/layer/Vector';
 import VectorSource from '@biigle/ol/source/Vector';
 import PolygonValidator from '../../../annotations/ol/PolygonValidator';
+import Feature from '@biigle/ol/Feature';
+import Polygon from '@biigle/ol/geom/Polygon';
 
 /**
  * Mixin for the videoScreen component that contains logic for the draw interactions.

--- a/resources/assets/js/videos/components/videoScreen/drawInteractions.vue
+++ b/resources/assets/js/videos/components/videoScreen/drawInteractions.vue
@@ -166,8 +166,7 @@ export default {
         extendPendingAnnotation(e) {
             // Check polygons
             if (e.feature.getGeometry().getType() === 'Polygon') {
-                let polygonValidator = new PolygonValidator(e.feature);
-                if (polygonValidator.isInvalidPolygon()) {
+                if (PolygonValidator.isInvalidPolygon(e.feature)) {
                     // Disallow polygons with less than three non-overlapping points
                     this.$emit('is-invalid-polygon')
                     this.removeFeature(e.feature)
@@ -175,9 +174,9 @@ export default {
                 }
 
                 // If polygon is self-intersecting, create valid polygon
-                let validPolygon = polygonValidator.getValidPolygon();
-                let twoDimCoords = validPolygon.getGeometry().getCoordinates();
-                e.feature.getGeometry().setCoordinates([twoDimCoords[0]]);
+                let validPolygon = PolygonValidator.makePolygonSimple(e.feature);
+                let coords = validPolygon.getGeometry().getCoordinates();
+                e.feature.getGeometry().setCoordinates([coords[0]]);
                 
             }
 

--- a/resources/assets/js/videos/components/videoScreen/drawInteractions.vue
+++ b/resources/assets/js/videos/components/videoScreen/drawInteractions.vue
@@ -4,8 +4,7 @@ import Keyboard from '../../../core/keyboard';
 import Styles from '../../../annotations/stores/styles';
 import VectorLayer from '@biigle/ol/layer/Vector';
 import VectorSource from '@biigle/ol/source/Vector';
-import PolygonValidator from '../../../annotations/ol/PolygonValidator';
-
+import * as PolygonValidator from "../../../annotations/ol/PolygonValidator";
 /**
  * Mixin for the videoScreen component that contains logic for the draw interactions.
  *
@@ -173,11 +172,8 @@ export default {
                     return;
                 }
 
-                // If polygon is self-intersecting, create valid polygon
-                let validPolygon = PolygonValidator.makePolygonSimple(e.feature);
-                let coords = validPolygon.getGeometry().getCoordinates();
-                e.feature.getGeometry().setCoordinates([coords[0]]);
-                
+                // If polygon is self-intersecting, create simple polygon
+                PolygonValidator.makePolygonSimple(e.feature);
             }
 
             let lastFrame = this.pendingAnnotation.frames[this.pendingAnnotation.frames.length - 1];

--- a/resources/assets/js/videos/components/videoScreen/modifyInteractions.vue
+++ b/resources/assets/js/videos/components/videoScreen/modifyInteractions.vue
@@ -5,6 +5,7 @@ import ModifyInteraction from '@biigle/ol/interaction/Modify';
 import TranslateInteraction from '../../../annotations/ol/TranslateInteraction';
 import {shiftKeyOnly as shiftKeyOnlyCondition} from '@biigle/ol/events/condition';
 import {singleClick as singleClickCondition} from '@biigle/ol/events/condition';
+import * as PolygonValidator from "../../../annotations/ol/PolygonValidator";
 
 const allowedSplitShapes = ['Point', 'Circle', 'Rectangle', 'WholeFrame'];
 
@@ -70,6 +71,17 @@ export default {
                     return this.featureRevisionMap[feature.getId()] !== feature.getRevision();
                 })
                 .map((feature) => {
+                    // Check polygons
+                    if (feature.getGeometry().getType() === 'Polygon') {
+                        if (PolygonValidator.isInvalidPolygon(feature)) {
+                            // Disallow polygons with less than three non-overlapping points
+                            this.$emit('is-invalid-polygon')
+                            return;
+                        }
+                        
+                        // If polygon is self-intersecting, create simple polygon
+                        PolygonValidator.simplifyPolygon(feature);
+                    }
                     return {
                         annotation: feature.get('annotation'),
                         points: this.getPointsFromGeometry(feature.getGeometry()),

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -613,9 +613,9 @@ export default {
                 annotation.failTracking();
             }
         },
-        handleInvalidPolygon(){
+        handleInvalidPolygon() {
             Messages.danger(`Invalid shape. Polygon needs at least 3 non-overlapping vertices.`);
-        }
+        },
     },
     watch: {
         'settings.playbackRate'(rate) {

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -20,9 +20,6 @@ import VideoScreen from './components/videoScreen';
 import VideoTimeline from './components/videoTimeline';
 import {handleErrorResponse} from '../core/messages/store';
 import {urlParams as UrlParams} from '../core/utils';
-import PolygonValidator from '../annotations/ol/PolygonValidator';
-import Feature from '@biigle/ol/Feature';
-import Polygon from '@biigle/ol/geom/Polygon';
 
 class VideoError extends Error {}
 class VideoNotProcessedError extends VideoError {}
@@ -278,23 +275,6 @@ export default {
                 label_id: this.selectedLabel ? this.selectedLabel.id : 0,
             });
 
-            // Check polygons
-            if (annotation.shape === 'Polygon') {
-                let feature = this.getFeatureFromAnnotation(annotation);
-                let polygonValidator = new PolygonValidator(feature);
-                if (polygonValidator.isInvalidPolygon()) {
-                    // Disallow polygons with less than three non-overlapping points
-                    Messages.danger(`Invalid shape. Polygon needs at least 3 non-overlapping vertices.`);
-                    this.removeAnnotation(tmpAnnotation);
-                    return;
-                }
-
-                // If polygon is self-intersecting, create valid polygon
-                let validPolygon = polygonValidator.getValidPolygon();
-                let twoDimCoords = validPolygon.getGeometry().getCoordinates();
-                annotation.points = [twoDimCoords[0].flat()];
-            }
-
             delete annotation.shape;
 
             return VideoAnnotationApi.save({id: this.videoId}, annotation)
@@ -305,13 +285,6 @@ export default {
                         this.annotations.splice(index, 1);
                     }
                 });
-        },
-        getFeatureFromAnnotation(annotation){
-            let points = annotation.points;
-            let xValues = points[0].filter((_,i) => {return i%2===0;});
-            let yValues = points[0].filter((_,i) => {return i%2===1;});
-            let coords = xValues.map((x,i) => [x,yValues[i]]);
-            return new Feature({geometry: new Polygon([coords])});
         },
         trackAnnotation(pendingAnnotation) {
             pendingAnnotation.track = true;
@@ -640,6 +613,9 @@ export default {
                 annotation.failTracking();
             }
         },
+        handleInvalidPolygon(){
+            Messages.danger(`Invalid shape. Polygon needs at least 3 non-overlapping vertices.`);
+        }
     },
     watch: {
         'settings.playbackRate'(rate) {

--- a/resources/views/annotations/show.blade.php
+++ b/resources/views/annotations/show.blade.php
@@ -95,6 +95,7 @@
             v-on:delete="handleDeleteAnnotations"
             v-on:measuring="fetchImagesArea"
             v-on:requires-selected-label="handleRequiresSelectedLabel"
+            v-on:has-invalid-shape="handleInvalidShape"
             ref="canvas"
             inline-template>
             @include('annotations.show.annotationCanvas')

--- a/resources/views/annotations/show.blade.php
+++ b/resources/views/annotations/show.blade.php
@@ -95,7 +95,7 @@
             v-on:delete="handleDeleteAnnotations"
             v-on:measuring="fetchImagesArea"
             v-on:requires-selected-label="handleRequiresSelectedLabel"
-            v-on:has-invalid-polygon="handleInvalidPolygon"
+            v-on:is-invalid-polygon="handleInvalidPolygon"
             ref="canvas"
             inline-template>
             @include('annotations.show.annotationCanvas')

--- a/resources/views/annotations/show.blade.php
+++ b/resources/views/annotations/show.blade.php
@@ -95,7 +95,7 @@
             v-on:delete="handleDeleteAnnotations"
             v-on:measuring="fetchImagesArea"
             v-on:requires-selected-label="handleRequiresSelectedLabel"
-            v-on:has-invalid-shape="handleInvalidShape"
+            v-on:has-invalid-polygon="handleInvalidPolygon"
             ref="canvas"
             inline-template>
             @include('annotations.show.annotationCanvas')

--- a/resources/views/videos/show/content.blade.php
+++ b/resources/views/videos/show/content.blade.php
@@ -60,6 +60,7 @@
       v-on:attaching-active="handleAttachingLabelActive"
       v-on:swapping-active="handleSwappingLabelActive"
       v-on:seek="seek"
+      v-on:is-invalid-polygon="handleInvalidPolygon"
       ></video-screen>
 <video-timeline
       ref="videoTimeline"


### PR DESCRIPTION
Shapes are checked for overlapping points. Rectangles need 4 vertices, lines need at least 2 vertices and polygons need at least 3 vertices that do not overlap. Another solution could be realized with JSTS.

Still missing: Solution for bowties, dangling lines and pinch points.

Open question: Should [JSTS](https://github.com/bjornharrtell/jsts) be used?