### PR TITLE
Fix manually set headers in TrustProxies

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -25,4 +25,16 @@ class TrustProxies extends Middleware
         Request::HEADER_X_FORWARDED_PORT |
         Request::HEADER_X_FORWARDED_PROTO |
         Request::HEADER_X_FORWARDED_AWS_ELB;
+
+    /**
+     * Manual fix for: https://github.com/laravel/framework/pull/47844
+     *
+     * TODO: Remove after upgrading to Laravel 10.x.
+     *
+     * @return int
+     */
+    protected function getTrustedHeaderNames()
+    {
+      return $this->headers;
+    }
 }


### PR DESCRIPTION
This can be reverted when upgrading to Laravel 10.

References: https://github.com/laravel/framework/pull/47844