### PR TITLE
Add annotation count feature

### DIFF
--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -160,6 +160,9 @@ export default {
         annotationsHiddenByFilter() {
             return this.annotations.length !== this.filteredAnnotations.length;
         },
+        getAnnotationCount() {
+            return this.annotations.length;
+        }
     },
     methods: {
         getImageAndAnnotationsPromises(id) {

--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -160,7 +160,7 @@ export default {
         annotationsHiddenByFilter() {
             return this.annotations.length !== this.filteredAnnotations.length;
         },
-        getAnnotationCount() {
+        annotationCount() {
             return this.annotations.length;
         }
     },

--- a/resources/assets/js/annotations/components/annotationsTab.vue
+++ b/resources/assets/js/annotations/components/annotationsTab.vue
@@ -83,12 +83,14 @@ export default {
                     };
                 });
         },
-        getTotalAnnotationCount() {
-            return this.totalAnnotationCount;
+        annotationCount() {
+            if (this.hasActiveFilter) {
+                return this.annotations.length + "/" + this.totalAnnotationCount
+            }
+            else {
+                return this.totalAnnotationCount;
+            }
         },
-        getFilteredAnnotationCountString() {
-            return this.annotations.length + "/" + this.getTotalAnnotationCount;
-        }
     },
     methods: {
         handleSelect(annotation, shift) {

--- a/resources/assets/js/annotations/components/annotationsTab.vue
+++ b/resources/assets/js/annotations/components/annotationsTab.vue
@@ -83,11 +83,10 @@ export default {
                     };
                 });
         },
-        annotationCount() {
+        annotationBadgeCount() {
             if (this.hasActiveFilter) {
                 return this.annotations.length + "/" + this.totalAnnotationCount
-            }
-            else {
+            } else {
                 return this.totalAnnotationCount;
             }
         },

--- a/resources/assets/js/annotations/components/annotationsTab.vue
+++ b/resources/assets/js/annotations/components/annotationsTab.vue
@@ -42,6 +42,10 @@ export default {
             type: Boolean,
             default: false,
         },
+        totalAnnotationCount: {
+            type: Number,
+            default: 0
+        }
     },
     computed: {
         labelItems() {
@@ -79,6 +83,12 @@ export default {
                     };
                 });
         },
+        getTotalAnnotationCount() {
+            return this.totalAnnotationCount;
+        },
+        getFilteredAnnotationCountString() {
+            return this.annotations.length + "/" + this.getTotalAnnotationCount;
+        }
     },
     methods: {
         handleSelect(annotation, shift) {

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -162,7 +162,7 @@ export default {
         annotationsHiddenByFilter() {
             return this.annotations.length !== this.filteredAnnotations.length;
         },
-        getAnnotationCount() {
+        annotationCount() {
             return this.annotations.length;
         }
     },

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -162,6 +162,9 @@ export default {
         annotationsHiddenByFilter() {
             return this.annotations.length !== this.filteredAnnotations.length;
         },
+        getAnnotationCount() {
+            return this.annotations.length;
+        }
     },
     methods: {
         prepareAnnotation(annotation) {

--- a/resources/views/annotations/show/tabs/annotations.blade.php
+++ b/resources/views/annotations/show/tabs/annotations.blade.php
@@ -1,7 +1,7 @@
 <sidebar-tab name="annotations" icon="map-marker-alt" title="Annotations" class="sidebar__tab--nopad" :highlight="hasAnnotationFilter">
     <annotations-tab
         :annotations="filteredAnnotations"
-        :total-annotation-count="getAnnotationCount"
+        :total-annotation-count="annotationCount"
         :selected-annotations="selectedAnnotations"
         :annotation-filters="annotationFilters"
         :can-detach-others="@can('forceEditIn', $volume) true @else false @endcan"
@@ -30,7 +30,7 @@
                     <div class="text-muted">Total
                         <span
                             class="pull-right badge"
-                            v-text="annotationCount"
+                            v-text="annotationBadgeCount"
                         ></span>          
                     </div> 
                 </div>

--- a/resources/views/annotations/show/tabs/annotations.blade.php
+++ b/resources/views/annotations/show/tabs/annotations.blade.php
@@ -1,6 +1,7 @@
 <sidebar-tab name="annotations" icon="map-marker-alt" title="Annotations" class="sidebar__tab--nopad" :highlight="hasAnnotationFilter">
     <annotations-tab
         :annotations="filteredAnnotations"
+        :total-annotation-count="getAnnotationCount"
         :selected-annotations="selectedAnnotations"
         :annotation-filters="annotationFilters"
         :can-detach-others="@can('forceEditIn', $volume) true @else false @endcan"
@@ -26,6 +27,10 @@
                     <div v-if="annotationsHiddenByFilter" class="text-info">
                         Some annotations are hidden by a filter.
                     </div>
+                    <div>Annotation count: 
+                        <b v-if="hasActiveFilter" v-text="getFilteredAnnotationCountString"></b>
+                        <b v-else v-text="getTotalAnnotationCount"></b>
+                    </div>           
                 </div>
                 <ul class="annotations-tab__list list-unstyled" ref="scrollList">
                     <label-item

--- a/resources/views/annotations/show/tabs/annotations.blade.php
+++ b/resources/views/annotations/show/tabs/annotations.blade.php
@@ -27,10 +27,12 @@
                     <div v-if="annotationsHiddenByFilter" class="text-info">
                         Some annotations are hidden by a filter.
                     </div>
-                    <div>Annotation count: 
-                        <b v-if="hasActiveFilter" v-text="getFilteredAnnotationCountString"></b>
-                        <b v-else v-text="getTotalAnnotationCount"></b>
-                    </div>           
+                    <div class="text-muted">Total
+                        <span
+                            class="pull-right badge"
+                            v-text="annotationCount"
+                        ></span>          
+                    </div> 
                 </div>
                 <ul class="annotations-tab__list list-unstyled" ref="scrollList">
                     <label-item

--- a/resources/views/videos/show/sidebar-annotations.blade.php
+++ b/resources/views/videos/show/sidebar-annotations.blade.php
@@ -7,7 +7,7 @@
     >
         <annotations-tab
             :annotations="filteredAnnotations"
-            :total-annotation-count="getAnnotationCount"
+            :total-annotation-count="annotationCount"
             :selected-annotations="selectedAnnotations"
             :annotation-filters="annotationFilters"
             :can-detach-others="@can('forceEditIn', $volume) true @else false @endcan"
@@ -35,7 +35,7 @@
                         <div class="text-muted">Total 
                             <span
                                 class="pull-right badge"
-                                v-text="annotationCount"
+                                v-text="annotationBadgeCount"
                             ></span>          
                         </div>                       
                     </div>

--- a/resources/views/videos/show/sidebar-annotations.blade.php
+++ b/resources/views/videos/show/sidebar-annotations.blade.php
@@ -32,10 +32,12 @@
                         <div v-if="annotationsHiddenByFilter" class="text-info">
                             Some annotations are hidden by a filter.
                         </div>
-                        <div>Annotation count: 
-                            <b v-if="hasActiveFilter" v-text="getFilteredAnnotationCountString"></b>
-                            <b v-else v-text="getTotalAnnotationCount"></b>
-                        </div>                        
+                        <div class="text-muted">Total 
+                            <span
+                                class="pull-right badge"
+                                v-text="annotationCount"
+                            ></span>          
+                        </div>                       
                     </div>
                     <ul class="annotations-tab__list list-unstyled" ref="scrollList">
                         <label-item

--- a/resources/views/videos/show/sidebar-annotations.blade.php
+++ b/resources/views/videos/show/sidebar-annotations.blade.php
@@ -7,6 +7,7 @@
     >
         <annotations-tab
             :annotations="filteredAnnotations"
+            :total-annotation-count="getAnnotationCount"
             :selected-annotations="selectedAnnotations"
             :annotation-filters="annotationFilters"
             :can-detach-others="@can('forceEditIn', $volume) true @else false @endcan"
@@ -31,6 +32,10 @@
                         <div v-if="annotationsHiddenByFilter" class="text-info">
                             Some annotations are hidden by a filter.
                         </div>
+                        <div>Annotation count: 
+                            <b v-if="hasActiveFilter" v-text="getFilteredAnnotationCountString"></b>
+                            <b v-else v-text="getTotalAnnotationCount"></b>
+                        </div>                        
                     </div>
                     <ul class="annotations-tab__list list-unstyled" ref="scrollList">
                         <label-item


### PR DESCRIPTION
Display an annotation count in the annotations tab beneath the filter. If a filter is active, return an filtered annotation count and total annotation count.

Resolves #459