### PR TITLE
Improve image cache size in annotation tool

### DIFF
--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -601,8 +601,10 @@ export default {
                 this.finishLoading();
             }
         },
-        cachedImagesCount() {
+        cachedImagesCount(count) {
             debounce(this.cachePreviousAndNext, 1000, 'annotations.cached-image-count.update');
+            // Twice the count because the next and previous images are cached.
+            ImagesStore.setMaxCacheSize(count * 2);
         },
         focussedAnnotation(annotation) {
             if (annotation) {

--- a/resources/assets/js/annotations/stores/images.vue
+++ b/resources/assets/js/annotations/stores/images.vue
@@ -12,7 +12,7 @@ export default new Vue({
         initialized: false,
         cache: {},
         cachedIds: [],
-        maxCacheSize: 200,
+        maxCacheSize: 2,
         supportsColorAdjustment: false,
         currentlyDrawnImage: null,
         colorAdjustmentDefaults: {
@@ -323,6 +323,9 @@ export default new Vue({
                 this.drawSimpleImage(this.currentlyDrawnImage);
             }
         },
+        setMaxCacheSize(size) {
+            this.maxCacheSize = size;
+        },
     },
     watch: {
         cachedIds(cachedIds) {
@@ -330,6 +333,12 @@ export default new Vue({
             // resources.
             if (cachedIds.length > this.maxCacheSize) {
                 let id = cachedIds.shift();
+                delete this.cache[id];
+            }
+        },
+        maxCacheSize(size) {
+            while (this.cachedIds.length > size) {
+                let id = this.cachedIds.shift();
                 delete this.cache[id];
             }
         },


### PR DESCRIPTION
The cache size is now controlled by the number of images that should be preloaded.

The largest chunk of memory required is taken up by decoded images, not the canvas elements of each cached image (see #653). Removing the canvases had no great impact. But limiting the size of the cache had, so the browser can know which images are "used" and which are "unused" to better optimize the memory requirement.

Resolves #653