### PR TITLE
Improve navbar (for mobile)

### DIFF
--- a/resources/assets/sass/_navbar.scss
+++ b/resources/assets/sass/_navbar.scss
@@ -129,6 +129,12 @@
     }
 }
 
+.navbar-btn-link {
+    .btn-default:not(:hover) {
+        background-color: transparent;
+    }
+}
+
 .nav > li > a.navbar-btn-link {
     padding: 9px 3px;
 }

--- a/resources/assets/sass/_navbar.scss
+++ b/resources/assets/sass/_navbar.scss
@@ -136,7 +136,7 @@
 }
 
 .nav > li > a.navbar-btn-link {
-    padding: 9px 3px;
+    padding: 8px 3px;
 }
 
 .nav > li:last-child > a.navbar-btn-link {

--- a/resources/assets/sass/_navbar.scss
+++ b/resources/assets/sass/_navbar.scss
@@ -89,3 +89,11 @@
         }
     }
 }
+
+.nav > li > a.navbar-btn-link {
+    padding: 9px 3px;
+}
+
+.nav > li:last-child > a.navbar-btn-link {
+    margin-right: 12px; // 15px space with the 3px padding
+}

--- a/resources/assets/sass/_navbar.scss
+++ b/resources/assets/sass/_navbar.scss
@@ -1,4 +1,43 @@
+// Disable navbar collapse on small screens.
+.navbar-header {
+    float: left !important;
+}
+
+.navbar-right {
+    float: right !important;
+}
+
+.navbar-nav {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+
+    .open .dropdown-menu {
+        position: absolute  !important;
+    }
+}
+
+.navbar-right .dropdown-menu {
+    right: 0 !important;
+    left: auto !important;
+}
+
+.navbar-nav > li {
+    float: left !important;
+}
+
+.navbar-default .navbar-nav .open .dropdown-menu > li > a {
+    color: $gray-darker !important;
+}
+
+@media (max-width: $screen-sm-max) {
+    .navbar-left {
+        display: none;
+    }
+}
+
 .dropdown-menu {
+    background-color: $gray-lighter !important;
+
     .divider {
         margin: 3px 0;
     }

--- a/resources/assets/sass/_notifications.scss
+++ b/resources/assets/sass/_notifications.scss
@@ -1,27 +1,5 @@
-@keyframes notification-blink {
-    0% {opacity: 0;}
-    1% {opacity: 1;}
-    2% {opacity: 0;}
-    3% {opacity: 1;}
-    4% {opacity: 0;}
-    5% {opacity: 1;}
-}
-
 .notifications-icon {
     position: relative;
-}
-
-.notifications-icon__count {
-    position: absolute;
-    display: block;
-    top: 10px;
-    right: 7px;
-    width: 10px;
-    height: 10px;
-    border-radius: 5px;
-    background-color: $brand-info;
-    border: 1px solid white;
-    animation: notification-blink 20s infinite;
 }
 
 .notification__action {

--- a/resources/views/partials/help-menu.blade.php
+++ b/resources/views/partials/help-menu.blade.php
@@ -1,5 +1,9 @@
 <li id="help-menu" is="dropdown" ref="dropdown" tag="li">
-    <a href="#" onclick="event.preventDefault()" class="dropdown-toggle" role="button" aria-haspopup="true" aria-expanded="false" title="Help menu"><i class="fa fa-question-circle"></i></a>
+    <a href="#" onclick="event.preventDefault()" class="dropdown-toggle navbar-btn-link" role="button" aria-haspopup="true" aria-expanded="false" title="Help menu">
+        <span class="btn btn-default">
+            <i class="fa fa-question-circle"></i> <span class="caret"></span>
+        </span>
+    </a>
     <template slot="dropdown">
         <li>
             <a href="{{ route('manual') }}" title="View the manual">Manual</a>

--- a/resources/views/partials/navbar.blade.php
+++ b/resources/views/partials/navbar.blade.php
@@ -20,18 +20,21 @@
                 <ul class="nav navbar-nav">
                     @can('sudo')
                         <li class="sudo-mode-indicator" title="You are in Super User Mode">
-                            <p class="navbar-text">su</p>
+                            <a href="{{route('settings-account')}}" class="navbar-btn-link">
+                                <span class="btn btn-danger">
+                                    su
+                                </span>
+                            </a>
                         </li>
                     @endcan
                     <li>
-                        <a href="{{route('search')}}" title="Search"><i class="fa fa-search"></i></a>
+                        <a href="{{route('search')}}" title="Search" class="navbar-btn-link"><span class="btn btn-default"><i class="fa fa-search"></i></span></a>
                     </li>
                     <li>
-                        <a href="{{route('notifications')}}" class="notifications-icon" @if ($hasNotification) title="You have unread notifications" @else title="Notifications" @endif>
-                            <i class="fa fa-bell"></i>
-                            @if ($hasNotification)
-                                <span class="notifications-icon__count"></span>
-                            @endif
+                        <a href="{{route('notifications')}}" class="notifications-icon navbar-btn-link" @if ($hasNotification) title="You have unread notifications" @else title="Notifications" @endif>
+                            <span class="btn @if ($hasNotification) btn-info @else btn-default @endif">
+                                <i class="fa fa-bell"></i>
+                            </span>
                         </a>
                     </li>
                     @include('partials.help-menu')

--- a/resources/views/partials/top-menu.blade.php
+++ b/resources/views/partials/top-menu.blade.php
@@ -1,5 +1,9 @@
 <li id="top-menu" is="dropdown" ref="dropdown" tag="li">
-    <a href="#" onclick="event.preventDefault()" class="dropdown-toggle" role="button" aria-haspopup="true" aria-expanded="false" title="Main menu"><i class="fa fa-bars"></i></a>
+    <a href="#" onclick="event.preventDefault()" class="dropdown-toggle navbar-btn-link" role="button" aria-haspopup="true" aria-expanded="false" title="Main menu">
+        <span class="btn btn-default">
+            <i class="fa fa-bars"></i> <span class="caret"></span>
+        </span>
+    </a>
     <template slot="dropdown">
         <li class="dropdown-header">
             Signed in as <strong>{{ $user->firstname }} {{ $user->lastname }}</strong>


### PR DESCRIPTION
So I was fed up with the navbar behavior on mobile for the final time. While we won't optimize all of BIIGLE for mobile anytime soon, at least the navbar should work. Here are the changes:

| before | after |
| --- | ---|
| desktop view:  | |
| ![Screenshot from 2023-10-23 16-30-33](https://github.com/biigle/core/assets/2457311/137f2a5c-658c-4cd3-ab64-e1250f0ef973) | ![Screenshot from 2023-10-23 16-30-38](https://github.com/biigle/core/assets/2457311/12ec8fc2-4eda-41eb-af1b-b9bcb75cde35) |
| ![Screenshot from 2023-10-23 16-44-16](https://github.com/biigle/core/assets/2457311/21b2e0f6-334c-4c56-8370-9a5469fff383) | ![Screenshot from 2023-10-23 16-43-19](https://github.com/biigle/core/assets/2457311/d0912252-c830-4690-9d4d-8da4f11fd139) |
| mobile view:  | |
| ![Screen Shot 2023-10-23 at 16 31 06](https://github.com/biigle/core/assets/2457311/9a3417b7-5b97-4024-b646-af755b354a52) | ![Screen Shot 2023-10-23 at 16 31 04](https://github.com/biigle/core/assets/2457311/fb1098e0-0395-4764-8d26-6cf32834189c) |
| ![Screen Shot 2023-10-23 at 16 31 13](https://github.com/biigle/core/assets/2457311/e31b0f1d-f5b2-4058-b403-8bdbf885455d) | ![Screen Shot 2023-10-23 at 16 31 10](https://github.com/biigle/core/assets/2457311/7a19ae85-6699-4597-9458-1945dd5a6f1c) |

@dlangenk Comments?

