### PR TITLE
Improve handling and configuration of GenerateFederatedSearchIndex job

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -30,13 +30,14 @@ class Kernel extends ConsoleKernel
         $schedule
             ->call(function () {
                 if (FederatedSearchInstance::withLocalToken()->exists()) {
-                    GenerateFederatedSearchIndex::dispatch();
+                    GenerateFederatedSearchIndex::dispatch()
+                        ->onQueue(config('biigle.federated_search.index_queue'));
                 }
             })
             ->name('generate-federated-search-index')
             // The requests to retrieve the federated search index are sent hourly at 05.
             // This should not collide with this job to generate the index.
-            ->hourlyAt(55)
+            ->hourlyAt(35)
             ->onOneServer();
 
         $schedule

--- a/config/biigle.php
+++ b/config/biigle.php
@@ -44,6 +44,11 @@ return [
         | Cache key to use for the federated search index.
         */
         'cache_key' => env('BIIGLE_FEDERATED_SEARCH_CACHE_KEY', 'federated_search_index'),
+
+        /*
+        | The queue to submit the "generate federated search index" job to.
+        */
+        'index_queue' => env('BIIGLE_FEDERATED_SEARCH_INDEX_QUEUE', 'default'),
     ],
 
 ];


### PR DESCRIPTION
If the default queue was congested, the job would not be run within 1 hour. When the "fetch index" request came from another instance, it would attempt to generate the index synchronously because the index was not there in the cache. This failed because generating the index took longer than the 30 s request timeout.

Now the job is dispatched 30 min before the requests should arrive. Also, the job can be pushed to a higher priority queue.