### PR TITLE
Allow the configuration of a queue for the ProcessNewVideo job

### DIFF
--- a/app/Jobs/ProcessNewVolumeFiles.php
+++ b/app/Jobs/ProcessNewVolumeFiles.php
@@ -62,7 +62,7 @@ class ProcessNewVolumeFiles extends Job implements ShouldQueue
             $query->eachById([ProcessNewImage::class, 'dispatch']);
         } else {
             $queue = config('videos.process_new_video_queue');
-            $query->eachById(fn($v) => ProcessNewVideo::dispatch($v)->onQueue($queue));
+            $query->eachById(fn ($v) => ProcessNewVideo::dispatch($v)->onQueue($queue));
         }
     }
 }

--- a/app/Jobs/ProcessNewVolumeFiles.php
+++ b/app/Jobs/ProcessNewVolumeFiles.php
@@ -61,7 +61,8 @@ class ProcessNewVolumeFiles extends Job implements ShouldQueue
         if ($this->volume->isImageVolume()) {
             $query->eachById([ProcessNewImage::class, 'dispatch']);
         } else {
-            $query->eachById([ProcessNewVideo::class, 'dispatch']);
+            $queue = config('videos.process_new_video_queue');
+            $query->eachById(fn($v) => ProcessNewVideo::dispatch($v)->onQueue($queue));
         }
     }
 }

--- a/tests/php/Jobs/ProcessNewVolumeFilesTest.php
+++ b/tests/php/Jobs/ProcessNewVolumeFilesTest.php
@@ -73,4 +73,16 @@ class ProcessNewVolumeFilesTest extends TestCase
 
         Queue::assertNotPushed(ProcessNewVideo::class, fn ($job) => $job->video->id === $v2->id);
     }
+
+    public function testHandleVideosQueue()
+    {
+        config(['videos.process_new_video_queue' => 'low']);
+        $volume = VolumeTest::create(['media_type_id' => MediaType::videoId()]);
+        $v1 = VideoTest::create(['volume_id' => $volume->id, 'filename' => 'a.mp4']);
+
+        Queue::fake();
+        with(new ProcessNewVolumeFiles($volume))->handle();
+
+        Queue::assertPushedOn('low', ProcessNewVideo::class, fn ($job) => $job->video->id === $v1->id);
+    }
 }


### PR DESCRIPTION
Video processing can be slow if there is a slow remote connection and it can congest the queue. This allows instance admins to configure a lower priority queue for the processing.