### PR TITLE
Fix active spinning wheel after video finished loading

### DIFF
--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -553,7 +553,11 @@ export default {
                 .then(this.handleVideoInformationResponse)
                 .then(this.fetchVideoContent)
                 .catch(this.handleVideoError)
-                .finally(this.finishLoading);
+                .finally(() => {
+                    this.finishLoading();
+                    // Avoid spinning wheel continuing to be displayed after moving fast through videos
+                    this.seeking = false;
+                });
 
             return promise;
         },


### PR DESCRIPTION
Set seeking on false again after loading video,
because seek() is called everytime a video is loaded.

Fixes #695.