### PR TITLE
Remove null (gap) to prevent validation errors

### DIFF
--- a/app/Traits/HasPointsAttribute.php
+++ b/app/Traits/HasPointsAttribute.php
@@ -15,11 +15,6 @@ trait HasPointsAttribute
      */
     public function validatePoints(array $points)
     {
-        // Gaps are represented as empty arrays
-        if (empty($points)) {
-            return;
-        }
-
         // check if all elements are integer
         $valid = array_reduce($points, fn ($carry, $point) => $carry && (is_float($point) || is_int($point)), true);
 

--- a/app/Traits/HasPointsAttribute.php
+++ b/app/Traits/HasPointsAttribute.php
@@ -15,6 +15,11 @@ trait HasPointsAttribute
      */
     public function validatePoints(array $points)
     {
+        // Gaps are represented as empty arrays
+        if (empty($points)) {
+            return;
+        }
+
         // check if all elements are integer
         $valid = array_reduce($points, fn ($carry, $point) => $carry && (is_float($point) || is_int($point)), true);
 

--- a/app/VideoAnnotation.php
+++ b/app/VideoAnnotation.php
@@ -105,7 +105,8 @@ class VideoAnnotation extends Annotation
             throw new Exception('The number of key frames does not match the number of annotation coordinates.');
         }
 
-        array_map([$this, 'parent::validatePoints'], $this->points);
+        // Gaps are represented as empty arrays
+        array_map(function ($point) { if (count($point)) { parent::validatePoints($point); } }, $this->points);
     }
 
     /**

--- a/resources/assets/js/videos/models/Annotation.vue
+++ b/resources/assets/js/videos/models/Annotation.vue
@@ -283,12 +283,14 @@ export default Vue.extend({
                 this.points.splice(index, 1);
 
                 // Remove null (gap filler) as first/last element to prevent validation errors
-                if (this.frames[0] === null) {
+                // Multiple consecutive 'null' can occur after removing elements of linked anntations
+                // in specific order
+                while (this.frames[0] === null) {
                     this.frames.shift();
                     this.points.shift();
                 }
 
-                if (this.frames.at(-1) === null) {
+                while (this.frames.at(-1) === null) {
                     this.frames.pop();
                     this.points.pop();
                 }

--- a/resources/assets/js/videos/models/Annotation.vue
+++ b/resources/assets/js/videos/models/Annotation.vue
@@ -282,7 +282,12 @@ export default Vue.extend({
                 this.frames.splice(index, 1);
                 this.points.splice(index, 1);
 
-                // Remove null (gap filler) as last element to prevent validation errors
+                // Remove null (gap filler) as first/last element to prevent validation errors
+                if (this.frames[0] === null) {
+                    this.frames.shift();
+                    this.points.shift();
+                }
+
                 if (this.frames.at(-1) === null) {
                     this.frames.pop();
                     this.points.pop();

--- a/resources/assets/js/videos/models/Annotation.vue
+++ b/resources/assets/js/videos/models/Annotation.vue
@@ -282,15 +282,14 @@ export default Vue.extend({
                 this.frames.splice(index, 1);
                 this.points.splice(index, 1);
 
-                // Remove null (gap filler) as first/last element to prevent validation errors
-                if (this.frames[0] === null) {
-                    this.frames.shift();
-                    this.points.shift();
-                }
-
-                if (this.frames.at(-1) === null) {
-                    this.frames.pop();
-                    this.points.pop();
+                // Remove "null" elements of adjacent gaps to
+                // avoid multiple consecutive "null"s.
+                if (index === 0 && this.frames[0] === null) {
+                    this.frames.splice(0, 1);
+                    this.points.splice(0, 1);
+                } else if (this.frames[index - 1] === null) {
+                    this.frames.splice(index - 1, 1);
+                    this.points.splice(index - 1, 1);
                 }
 
                 return VideoAnnotationApi.update({id: this.id}, {

--- a/resources/assets/js/videos/models/Annotation.vue
+++ b/resources/assets/js/videos/models/Annotation.vue
@@ -282,6 +282,12 @@ export default Vue.extend({
                 this.frames.splice(index, 1);
                 this.points.splice(index, 1);
 
+                // Remove null (gap filler) as last element to prevent validation errors
+                if (this.frames.at(-1) === null) {
+                    this.frames.pop();
+                    this.points.pop();
+                }
+
                 return VideoAnnotationApi.update({id: this.id}, {
                     frames: this.frames,
                     points: this.points

--- a/resources/assets/js/videos/models/Annotation.vue
+++ b/resources/assets/js/videos/models/Annotation.vue
@@ -283,14 +283,12 @@ export default Vue.extend({
                 this.points.splice(index, 1);
 
                 // Remove null (gap filler) as first/last element to prevent validation errors
-                // Multiple consecutive 'null' can occur after removing elements of linked anntations
-                // in specific order
-                while (this.frames[0] === null) {
+                if (this.frames[0] === null) {
                     this.frames.shift();
                     this.points.shift();
                 }
 
-                while (this.frames.at(-1) === null) {
+                if (this.frames.at(-1) === null) {
                     this.frames.pop();
                     this.points.pop();
                 }

--- a/tests/php/VideoAnnotationTest.php
+++ b/tests/php/VideoAnnotationTest.php
@@ -49,6 +49,14 @@ class VideoAnnotationTest extends ModelTestCase
         $this->model->validatePoints();
     }
 
+    public function testValidatePointsWithGap()
+    {
+        $this->expectNotToPerformAssertions();
+        $this->model->points = [[10, 10], [], [20, 20]];
+        $this->model->frames = [0.0, null, 1.0];
+        $this->model->validatePoints();
+    }
+
     public function testValidatePointsPoint()
     {
         $this->model->shape_id = Shape::pointId();


### PR DESCRIPTION
If single frame and clip annotations are linked and are not touching each other, then null is added. When deleting the single frame annotation, delete also the null.

Fix #488