### PR TITLE
Fix volume URL validation

### DIFF
--- a/app/Http/Requests/StoreVolume.php
+++ b/app/Http/Requests/StoreVolume.php
@@ -48,7 +48,7 @@ class StoreVolume extends FormRequest
         return [
             'name' => 'required|max:512',
             'media_type' => ['filled', Rule::in(array_keys(MediaType::INSTANCES))],
-            'url' => ['required', 'max:256', new VolumeUrl],
+            'url' => ['required', 'string', 'max:256', new VolumeUrl],
             'files' => [
                 'required',
                 'array',

--- a/app/Http/Requests/UpdateVolume.php
+++ b/app/Http/Requests/UpdateVolume.php
@@ -37,7 +37,7 @@ class UpdateVolume extends FormRequest
     {
         return [
             'name' => 'filled|max:512',
-            'url' => ['required', 'string', 'max:256', new VolumeUrl],
+            'url' => ['filled', 'string', 'max:256', new VolumeUrl],
             'handle' => ['nullable', 'max:256', new Handle],
         ];
     }

--- a/app/Http/Requests/UpdateVolume.php
+++ b/app/Http/Requests/UpdateVolume.php
@@ -37,7 +37,7 @@ class UpdateVolume extends FormRequest
     {
         return [
             'name' => 'filled|max:512',
-            'url' => ['filled', 'max:256', new VolumeUrl],
+            'url' => ['required', 'string', 'max:256', new VolumeUrl],
             'handle' => ['nullable', 'max:256', new Handle],
         ];
     }


### PR DESCRIPTION
Someone managed to pass an array as volume URL. This threw an error in the VolumeUrl rule which expects a string.