### PR TITLE
Disable tracking button if job limit is exceeded

### DIFF
--- a/app/Http/Controllers/Api/VideoAnnotationController.php
+++ b/app/Http/Controllers/Api/VideoAnnotationController.php
@@ -240,6 +240,7 @@ class VideoAnnotationController extends Controller
             $queue = config('videos.track_object_queue');
             Queue::pushOn($queue, new TrackObject($annotation, $request->user()));
             Cache::increment(TrackObject::getRateLimitCacheKey($request->user()));
+            $annotation->trackedAnnotationRate = $currentJobs / (float) ($maxJobs-1);
         }
 
         $annotation->load('labels.label', 'labels.user');

--- a/app/Http/Controllers/Api/VideoAnnotationController.php
+++ b/app/Http/Controllers/Api/VideoAnnotationController.php
@@ -240,7 +240,7 @@ class VideoAnnotationController extends Controller
             $queue = config('videos.track_object_queue');
             Queue::pushOn($queue, new TrackObject($annotation, $request->user()));
             Cache::increment(TrackObject::getRateLimitCacheKey($request->user()));
-            $annotation->trackedAnnotationRate = $currentJobs / (float) ($maxJobs-1);
+            $annotation->trackingJobLimitReached = $currentJobs === ($maxJobs - 1);
         }
 
         $annotation->load('labels.label', 'labels.user');

--- a/resources/assets/js/videos/components/videoScreen.vue
+++ b/resources/assets/js/videos/components/videoScreen.vue
@@ -59,7 +59,8 @@
                             icon="fa-project-diagram"
                             title="Finish and track the point annotation"
                             v-on:click="finishTrackAnnotation"
-                            :disabled="cantFinishTrackAnnotation"
+                            :disabled="cantFinishTrackAnnotation || disableJobTracking"
+                            :loading="disableJobTracking"
                             ></control-button>
                 </control-button>
                 <control-button
@@ -97,7 +98,8 @@
                             icon="fa-project-diagram"
                             title="Finish and track the circle annotation"
                             v-on:click="finishTrackAnnotation"
-                            :disabled="cantFinishTrackAnnotation"
+                            :disabled="cantFinishTrackAnnotation || disableJobTracking"
+                            :loading="disableJobTracking"
                             ></control-button>
                 </control-button>
                 <control-button
@@ -351,6 +353,10 @@ export default {
             type: Boolean,
             default: false,
         },
+        reachedTrackedAnnotationLimit: {
+            type: Boolean,
+            default: false,
+        }
     },
     data() {
         return {
@@ -378,6 +384,9 @@ export default {
             }
 
             return '';
+        },
+        disableJobTracking() {
+            return this.reachedTrackedAnnotationLimit;
         },
     },
     methods: {

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -286,10 +286,10 @@ export default {
 
             return VideoAnnotationApi.save({id: this.videoId}, annotation)
                 .then((res) => {
-                    this.addCreatedAnnotation(res);
                     if (tmpAnnotation.track) {
                         this.disableJobTracking = res.body.trackingJobLimitReached;
                     }
+                    return this.addCreatedAnnotation(res);
                 }, (res) => {
                     handleErrorResponse(res);
                     this.disableJobTracking = res.status === 429;

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -288,8 +288,7 @@ export default {
                 .then((res) => {
                     this.addCreatedAnnotation(res);
                     if (tmpAnnotation.track) {
-                        // trackedAnnotationRate is the tracked annotation job occupancy rate
-                        this.disableJobTracking = res.body.trackedAnnotationRate === 1;
+                        this.disableJobTracking = res.body.trackingJobLimitReached;
                     }
                 }, (res) => {
                     handleErrorResponse(res);

--- a/resources/views/videos/show/content.blade.php
+++ b/resources/views/videos/show/content.blade.php
@@ -43,6 +43,7 @@
       :show-prev-next="hasSiblingVideos"
       :has-error="hasError"
       :seeking="seeking"
+      :reached-tracked-annotation-limit="reachedTrackedAnnotationLimit"
       v-on:create-annotation="createAnnotation"
       v-on:track-annotation="trackAnnotation"
       v-on:split-annotation="splitAnnotation"


### PR DESCRIPTION
Tracking annotation button is disabled if there are already 10 jobs in the queue.

Closes #609