### PR TITLE
fix error on console command creating new user without admin rights

### DIFF
--- a/app/Console/Commands/NewUser.php
+++ b/app/Console/Commands/NewUser.php
@@ -39,6 +39,8 @@ class NewUser extends Command
 
         if ($this->confirm('Should the user be global admin? [y|N]')) {
             $u->role_id = Role::adminId();
+        } else {
+            $u->role_id = Role::editorId();
         }
 
         if ($this->confirm('Do you wish to auto-generate a password? [y|N]')) {


### PR DESCRIPTION
The "new user" console command without admin rights was not handled and returned an error. 