### PR TITLE
Fix polygon tool bug

### DIFF
--- a/resources/assets/js/annotations/components/annotationCanvas/polygonBrushInteraction.vue
+++ b/resources/assets/js/annotations/components/annotationCanvas/polygonBrushInteraction.vue
@@ -111,18 +111,24 @@ export default {
     },
     watch: {
         isUsingPolygonBrush() {
-            this.resetCurrentInteraction();
-            this.togglePolygonBrushInteraction();
+            if(this.isUsingPolygonBrush){
+                this.resetCurrentInteraction();
+                this.togglePolygonBrushInteraction();
+            }
         },
         isUsingPolygonEraser() {
-            this.resetCurrentInteraction();
-            this.toggleShiftClickSelectInteraction();
-            this.togglePolygonEraserInteraction();
+            if(this.isUsingPolygonEraser){
+                this.resetCurrentInteraction();
+                this.toggleShiftClickSelectInteraction();
+                this.togglePolygonEraserInteraction();
+            }
         },
         isUsingPolygonFill() {
-            this.resetCurrentInteraction();
-            this.toggleShiftClickSelectInteraction();
-            this.togglePolygonFillInteraction();
+            if(this.isUsingPolygonFill){
+                this.resetCurrentInteraction();
+                this.toggleShiftClickSelectInteraction();
+                this.togglePolygonFillInteraction();
+            }
         },
     },
     created() {


### PR DESCRIPTION
When interaction mode is changed, the old and new computed property change, which triggers their corresponding watchers.
Fix bug by using watcher of current interaction mode only.