### PR TITLE
Fix disabled auto-rotation for image thumbnails

### DIFF
--- a/app/Jobs/ProcessNewImage.php
+++ b/app/Jobs/ProcessNewImage.php
@@ -126,9 +126,12 @@ class ProcessNewImage extends Job implements ShouldQueue
     {
         $prefix = fragment_uuid_path($image->uuid);
         $format = config('thumbnails.format');
-        $buffer = VipsImage::thumbnail($path, $this->width, ['height' => $this->height])
-            // Strip EXIF information to not auto rotate thumbnails because
-            // the orientation of AUV captured images is not reliable.
+        $buffer = VipsImage::thumbnail($path, $this->width, [
+                'height' => $this->height,
+                // Don't auto rotate thumbnails because the orientation of AUV captured
+                // images is not reliable.
+                'no-rotate' => true,
+            ])
             ->writeToBuffer(".{$format}", [
                 'Q' => 85,
                 'strip' => true,

--- a/app/Jobs/ProcessNewImage.php
+++ b/app/Jobs/ProcessNewImage.php
@@ -127,15 +127,14 @@ class ProcessNewImage extends Job implements ShouldQueue
         $prefix = fragment_uuid_path($image->uuid);
         $format = config('thumbnails.format');
         $buffer = VipsImage::thumbnail($path, $this->width, [
-                'height' => $this->height,
-                // Don't auto rotate thumbnails because the orientation of AUV captured
-                // images is not reliable.
-                'no-rotate' => true,
-            ])
-            ->writeToBuffer(".{$format}", [
-                'Q' => 85,
-                'strip' => true,
-            ]);
+            'height' => $this->height,
+            // Don't auto rotate thumbnails because the orientation of AUV captured
+            // images is not reliable.
+            'no-rotate' => true,
+        ])->writeToBuffer(".{$format}", [
+            'Q' => 85,
+            'strip' => true,
+        ]);
 
         Storage::disk(config('thumbnails.storage_disk'))
             ->put("{$prefix}.{$format}", $buffer);


### PR DESCRIPTION
The previously used 'strip' option doesn't seem to work any more. It works with the new 'no-rotate' option.