### PR TITLE
Implement frame-to-frame video navigation

### DIFF
--- a/resources/assets/js/videos/components/settingsTab.vue
+++ b/resources/assets/js/videos/components/settingsTab.vue
@@ -15,6 +15,7 @@ export default {
                 'showLabelTooltip',
                 'showMousePosition',
                 'showProgressIndicator',
+                'jumpStep',
             ],
             annotationOpacity: 1,
             showMinimap: true,
@@ -22,6 +23,7 @@ export default {
             showLabelTooltip: false,
             showMousePosition: false,
             playbackRate: 1.0,
+            jumpStep: 5.0,
             showProgressIndicator: true,
         };
     },
@@ -81,6 +83,11 @@ export default {
             if (!isNaN(value)) {
                 this.$emit('update', 'playbackRate', value);
             }
+        },
+        jumpStep(value) {
+            value = parseFloat(value);
+            this.$emit('update', 'jumpStep', value);
+            Settings.set('jumpStep', value);
         },
         showProgressIndicator(show) {
             this.$emit('update', 'showProgressIndicator', show);

--- a/resources/assets/js/videos/components/videoScreen.vue
+++ b/resources/assets/js/videos/components/videoScreen.vue
@@ -11,17 +11,24 @@
             :position="mousePosition"
             ></label-tooltip>
         <div class="controls">
+            <div class="btn-group"
+                v-if="showPrevNext">
+                 <control-button
+                    icon="fa-chevron-left"
+                    title="Previous video"
+                    @click="emitPrevious"
+                    ></control-button>
+            </div>     
             <div class="btn-group">
                  <control-button
-                    v-if="showPrevNext"
                     icon="fa-backward"
-                    title="Previous video 𝗟𝗲𝗳𝘁 𝗮𝗿𝗿𝗼𝘄"
-                    @click="emitPrevious"
+                    title="Rewind video by jump step"
+                    @click="jumpBackward"
                     ></control-button>
                 <control-button
                     icon="fa-step-backward"
                     title="Previous frame 𝗟𝗲𝗳𝘁 𝗮𝗿𝗿𝗼𝘄"
-                    v-on:click="showPreviousFrame"
+                    @click="showPreviousFrame"
                     ></control-button>
                 <control-button
                     v-if="playing"
@@ -39,13 +46,20 @@
                     ></control-button>
                 <control-button
                     icon="fa-step-forward"
-                    title="Next frame Right 𝗮𝗿𝗿𝗼𝘄"
-                    v-on:click="showNextFrame"
+                    title="Next frame 𝗥𝗶𝗴𝗵𝘁 𝗮𝗿𝗿𝗼𝘄"
+                    @click="showNextFrame"
                     ></control-button>
                 <control-button
-                    v-if="showPrevNext"
                     icon="fa-forward"
-                    title="Next video 𝗥𝗶𝗴𝗵𝘁 𝗮𝗿𝗿𝗼𝘄"
+                    title="Advance video by jump step"
+                    @click="jumpForward"
+                    ></control-button>
+            </div>
+            <div class="btn-group"
+                v-if="showPrevNext">
+                 <control-button
+                    icon="fa-chevron-right"
+                    title="Next video"
                     @click="emitNext"
                     ></control-button>
             </div>
@@ -295,6 +309,10 @@ export default {
         autoplayDraw: {
             type: Number,
             default: 0,
+        },
+        jumpStep: {
+            type: Number,
+            default: 5.0,
         },
         canAdd: {
             type: Boolean,
@@ -560,8 +578,8 @@ export default {
         this.map.on('moveend', this.emitMoveend);
 
         Keyboard.on('Escape', this.resetInteractionMode, 0, this.listenerSet);
-        Keyboard.on('ArrowRight', this.emitNext, 0, this.listenerSet);
-        Keyboard.on('ArrowLeft', this.emitPrevious, 0, this.listenerSet);
+        Keyboard.on('ArrowRight', this.showNextFrame, 0, this.listenerSet);
+        Keyboard.on('ArrowLeft', this.showPreviousFrame, 0, this.listenerSet);
     },
     mounted() {
         this.map.setTarget(this.$el);

--- a/resources/assets/js/videos/components/videoScreen.vue
+++ b/resources/assets/js/videos/components/videoScreen.vue
@@ -14,9 +14,14 @@
             <div class="btn-group">
                  <control-button
                     v-if="showPrevNext"
-                    icon="fa-step-backward"
+                    icon="fa-backward"
                     title="Previous video 𝗟𝗲𝗳𝘁 𝗮𝗿𝗿𝗼𝘄"
                     @click="emitPrevious"
+                    ></control-button>
+                <control-button
+                    icon="fa-step-backward"
+                    title="Previous frame 𝗟𝗲𝗳𝘁 𝗮𝗿𝗿𝗼𝘄"
+                    v-on:click="showPreviousFrame"
                     ></control-button>
                 <control-button
                     v-if="playing"
@@ -33,8 +38,13 @@
                     @click="play"
                     ></control-button>
                 <control-button
-                    v-if="showPrevNext"
                     icon="fa-step-forward"
+                    title="Next frame Right 𝗮𝗿𝗿𝗼𝘄"
+                    v-on:click="showNextFrame"
+                    ></control-button>
+                <control-button
+                    v-if="showPrevNext"
+                    icon="fa-forward"
                     title="Next video 𝗥𝗶𝗴𝗵𝘁 𝗮𝗿𝗿𝗼𝘄"
                     @click="emitNext"
                     ></control-button>

--- a/resources/assets/js/videos/components/videoScreen/videoPlayback.vue
+++ b/resources/assets/js/videos/components/videoScreen/videoPlayback.vue
@@ -197,6 +197,19 @@ export default {
                 if (metadata.mediaTime !== firstMetadata.mediaTime) break;
             }
         },
+        // Methods to jump back and forward in video. Step is given by parameter jumpStep.
+        async jumpBackward() {
+            if (this.video.currentTime > 0 && this.jumpStep > 0) {
+                this.video.currentTime -= this.jumpStep;
+                await this.frameInfoCallback();
+            }
+        },
+        async jumpForward() {
+            if (!this.video.ended && this.jumpStep > 0) {
+                this.video.currentTime += this.jumpStep;
+                await this.frameInfoCallback();
+            }
+        },
     },
     watch: {
         seeking(seeking) {

--- a/resources/assets/js/videos/stores/settings.js
+++ b/resources/assets/js/videos/stores/settings.js
@@ -7,6 +7,7 @@ let defaults = {
     showLabelTooltip: false,
     showMousePosition: false,
     showProgressIndicator: true,
+    jumpStep: 5.0,
 };
 
 export default new Settings({

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -67,6 +67,7 @@ export default {
                 showLabelTooltip: false,
                 showMousePosition: false,
                 playbackRate: 1.0,
+                jumpStep: 5.0,
                 showProgressIndicator: true,
             },
             openTab: '',

--- a/resources/views/videos/show/content.blade.php
+++ b/resources/views/videos/show/content.blade.php
@@ -28,6 +28,7 @@
       :annotations="filteredAnnotations"
       :annotation-opacity="settings.annotationOpacity"
       :autoplay-draw="settings.autoplayDraw"
+      :jump-step="settings.jumpStep"
       :can-add="canEdit"
       :can-modify="canEdit"
       :can-delete="canEdit"

--- a/resources/views/videos/show/sidebar-settings.blade.php
+++ b/resources/views/videos/show/sidebar-settings.blade.php
@@ -20,7 +20,7 @@
                 </div>
 
                 <div class="sidebar-tab__section">
-                    <input type="number" min="0.1" max="60.0" step="0.1" v-model="jumpStep" class="form-control form-control--small" title="Time in seconds that the video will jump (back or forward) with command buttons"> Jump step
+                    <input type="number" min="0.1" max="60.0" step="0.1" v-model="jumpStep" class="form-control form-control--small" title="Time in seconds that the video will jump (back or forward) with command buttons"> Jump step (s)
                 </div>
 
                 <div class="sidebar-tab__section">

--- a/resources/views/videos/show/sidebar-settings.blade.php
+++ b/resources/views/videos/show/sidebar-settings.blade.php
@@ -20,6 +20,10 @@
                 </div>
 
                 <div class="sidebar-tab__section">
+                    <input type="number" min="0.1" max="60.0" step="0.1" v-model="jumpStep" class="form-control form-control--small" title="Time in seconds that the video will jump (back or forward) with command buttons"> Jump step
+                </div>
+
+                <div class="sidebar-tab__section">
                     <power-toggle :active="showProgressIndicator" title-off="Show progress indicator" title-on="Hide progress indicator" v-on:on="handleShowProgressIndicator" v-on:off="handleHideProgressIndicator">Progress Indicator</power-toggle>
                 </div>
 


### PR DESCRIPTION
- Uses a hack to navigate frame-to-frame in video, based on [requestVideoFrameCallback](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback) and [https://github.com/angrycoding/requestVideoFrameCallback-prev-next](https://github.com/angrycoding/requestVideoFrameCallback-prev-next)

WARNING: this works only in Chrome (not in Firefox). Not tested in other navigators.

- Adds a 'Jump step' setting to directly jump a certain amount of seconds backward and forward

Changes video navigation buttons:

- step-backward and step-forward are used to go to previous and next frames in video
- add double-backward and double-forward buttons for Jump step setting
- add chevron-left and chevron-right to go to previous/next video of volume