### PR TITLE
Add bail to volume URL/handle validation rules

### DIFF
--- a/app/Http/Requests/StoreVolume.php
+++ b/app/Http/Requests/StoreVolume.php
@@ -48,12 +48,12 @@ class StoreVolume extends FormRequest
         return [
             'name' => 'required|max:512',
             'media_type' => ['filled', Rule::in(array_keys(MediaType::INSTANCES))],
-            'url' => ['required', 'string', 'max:256', new VolumeUrl],
+            'url' => ['bail', 'required', 'string', 'max:256', new VolumeUrl],
             'files' => [
                 'required',
                 'array',
             ],
-            'handle' => ['nullable', 'max:256', new Handle],
+            'handle' => ['bail', 'nullable', 'string', 'max:256', new Handle],
             'metadata_csv' => 'file|mimetypes:text/plain,text/csv,application/csv',
             'ifdo_file' => 'file',
             'metadata' => 'filled',

--- a/app/Http/Requests/UpdateVolume.php
+++ b/app/Http/Requests/UpdateVolume.php
@@ -37,8 +37,8 @@ class UpdateVolume extends FormRequest
     {
         return [
             'name' => 'filled|max:512',
-            'url' => ['filled', 'string', 'max:256', new VolumeUrl],
-            'handle' => ['nullable', 'max:256', new Handle],
+            'url' => ['bail', 'filled', 'string', 'max:256', new VolumeUrl],
+            'handle' => ['bail', 'nullable', 'string', 'max:256', new Handle],
         ];
     }
 


### PR DESCRIPTION
If the value is not a string, the VolumeUrl and Handle rules would throw an exception.