### PR TITLE
Fix video seeking on pause

### DIFF
--- a/resources/assets/js/videos/components/videoScreen.vue
+++ b/resources/assets/js/videos/components/videoScreen.vue
@@ -552,7 +552,7 @@ export default {
             this.$emit('next');
         },
         reset() {
-            this.setPaused(true);
+            this.setPaused();
             this.resetInteractionMode();
         },
         adaptKeyboardShortcuts() {

--- a/resources/assets/js/videos/components/videoScreen/videoPlayback.vue
+++ b/resources/assets/js/videos/components/videoScreen/videoPlayback.vue
@@ -120,7 +120,7 @@ export default {
                 this.startRenderLoop();
             }
         },
-        setPaused(dontSeek = false) {
+        setPaused(dontSeek) {
             this.playing = false;
             this.stopRenderLoop();
             // Force render the video frame that belongs to currentTime. This is a
@@ -128,7 +128,7 @@ export default {
             // currentTime (in most cases). With the workaround we can create annotations
             // at currentTime and be sure that the same frame can be reproduced later for
             // the annotations. See: https://github.com/biigle/core/issues/433
-            if (!dontSeek) {
+            if (dontSeek !== true) {
                 this.$emit('seek', this.video.currentTime, true);
             }
         },
@@ -254,7 +254,7 @@ export default {
         this.dummyCanvas.width = 1;
         this.dummyCanvas.height = 1;
         this.video.addEventListener('play', this.setPlaying);
-        this.video.addEventListener('pause', this.setPaused);
+        this.video.addEventListener('pause', (e) => this.setPaused());
         this.video.addEventListener('seeked', this.handleSeeked);
         this.video.addEventListener('loadeddata', this.renderVideo);
 

--- a/resources/assets/js/videos/components/videoScreen/videoPlayback.vue
+++ b/resources/assets/js/videos/components/videoScreen/videoPlayback.vue
@@ -120,17 +120,18 @@ export default {
                 this.startRenderLoop();
             }
         },
-        setPaused(dontSeek) {
+        setPaused() {
             this.playing = false;
             this.stopRenderLoop();
+        },
+        setPausedAndSeek() {
+            this.setPaused();
             // Force render the video frame that belongs to currentTime. This is a
             // workaround because the displayed frame not the one that belongs to
             // currentTime (in most cases). With the workaround we can create annotations
             // at currentTime and be sure that the same frame can be reproduced later for
             // the annotations. See: https://github.com/biigle/core/issues/433
-            if (dontSeek !== true) {
-                this.$emit('seek', this.video.currentTime, true);
-            }
+            this.$emit('seek', this.video.currentTime, true);
         },
         togglePlaying() {
             if (this.playing) {
@@ -254,7 +255,7 @@ export default {
         this.dummyCanvas.width = 1;
         this.dummyCanvas.height = 1;
         this.video.addEventListener('play', this.setPlaying);
-        this.video.addEventListener('pause', (e) => this.setPaused());
+        this.video.addEventListener('pause', this.setPausedAndSeek);
         this.video.addEventListener('seeked', this.handleSeeked);
         this.video.addEventListener('loadeddata', this.renderVideo);
 


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/biigle/core/pull/726. The video was supposed to seek to the current time on pause so the displayed frame is the exact frame that matches currentTime that is used for the annotations. However, on pause, the "dontSeek" argument was set to an event object and not false, so the seeking didn't happen.