### PR TITLE
truncates long image names in the navbar/content

### DIFF
--- a/resources/assets/sass/volumes/main.scss
+++ b/resources/assets/sass/volumes/main.scss
@@ -14,8 +14,9 @@ $volume-image-padding: 0.5em;
 }
 
 .navbar-text.navbar-volumes-breadcrumbs {
-    &, a {
-        color: $text-color;
+
+    .annotations-breadcrumb {
+        max-width: 600px;
     }
 }
 
@@ -39,6 +40,12 @@ $volume-image-padding: 0.5em;
 .volume-storage-disk-btn {
     overflow-x: hidden;
     text-overflow: ellipsis;
+}
+
+.file-info-title {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 @import 'components/image-grid';

--- a/resources/views/volumes/images/index.blade.php
+++ b/resources/views/volumes/images/index.blade.php
@@ -1,17 +1,16 @@
 @extends('app')
-@section('full-navbar', true)
-@section('title', "$image->filename")
+@section('title', $image->filename)
 
 @section('content')
 <div class="container">
     <div class="row">
-        <h2 class="col-lg-12 clearfix annotations-breadcrumb">
+        <h2 class="col-lg-12 clearfix file-info-title" title="{{ $image->filename }}">
             {{ $image->filename }}
-        </h2>
-        <span class="pull-right">
+            <span class="pull-right">
                 <a href="{{route('volume', $volume->id)}}" title="Back to {{ $volume->name }}" class="btn btn-default">back</a>
                 @mixin('imagesIndexButtons')
             </span>
+        </h2>
     </div>
     <div class="row">
         <div class="col-sm-6 col-lg-4">
@@ -30,13 +29,13 @@
 @endsection
 
 @section('navbar')
-<div class="navbar-text">
+<div class="navbar-text navbar-volumes-breadcrumbs">
     <div class="annotations-project-dd">
         @include('volumes.partials.projectsBreadcrumb', ['projects' => $volume->projects]) /
     </div>
     <div class="annotations-breadcrumb">
-    <a href="{{route('volume', $volume->id)}}" class="navbar-link" title="Show volume {{$volume->name}}">{{$volume->name}}</a> /
-            <strong>{{$image->filename}}</strong>
+        <a href="{{route('volume', $volume->id)}}" class="navbar-link" title="Show volume {{$volume->name}}">{{$volume->name}}</a> /
+        <strong title="{{$image->filename}}">{{$image->filename}}</strong>
     </div>
     @include('volumes.partials.annotationSessionIndicator')
 </div>

--- a/resources/views/volumes/images/index.blade.php
+++ b/resources/views/volumes/images/index.blade.php
@@ -5,7 +5,7 @@
 <div class="container">
     <div class="row">
         <h2 class="col-lg-12 clearfix">
-            {{ $image->filename }}
+            {{ mb_strimwidth($image->filename, 0, 63, '...')}}
             <span class="pull-right">
                 <a href="{{route('volume', $volume->id)}}" title="Back to {{ $volume->name }}" class="btn btn-default">back</a>
                 @mixin('imagesIndexButtons')
@@ -31,6 +31,6 @@
 @section('navbar')
 <div class="navbar-text navbar-volumes-breadcrumbs">
     @include('volumes.partials.projectsBreadcrumb', ['projects' => $volume->projects])/ <a href="{{route('volume', $volume->id)}}" class="navbar-link" title="Show volume {{$volume->name}}">{{$volume->name}}</a>
-    / <strong title="{{$image->filename}}">{{$image->filename}}</strong> @include('volumes.partials.annotationSessionIndicator')
+    / <strong title="{{mb_strimwidth($image->filename, 0, 63, '...')}}">{{mb_strimwidth($image->filename, 0, 63, '...')}}</strong> @include('volumes.partials.annotationSessionIndicator')
 </div>
 @endsection

--- a/resources/views/volumes/images/index.blade.php
+++ b/resources/views/volumes/images/index.blade.php
@@ -1,16 +1,17 @@
 @extends('app')
-@section('title', $image->filename)
+@section('full-navbar', true)
+@section('title', "$image->filename")
 
 @section('content')
 <div class="container">
     <div class="row">
-        <h2 class="col-lg-12 clearfix">
-            {{ mb_strimwidth($image->filename, 0, 63, '...')}}
-            <span class="pull-right">
+        <h2 class="col-lg-12 clearfix annotations-breadcrumb">
+            {{ $image->filename }}
+        </h2>
+        <span class="pull-right">
                 <a href="{{route('volume', $volume->id)}}" title="Back to {{ $volume->name }}" class="btn btn-default">back</a>
                 @mixin('imagesIndexButtons')
             </span>
-        </h2>
     </div>
     <div class="row">
         <div class="col-sm-6 col-lg-4">
@@ -29,8 +30,14 @@
 @endsection
 
 @section('navbar')
-<div class="navbar-text navbar-volumes-breadcrumbs">
-    @include('volumes.partials.projectsBreadcrumb', ['projects' => $volume->projects])/ <a href="{{route('volume', $volume->id)}}" class="navbar-link" title="Show volume {{$volume->name}}">{{$volume->name}}</a>
-    / <strong title="{{mb_strimwidth($image->filename, 0, 63, '...')}}">{{mb_strimwidth($image->filename, 0, 63, '...')}}</strong> @include('volumes.partials.annotationSessionIndicator')
+<div class="navbar-text">
+    <div class="annotations-project-dd">
+        @include('volumes.partials.projectsBreadcrumb', ['projects' => $volume->projects]) /
+    </div>
+    <div class="annotations-breadcrumb">
+    <a href="{{route('volume', $volume->id)}}" class="navbar-link" title="Show volume {{$volume->name}}">{{$volume->name}}</a> /
+            <strong>{{$image->filename}}</strong>
+    </div>
+    @include('volumes.partials.annotationSessionIndicator')
 </div>
 @endsection


### PR DESCRIPTION
Fixes #240. As I couldn't figure out how you trimmed the image filename in the annotation navbar, I used the php mb_strimwidth function. In the content the width fits exactly if you would use a resolution of 1024 x 768.