### PR TITLE
Fix slider focus to enable keyboard shortcuts again

### DIFF
--- a/resources/assets/js/annotations/components/settingsTab.vue
+++ b/resources/assets/js/annotations/components/settingsTab.vue
@@ -116,6 +116,9 @@ export default {
                 this.annotationOpacity = 1;
             }
         },
+        removeFocus(id) {
+            document.getElementById(id).blur();
+        }
     },
     watch: {
         annotationOpacity(opacity) {

--- a/resources/assets/js/annotations/components/settingsTab.vue
+++ b/resources/assets/js/annotations/components/settingsTab.vue
@@ -116,9 +116,6 @@ export default {
                 this.annotationOpacity = 1;
             }
         },
-        removeFocus(id) {
-            document.getElementById(id).blur();
-        }
     },
     watch: {
         annotationOpacity(opacity) {

--- a/resources/views/annotations/show/tabs/settings.blade.php
+++ b/resources/views/annotations/show/tabs/settings.blade.php
@@ -10,12 +10,12 @@
 
             <div class="sidebar-tab__section">
                 <h5 title="Set the opacity of annotations on the map">Annotation Opacity (<span v-text="annotationOpacity"></span>)</h5>
-                <input id="annotationOpacity" type="range" min="0" max="1" step="0.1" v-model="annotationOpacity" v-on:click='removeFocus("annotationOpacity")'>
+                <input type="range" min="0" max="1" step="0.1" v-model="annotationOpacity">
             </div>
 
             <div class="sidebar-tab__section">
                 <h5 title="Set the number of caches images ">Cached Images (<span v-text="cachedImagesCount"></span>)</h5>
-                <input id="cachedImagesCount" type="range" min="1" max="50" step="1" v-model="cachedImagesCount" v-on:click='removeFocus("cachedImagesCount")'>
+                <input type="range" min="1" max="50" step="1" v-model="cachedImagesCount">
             </div>
 
             <div class="sidebar-tab__section">

--- a/resources/views/annotations/show/tabs/settings.blade.php
+++ b/resources/views/annotations/show/tabs/settings.blade.php
@@ -10,12 +10,12 @@
 
             <div class="sidebar-tab__section">
                 <h5 title="Set the opacity of annotations on the map">Annotation Opacity (<span v-text="annotationOpacity"></span>)</h5>
-                <input type="range" min="0" max="1" step="0.1" v-model="annotationOpacity">
+                <input id="annotationOpacity" type="range" min="0" max="1" step="0.1" v-model="annotationOpacity" v-on:click='removeFocus("annotationOpacity")'>
             </div>
 
             <div class="sidebar-tab__section">
                 <h5 title="Set the number of caches images ">Cached Images (<span v-text="cachedImagesCount"></span>)</h5>
-                <input type="range" min="1" max="50" step="1" v-model="cachedImagesCount">
+                <input id="cachedImagesCount" type="range" min="1" max="50" step="1" v-model="cachedImagesCount" v-on:click='removeFocus("cachedImagesCount")'>
             </div>
 
             <div class="sidebar-tab__section">

--- a/resources/views/annotations/show/tabs/settings.blade.php
+++ b/resources/views/annotations/show/tabs/settings.blade.php
@@ -10,12 +10,12 @@
 
             <div class="sidebar-tab__section">
                 <h5 title="Set the opacity of annotations on the map">Annotation Opacity (<span v-text="annotationOpacity"></span>)</h5>
-                <input type="range" min="0" max="1" step="0.1" v-model="annotationOpacity">
+                <input type="range" min="0" max="1" step="0.1" v-model="annotationOpacity" onmouseup="this.blur()">
             </div>
 
             <div class="sidebar-tab__section">
                 <h5 title="Set the number of caches images ">Cached Images (<span v-text="cachedImagesCount"></span>)</h5>
-                <input type="range" min="1" max="50" step="1" v-model="cachedImagesCount">
+                <input type="range" min="1" max="50" step="1" v-model="cachedImagesCount" onmouseup="this.blur()">
             </div>
 
             <div class="sidebar-tab__section">


### PR DESCRIPTION
Remove slider focus after usage so that keyboard events are working again.

Fixes #635.