### PR TITLE
Fix error with label and user mapping during annotation import

### DIFF
--- a/app/Http/Requests/UpdatePendingVolumeLabelMap.php
+++ b/app/Http/Requests/UpdatePendingVolumeLabelMap.php
@@ -74,12 +74,13 @@ class UpdatePendingVolumeLabelMap extends FormRequest
                 }
             }
 
-            $count = Label::whereIn('id', array_values($map))->count();
-            if (count($map) !== $count) {
+            $uniqueIds = array_values(array_unique($map));
+            $count = Label::whereIn('id', $uniqueIds)->count();
+            if (count($uniqueIds) !== $count) {
                 $validator->errors()->add('label_map', 'Some label IDs do not exist in the database.');
             }
 
-            $count = Label::whereIn('id', array_values($map))
+            $count = Label::whereIn('id', $uniqueIds)
                 ->whereIn('label_tree_id', function ($query) {
                     // All public and all accessible private label trees.
                     $query->select('id')
@@ -93,7 +94,7 @@ class UpdatePendingVolumeLabelMap extends FormRequest
                 })
                 ->count();
 
-            if (count($map) !== $count) {
+            if (count($uniqueIds) !== $count) {
                 $validator->errors()->add('label_map', 'You do not have access to some label IDs in the database.');
             }
         });

--- a/app/Http/Requests/UpdatePendingVolumeUserMap.php
+++ b/app/Http/Requests/UpdatePendingVolumeUserMap.php
@@ -64,8 +64,9 @@ class UpdatePendingVolumeUserMap extends FormRequest
                 }
             }
 
-            $count = User::whereIn('id', array_values($map))->count();
-            if (count($map) !== $count) {
+            $uniqueIds = array_values(array_unique($map));
+            $count = User::whereIn('id', $uniqueIds)->count();
+            if (count($uniqueIds) !== $count) {
                 $validator->errors()->add('user_map', 'Some user IDs do not exist in the database.');
             }
         });


### PR DESCRIPTION
The error happened when two or more import labels/users were mapped to the same database label/user.