### PR TITLE
Replace metadata disk static property with getter method

### DIFF
--- a/app/PendingVolume.php
+++ b/app/PendingVolume.php
@@ -67,8 +67,6 @@ class PendingVolume extends Model
 
     protected static function booted(): void
     {
-        static::$metadataFileDisk = config('volumes.pending_metadata_storage_disk');
-
         static::deleting(function (PendingVolume $pv) {
             $pv->deleteMetadata(true);
         });
@@ -82,5 +80,13 @@ class PendingVolume extends Model
     public function volume(): BelongsTo
     {
         return $this->belongsTo(Volume::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataFileDisk(): string
+    {
+        return config('volumes.pending_metadata_storage_disk');
     }
 }

--- a/app/Traits/HasMetadataFile.php
+++ b/app/Traits/HasMetadataFile.php
@@ -13,9 +13,9 @@ use SplFileInfo;
 trait HasMetadataFile
 {
     /**
-     * Name of the storage disk where the metadata files are stored.
+     * Get the name of the disk to store metadata files.
      */
-    public static string $metadataFileDisk;
+    abstract public function getMetadataFileDisk(): string;
 
     public function hasMetadata(): bool
     {
@@ -28,7 +28,7 @@ trait HasMetadataFile
         if ($extension = $file->getClientOriginalExtension()) {
             $this->metadata_file_path .= '.'.$extension;
         }
-        $file->storeAs('', $this->metadata_file_path, static::$metadataFileDisk);
+        $file->storeAs('', $this->metadata_file_path, $this->getMetadataFileDisk());
         $this->save();
     }
 
@@ -38,7 +38,7 @@ trait HasMetadataFile
             return null;
         }
 
-        $disk = static::$metadataFileDisk;
+        $disk = $this->getMetadataFileDisk();
         $key = "metadata-{$disk}-{$this->metadata_file_path}";
 
         return Cache::store('array')->remember($key, 60, function () use ($disk) {
@@ -67,7 +67,7 @@ trait HasMetadataFile
     public function deleteMetadata($noUpdate = false): void
     {
         if ($this->hasMetadata()) {
-            Storage::disk(static::$metadataFileDisk)->delete($this->metadata_file_path);
+            Storage::disk($this->getMetadataFileDisk())->delete($this->metadata_file_path);
             if (!$noUpdate) {
                 $this->update(['metadata_file_path' => null]);
             }

--- a/app/Volume.php
+++ b/app/Volume.php
@@ -73,11 +73,6 @@ class Volume extends Model
         'media_type_id' => 'int',
     ];
 
-    protected static function booted(): void
-    {
-        static::$metadataFileDisk = config('volumes.metadata_storage_disk');
-    }
-
     /**
      * Parses a comma separated list of filenames to an array.
      *
@@ -456,6 +451,14 @@ class Volume extends Model
     public function isVideoVolume()
     {
         return $this->media_type_id === MediaType::videoId();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataFileDisk(): string
+    {
+        return config('volumes.metadata_storage_disk');
     }
 
     /**


### PR DESCRIPTION
The static property was not set properly during a queue job. The getter method should work fine.