### PR TITLE
Fix magic wand sketch opacity

### DIFF
--- a/resources/assets/js/annotations/ol/MagicWandInteraction.js
+++ b/resources/assets/js/annotations/ol/MagicWandInteraction.js
@@ -183,14 +183,14 @@ class MagicWandInteraction extends PointerInteraction {
     handleUpEvent() {
         this.currentThreshold = this.colorThreshold;
 
-        if (this.isShowingCross) {
-            this.sketchSource.removeFeature(this.sketchFeature);
-        } else {
-            this.dispatchEvent({type: 'drawend', feature: this.sketchFeature});
+        if (!this.isShowingCross) {
+            this.sketchFeature.setStyle(null);
+            this.dispatchEvent({ type: 'drawend', feature: this.sketchFeature });
             // Add feature to annotation source to prevent flickering feature
             this.source.addFeature(this.sketchFeature);
-            this.sketchSource.removeFeature(this.sketchFeature);
         }
+        
+        this.sketchSource.removeFeature(this.sketchFeature);
 
         this.sketchFeature = null;
 

--- a/resources/assets/js/annotations/ol/MagicWandInteraction.js
+++ b/resources/assets/js/annotations/ol/MagicWandInteraction.js
@@ -60,15 +60,14 @@ class MagicWandInteraction extends PointerInteraction {
             options.discardRadius;
 
         this.sketchFeature = null;
-        this.sketchSource = options.source;
+        this.sketchSource = null;
+        this.source = options.source;
 
-        if (this.sketchSource === undefined) {
-            this.sketchSource = new VectorSource();
-            this.map.addLayer(new VectorLayer({
-                source: this.sketchSource,
-                zIndex: 200,
-            }));
-        }
+        this.sketchSource = new VectorSource();
+        this.map.addLayer(new VectorLayer({
+            source: this.sketchSource,
+            zIndex: 200,
+        }));
 
         this.sketchStyle = options.style === undefined ? null : options.style;
 
@@ -188,6 +187,9 @@ class MagicWandInteraction extends PointerInteraction {
             this.sketchSource.removeFeature(this.sketchFeature);
         } else {
             this.dispatchEvent({type: 'drawend', feature: this.sketchFeature});
+            // Add feature to annotation source to prevent flickering feature
+            this.source.addFeature(this.sketchFeature);
+            this.sketchSource.removeFeature(this.sketchFeature);
         }
 
         this.sketchFeature = null;


### PR DESCRIPTION
Delete sketch feature after adding it to annotation source.

References biigle/core#636.