### PR TITLE
Fix thumbnail size configuration

### DIFF
--- a/app/Jobs/ProcessNewImage.php
+++ b/app/Jobs/ProcessNewImage.php
@@ -81,8 +81,9 @@ class ProcessNewImage extends Job implements ShouldQueue
      */
     public function handle()
     {
-        $this->width = config('thumbnails.width');
-        $this->height = config('thumbnails.height');
+        // Double the size for crisp display on high-dpi montors.
+        $this->width = config('thumbnails.width') * 2;
+        $this->height = config('thumbnails.height') * 2;
         $this->threshold = config('image.tiles.threshold');
 
         try {

--- a/app/Jobs/ProcessNewVideo.php
+++ b/app/Jobs/ProcessNewVideo.php
@@ -261,8 +261,9 @@ class ProcessNewVideo extends Job implements ShouldQueue
         // Config for normal thumbs
         $format = config('thumbnails.format');
         $thumbCount = config('videos.thumbnail_count');
-        $width = config('thumbnails.width');
-        $height = config('thumbnails.height');
+        // Double the size for crisp display on high-dpi montors.
+        $width = config('thumbnails.width') * 2;
+        $height = config('thumbnails.height') * 2;
 
         // Config for sprite thumbs
         $thumbnailsPerSprite = config('videos.sprites_thumbnails_per_sprite');

--- a/config/thumbnails.php
+++ b/config/thumbnails.php
@@ -12,8 +12,8 @@ return [
     | you are doing, since the views must work with these images. The images are always
     | scaled proportionally, so this values are kind of a max-width and max-height.
     */
-    'width' => 360,
-    'height' => 270,
+    'width' => 180,
+    'height' => 135,
 
     /*
      | Thumbnail file format. Depending on your thumbnail service, different formats are

--- a/tests/php/Jobs/ProcessNewImageTest.php
+++ b/tests/php/Jobs/ProcessNewImageTest.php
@@ -95,9 +95,9 @@ class ProcessNewImageTest extends TestCase
         $size = getimagesize(Storage::disk('test-thumbs')->path("{$prefix}.{$format}"));
         $config = [config('thumbnails.width'), config('thumbnails.height')];
 
-        $this->assertTrue($size[0] <= $config[0]);
-        $this->assertTrue($size[1] <= $config[1]);
-        $this->assertTrue($size[0] == $config[0] || $size[1] == $config[1]);
+        $this->assertTrue($size[0] <= ($config[0] * 2));
+        $this->assertTrue($size[1] <= ($config[1] * 2));
+        $this->assertTrue($size[0] == ($config[0] * 2) || $size[1] == ($config[1] * 2));
     }
 
     public function testHandleMakeThumbnailNotReadable()


### PR DESCRIPTION
All sorts of stuff depends on the dimensions (e.g. the volume image grid display, the feature vecto computation). These values should better be left alone. Instead, the jobs to generate thumbnails now just use twice the size.