### PR TITLE
Shortcut to focus the "find label" input field

### DIFF
--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -87,6 +87,7 @@ export default {
             userUpdatedVolareResolution: false,
             userId: null,
             crossOriginError: false,
+            focusInputFindlabel: false,
         };
     },
     computed: {
@@ -760,8 +761,12 @@ export default {
         Events.$on('focusTypeaheadEvent', () => {
             this.$nextTick(() => {
                 // call global for  focustypeahead TODO need other way!
-                Events.$emit('callFunctionFocustypeahead')
+                this.focusInputFindlabel = true;
+               // Events.$emit('callFunctionFocustypeahead')
             });
+            
+           this.focusInputFindlabel = false;
+            
         });
         
         Keyboard.on('control+k', () => {

--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -601,11 +601,9 @@ export default {
         },
         
         openSidebarLabels(){ 
-            // opens sidebar labels
             this.$refs.sidebar.$emit('open', 'labels');
             Events.$emit('focusTypeaheadEvent');
         },
-
 
     },
     watch: {
@@ -758,15 +756,11 @@ export default {
             }
         }
 
-        Events.$on('focusTypeaheadEvent', () => {
+        Events.$on('focusTypeaheadEvent', () => { 
             this.$nextTick(() => {
-                // call global for  focustypeahead TODO need other way!
                 this.focusInputFindlabel = true;
-               // Events.$emit('callFunctionFocustypeahead')
             });
-            
            this.focusInputFindlabel = false;
-            
         });
         
         Keyboard.on('control+k', () => {

--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -24,6 +24,7 @@ import {CrossOriginError} from './stores/images';
 import {debounce} from './../core/utils';
 import {handleErrorResponse} from '../core/messages/store';
 import {urlParams as UrlParams} from '../core/utils';
+import Keyboard from '../core/keyboard';
 
 /**
  * View model for the annotator container
@@ -592,6 +593,13 @@ export default {
             }
             Messages.danger(`Invalid shape. ${shape} needs ${count} different points.`);
         },
+
+        openSidebarLabels(){ 
+            // opens sidebar labels
+            this.$refs.sidebar.$emit('open', 'labels');
+            Events.$emit('focusTypeaheadEvent');
+        },
+
     },
     watch: {
         async imageId(id) {
@@ -742,6 +750,18 @@ export default {
                 this.openTab = openTab;
             }
         }
+
+        Events.$on('focusTypeaheadEvent', () => {
+            this.$nextTick(() => {
+                // call global for  focustypeahead TODO need other way!
+                this.$root.$emit('callFunctionFocustypeahead')
+            });
+        });
+        
+        Keyboard.on('control+k', () => {
+            this.openSidebarLabels()
+        });
+        
     },
     mounted() {
         Events.$emit('annotations.map.init', this.$refs.canvas.map);

--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -87,7 +87,6 @@ export default {
             userUpdatedVolareResolution: false,
             userId: null,
             crossOriginError: false,
-            focusInputFindlabel: false,
         };
     },
     computed: {
@@ -598,17 +597,9 @@ export default {
             let lastAnnotation = this.annotations.reduce((lastAnnotated, a) => a.id > lastAnnotated.id ? a : lastAnnotated, { id: 0 });
             this.handleSelectAnnotation(lastAnnotation);
         },
-        openSidebarLabels() { 
+        openSidebarLabels() {
             this.$refs.sidebar.$emit('open', 'labels');
-           this.setFocusInputFindLabel()
         },
-        setFocusInputFindLabel(){
-            this.focusInputFindlabel = false;
-            this.$nextTick(() => {
-                this.focusInputFindlabel = true;
-            });
-        }
-
     },
     watch: {
         async imageId(id) {
@@ -759,8 +750,6 @@ export default {
                 this.openTab = openTab;
             }
         }
-        
-        Keyboard.on('control+k', this.openSidebarLabels, 0, this.listenerSet);
 
         Keyboard.on('C', this.selectLastAnnotation, 0, this.listenerSet);
     },

--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -757,6 +757,7 @@ export default {
         }
 
         Events.$on('focusTypeaheadEvent', () => { 
+            this.focusInputFindlabel = false;
             this.$nextTick(() => {
                 this.focusInputFindlabel = true;
             });

--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -594,16 +594,20 @@ export default {
             }
             Messages.danger(`Invalid shape. ${shape} needs ${count} different points.`);
         },
-
         selectLastAnnotation() {
             let lastAnnotation = this.annotations.reduce((lastAnnotated, a) => a.id > lastAnnotated.id ? a : lastAnnotated, { id: 0 });
             this.handleSelectAnnotation(lastAnnotation);
         },
-        
-        openSidebarLabels(){ 
+        openSidebarLabels() { 
             this.$refs.sidebar.$emit('open', 'labels');
-            Events.$emit('focusTypeaheadEvent');
+           this.setFocusInputFindLabel()
         },
+        setFocusInputFindLabel(){
+            this.focusInputFindlabel = false;
+            this.$nextTick(() => {
+                this.focusInputFindlabel = true;
+            });
+        }
 
     },
     watch: {
@@ -755,18 +759,8 @@ export default {
                 this.openTab = openTab;
             }
         }
-
-        Events.$on('focusTypeaheadEvent', () => { 
-            this.focusInputFindlabel = false;
-            this.$nextTick(() => {
-                this.focusInputFindlabel = true;
-            });
-           this.focusInputFindlabel = false;
-        });
         
-        Keyboard.on('control+k', () => {
-            this.openSidebarLabels()
-        });
+        Keyboard.on('control+k', this.openSidebarLabels, 0, this.listenerSet);
 
         Keyboard.on('C', this.selectLastAnnotation, 0, this.listenerSet);
     },

--- a/resources/assets/js/annotations/annotatorContainer.vue
+++ b/resources/assets/js/annotations/annotatorContainer.vue
@@ -760,7 +760,7 @@ export default {
         Events.$on('focusTypeaheadEvent', () => {
             this.$nextTick(() => {
                 // call global for  focustypeahead TODO need other way!
-                this.$root.$emit('callFunctionFocustypeahead')
+                Events.$emit('callFunctionFocustypeahead')
             });
         });
         

--- a/resources/assets/js/annotations/components/labelsTab.vue
+++ b/resources/assets/js/annotations/components/labelsTab.vue
@@ -38,7 +38,6 @@ export default {
     },
     watch: {
         focusInput(){
-           //  console.log("n ", this.focusInput);
         }
     },
     methods: {

--- a/resources/assets/js/annotations/components/labelsTab.vue
+++ b/resources/assets/js/annotations/components/labelsTab.vue
@@ -36,10 +36,6 @@ export default {
             return plugins;
         },
     },
-    watch: {
-        focusInput(){
-        }
-    },
     methods: {
         handleSelectedLabel(label) {
             this.selectedLabel = label;

--- a/resources/assets/js/annotations/components/labelsTab.vue
+++ b/resources/assets/js/annotations/components/labelsTab.vue
@@ -25,10 +25,21 @@ export default {
             selectedLabel: null,
         };
     },
+    props: {
+        focusInput:{
+            type: Boolean,
+            default: false,
+        }
+    },
     computed: {
         plugins() {
             return plugins;
         },
+    },
+    watch: {
+        focusInput(){
+           //  console.log("n ", this.focusInput);
+        }
     },
     methods: {
         handleSelectedLabel(label) {

--- a/resources/assets/js/annotations/components/labelsTab.vue
+++ b/resources/assets/js/annotations/components/labelsTab.vue
@@ -1,5 +1,6 @@
 <script>
 import LabelTrees from '../../label-trees/components/labelTrees';
+import Keyboard from '../../core/keyboard';
 
 /**
  * Additional components that can be dynamically added by other Biigle modules via
@@ -23,6 +24,7 @@ export default {
         return {
             labelTrees: [],
             selectedLabel: null,
+            focusInputFindlabel: false,
         };
     },
     props: {
@@ -45,9 +47,18 @@ export default {
             this.selectedLabel = null;
             this.$emit('select', null);
         },
+        setFocusInputFindLabel() {
+            this.$emit('open', 'labels');
+            this.focusInputFindlabel = false;
+            this.$nextTick(() => {
+                this.focusInputFindlabel = true;
+            });
+        },
     },
     created() {
         this.labelTrees = biigle.$require('annotations.labelTrees');
+
+        Keyboard.on('control+k', this.setFocusInputFindLabel, 0, this.listenerSet);
     },
 };
 </script>

--- a/resources/assets/js/label-trees/components/labelTrees.vue
+++ b/resources/assets/js/label-trees/components/labelTrees.vue
@@ -2,7 +2,7 @@
     <div class="label-trees">
         <div v-if="typeahead || clearable" class="label-trees__head">
             <button v-if="clearable" @click="clear" class="btn btn-default" title="Clear selected labels" type="button"><span class="fa fa-times fa-fw" aria-hidden="true"></span></button>
-            <typeahead v-if="typeahead" :items="labels" more-info="tree.versionedName" @select="handleSelect" placeholder="Find label"></typeahead>
+            <typeahead ref="typeaheadInput" v-if="typeahead" :items="labels" more-info="tree.versionedName" @select="handleSelect" placeholder="Find label"></typeahead>
         </div>
         <div class="label-trees__body">
             <label-tree v-if="hasFavourites" name="Favourites" :labels="favourites" :show-favourites="showFavourites" :flat="true" :showFavouriteShortcuts="true" :collapsible="collapsible" @select="handleSelect" @deselect="handleDeselect" @remove-favourite="handleRemoveFavourite"></label-tree>
@@ -174,6 +174,9 @@ export default {
                 this.handleSelect(this.favourites[index]);
             }
         },
+        focusTypeahead() {
+            this.$refs.typeaheadInput.$el.querySelector('input').focus();
+        },
     },
     watch: {
         trees: {
@@ -222,6 +225,13 @@ export default {
             }
             bindFavouriteKey('0', 9);
         }
+
+        window.addEventListener('keydown', (e) => {
+            if (e.ctrlKey && e.key === 'k') {
+                e.preventDefault();
+                this.focusTypeahead();
+            }
+        });
     },
 };
 </script>

--- a/resources/assets/js/label-trees/components/labelTrees.vue
+++ b/resources/assets/js/label-trees/components/labelTrees.vue
@@ -197,8 +197,8 @@ export default {
                 });
             },
         },
-        focusInput(){
-            if(this.focusInput){
+        focusInput() {
+            if (this.focusInput) {
                 this.$refs.typeaheadInput.$el.querySelector('input').focus();
             }
         }
@@ -234,9 +234,6 @@ export default {
             }
             bindFavouriteKey('0', 9);
         }
-        Events.$on('callFunctionFocustypeahead', () => {
-            this.focusTypeahead();
-        });        
     },
 };
 </script>

--- a/resources/assets/js/label-trees/components/labelTrees.vue
+++ b/resources/assets/js/label-trees/components/labelTrees.vue
@@ -234,7 +234,6 @@ export default {
             }
             bindFavouriteKey('0', 9);
         }
-        // call global for  focustypeahead TODO need other way!
         Events.$on('callFunctionFocustypeahead', () => {
             this.focusTypeahead();
         });        

--- a/resources/assets/js/label-trees/components/labelTrees.vue
+++ b/resources/assets/js/label-trees/components/labelTrees.vue
@@ -174,9 +174,30 @@ export default {
                 this.handleSelect(this.favourites[index]);
             }
         },
+        /*
+            // Add the new method to focus the typeahead field
+    focusFindLabel() {
+        // Assuming your Typeahead component has a method or input field that can be focused
+       // if (this.$refs.typeaheadInput) {
+       if(this.showFavourites){
+            console.log("infocusFindLabel");
+            this.$refs.typeaheadInput.$el.querySelector('input').focus();
+            // This is an example, adjust if Typeahead has a different way to focus
+            //this.$refs.typeahead.focus();
+        }
+    },
+        
+*/
+
+
+         //   <typeahead ref="typeaheadInput" v-if="typeahead" :items="labels" more-info="tree.versionedName" @select="handleSelect" placeholder="Find label"></typeahead>
+
+
         focusTypeahead() {
             this.$refs.typeaheadInput.$el.querySelector('input').focus();
+            console.log("focusTypeahead");
         },
+
     },
     watch: {
         trees: {
@@ -195,6 +216,13 @@ export default {
                 });
             },
         },
+    },
+    created(){
+        Keyboard.on('control+k', (e) => {
+            e.preventDefault(); // Prevent the default browser action (Print)
+            this.focusTypeahead();
+            console.log("labelTrees");
+        });
     },
     mounted() {
         if (this.showFavourites) {
@@ -225,13 +253,16 @@ export default {
             }
             bindFavouriteKey('0', 9);
         }
-
+/*
         window.addEventListener('keydown', (e) => {
             if (e.ctrlKey && e.key === 'k') {
                 e.preventDefault();
                 this.focusTypeahead();
+                //this.focusFindLabel();
+                console.log("aktiv");
             }
-        });
+        });    
+  */         
     },
 };
 </script>

--- a/resources/assets/js/label-trees/components/labelTrees.vue
+++ b/resources/assets/js/label-trees/components/labelTrees.vue
@@ -174,28 +174,9 @@ export default {
                 this.handleSelect(this.favourites[index]);
             }
         },
-        /*
-            // Add the new method to focus the typeahead field
-    focusFindLabel() {
-        // Assuming your Typeahead component has a method or input field that can be focused
-       // if (this.$refs.typeaheadInput) {
-       if(this.showFavourites){
-            console.log("infocusFindLabel");
-            this.$refs.typeaheadInput.$el.querySelector('input').focus();
-            // This is an example, adjust if Typeahead has a different way to focus
-            //this.$refs.typeahead.focus();
-        }
-    },
-        
-*/
-
-
-         //   <typeahead ref="typeaheadInput" v-if="typeahead" :items="labels" more-info="tree.versionedName" @select="handleSelect" placeholder="Find label"></typeahead>
-
 
         focusTypeahead() {
             this.$refs.typeaheadInput.$el.querySelector('input').focus();
-            console.log("focusTypeahead");
         },
 
     },
@@ -217,13 +198,7 @@ export default {
             },
         },
     },
-    created(){
-        Keyboard.on('control+k', (e) => {
-            e.preventDefault(); // Prevent the default browser action (Print)
-            this.focusTypeahead();
-            console.log("labelTrees");
-        });
-    },
+
     mounted() {
         if (this.showFavourites) {
             let favouriteIds = JSON.parse(localStorage.getItem(this.favouriteStorageKey));
@@ -253,16 +228,10 @@ export default {
             }
             bindFavouriteKey('0', 9);
         }
-/*
-        window.addEventListener('keydown', (e) => {
-            if (e.ctrlKey && e.key === 'k') {
-                e.preventDefault();
-                this.focusTypeahead();
-                //this.focusFindLabel();
-                console.log("aktiv");
-            }
-        });    
-  */         
+        // call global for  focustypeahead TODO need other way!
+        this.$root.$on('callFunctionFocustypeahead', () => {
+            this.focusTypeahead();
+        });        
     },
 };
 </script>

--- a/resources/assets/js/label-trees/components/labelTrees.vue
+++ b/resources/assets/js/label-trees/components/labelTrees.vue
@@ -179,11 +179,6 @@ export default {
                 this.handleSelect(this.favourites[index]);
             }
         },
-/*
-        focusTypeahead() {
-            this.$refs.typeaheadInput.$el.querySelector('input').focus();
-        },
-*/
     },
     watch: {
         trees: {

--- a/resources/assets/js/label-trees/components/labelTrees.vue
+++ b/resources/assets/js/label-trees/components/labelTrees.vue
@@ -15,6 +15,7 @@
 import Keyboard from '../../core/keyboard';
 import LabelTree from './labelTree';
 import Typeahead from './labelTypeahead';
+import Events from '../../core/events';
 
 /**
  * A component that displays a list of label trees.
@@ -229,7 +230,7 @@ export default {
             bindFavouriteKey('0', 9);
         }
         // call global for  focustypeahead TODO need other way!
-        this.$root.$on('callFunctionFocustypeahead', () => {
+        Events.$on('callFunctionFocustypeahead', () => {
             this.focusTypeahead();
         });        
     },

--- a/resources/assets/js/label-trees/components/labelTrees.vue
+++ b/resources/assets/js/label-trees/components/labelTrees.vue
@@ -15,7 +15,6 @@
 import Keyboard from '../../core/keyboard';
 import LabelTree from './labelTree';
 import Typeahead from './labelTypeahead';
-import Events from '../../core/events';
 
 /**
  * A component that displays a list of label trees.

--- a/resources/assets/js/label-trees/components/labelTrees.vue
+++ b/resources/assets/js/label-trees/components/labelTrees.vue
@@ -74,6 +74,10 @@ export default {
             type: String,
             default: 'default',
         },
+        focusInput:{
+            type: Boolean,
+            default: false,
+        }
     },
     computed: {
         localeCompareSupportsLocales() {
@@ -175,11 +179,11 @@ export default {
                 this.handleSelect(this.favourites[index]);
             }
         },
-
+/*
         focusTypeahead() {
             this.$refs.typeaheadInput.$el.querySelector('input').focus();
         },
-
+*/
     },
     watch: {
         trees: {
@@ -198,6 +202,12 @@ export default {
                 });
             },
         },
+        focusInput(){
+            if(this.focusInput){
+                this.$refs.typeaheadInput.$el.querySelector('input').focus();
+            }
+        }
+        
     },
 
     mounted() {

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -99,6 +99,7 @@ export default {
             swappingLabel: false,
             disableJobTracking: false,
             supportsJumpByFrame: false,
+            focusInputFindlabel: false,
         };
     },
     computed: {
@@ -747,14 +748,13 @@ export default {
             this.supportsJumpByFrame = true;
         }
         
-        // Focus findbar in labelTrees
         Events.$on('focusTypeaheadEvent', () => {
             this.$nextTick(() => {
-                Events.$emit('callFunctionFocustypeahead')
+                this.focusInputFindlabel = true;
             });
+            this.focusInputFindlabel = false;
         });
         
-        // on control + k openSidebar labels and after focus find
         Keyboard.on('control+k', () => {
             this.openSidebarLabels()
         });

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -749,6 +749,7 @@ export default {
         }
         
         Events.$on('focusTypeaheadEvent', () => {
+            this.focusInputFindlabel = false;
             this.$nextTick(() => {
                 this.focusInputFindlabel = true;
             });

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -683,7 +683,7 @@ export default {
             this.$refs.sidebar.$emit('open', 'labels');
             this.setFocusInputFindLabel()
         },
-        setFocusInputFindLabel(){
+        setFocusInputFindLabel() {
             this.focusInputFindlabel = false;
             this.$nextTick(() => {
                 this.focusInputFindlabel = true;
@@ -753,17 +753,9 @@ export default {
         if ("requestVideoFrameCallback" in HTMLVideoElement.prototype) {
             this.supportsJumpByFrame = true;
         }
-        
-        Events.$on('focusTypeaheadEvent', () => {
-            this.focusInputFindlabel = false;
-            this.$nextTick(() => {
-                this.focusInputFindlabel = true;
-            });
-            this.focusInputFindlabel = false;
-        });
-        
+
         Keyboard.on('control+k', this.openSidebarLabels, 0, this.listenerSet);
-    
+
     },
     mounted() {
         // Wait for the sub-components to register their event listeners before

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -750,8 +750,7 @@ export default {
         // Focus findbar in labelTrees
         Events.$on('focusTypeaheadEvent', () => {
             this.$nextTick(() => {
-                // call global for  focustypeahead TODO need other way!
-                this.$root.$emit('callFunctionFocustypeahead')
+                Events.$emit('callFunctionFocustypeahead')
             });
         });
         

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -20,6 +20,7 @@ import VideoScreen from './components/videoScreen';
 import VideoTimeline from './components/videoTimeline';
 import {handleErrorResponse} from '../core/messages/store';
 import {urlParams as UrlParams} from '../core/utils';
+import Keyboard from '../core/keyboard';
 
 class VideoError extends Error {}
 class VideoNotProcessedError extends VideoError {}
@@ -673,6 +674,11 @@ export default {
             }
             Messages.danger(`Invalid shape. ${shape} needs ${count} different points.`);
         },
+
+        openSidebarLabels(){ 
+            this.$refs.sidebar.$emit('open', 'labels');
+            Events.$emit('focusTypeaheadEvent');
+        },
     },
     watch: {
         'settings.playbackRate'(rate) {
@@ -735,6 +741,19 @@ export default {
         if ("requestVideoFrameCallback" in HTMLVideoElement.prototype) {
             this.supportsJumpByFrame = true;
         }
+
+        // Focus findbar in labelTrees
+        Events.$on('focusTypeaheadEvent', () => {
+            this.$nextTick(() => {
+                // call global for  focustypeahead TODO need other way!
+                this.$root.$emit('callFunctionFocustypeahead')
+            });
+        });
+        
+        // on control + k openSidebar labels and after focus find
+        Keyboard.on('control+k', () => {
+            this.openSidebarLabels()
+        });
     },
     mounted() {
         // Wait for the sub-components to register their event listeners before

--- a/resources/assets/js/videos/videoContainer.vue
+++ b/resources/assets/js/videos/videoContainer.vue
@@ -679,10 +679,16 @@ export default {
             let lastAnnotation = this.annotations.reduce((lastAnnotated, a) => a.id > lastAnnotated.id ? a : lastAnnotated, { id: 0 });
             this.selectAnnotations([lastAnnotation], this.selectedAnnotations, lastAnnotation.startFrame);
         },
-        openSidebarLabels(){ 
+        openSidebarLabels() {
             this.$refs.sidebar.$emit('open', 'labels');
-            Events.$emit('focusTypeaheadEvent');
+            this.setFocusInputFindLabel()
         },
+        setFocusInputFindLabel(){
+            this.focusInputFindlabel = false;
+            this.$nextTick(() => {
+                this.focusInputFindlabel = true;
+            });
+        }
     },
     watch: {
         'settings.playbackRate'(rate) {
@@ -756,9 +762,7 @@ export default {
             this.focusInputFindlabel = false;
         });
         
-        Keyboard.on('control+k', () => {
-            this.openSidebarLabels()
-        });
+        Keyboard.on('control+k', this.openSidebarLabels, 0, this.listenerSet);
     
     },
     mounted() {

--- a/resources/views/annotations/show.blade.php
+++ b/resources/views/annotations/show.blade.php
@@ -105,7 +105,6 @@
         ref="sidebar"
         :open-tab="openTab"
         :toggle-on-keyboard="true"
-        :focus-input="focusInputFindlabel"
         v-on:open="handleOpenedTab"
         v-on:close="handleClosedTab"
         v-cloak>

--- a/resources/views/annotations/show.blade.php
+++ b/resources/views/annotations/show.blade.php
@@ -105,6 +105,7 @@
         ref="sidebar"
         :open-tab="openTab"
         :toggle-on-keyboard="true"
+        :focus-input="focusInputFindlabel"
         v-on:open="handleOpenedTab"
         v-on:close="handleClosedTab"
         v-cloak>

--- a/resources/views/annotations/show/tabs/labels.blade.php
+++ b/resources/views/annotations/show/tabs/labels.blade.php
@@ -1,4 +1,4 @@
-<sidebar-tab name="labels" icon="tags" title="Label trees" >
+<sidebar-tab name="labels" icon="tags" title="Label trees">
     <labels-tab v-on:select="handleSelectedLabel" :focus-input="focusInputFindlabel" v-cloak inline-template>
         <div class="labels-tab">
             <div class="labels-tab__trees">

--- a/resources/views/annotations/show/tabs/labels.blade.php
+++ b/resources/views/annotations/show/tabs/labels.blade.php
@@ -1,8 +1,8 @@
 <sidebar-tab name="labels" icon="tags" title="Label trees">
-    <labels-tab v-on:select="handleSelectedLabel" :focus-input="focusInputFindlabel" v-cloak inline-template>
+    <labels-tab v-on:select="handleSelectedLabel" v-on:open="openSidebarLabels" v-cloak inline-template>
         <div class="labels-tab">
             <div class="labels-tab__trees">
-                <label-trees :trees="labelTrees" :show-favourites="true" :focus-input="focusInput" v-on:select="handleSelectedLabel" v-on:deselect="handleDeselectedLabel" v-on:clear="handleDeselectedLabel"></label-trees>
+                <label-trees :trees="labelTrees" :show-favourites="true" :focus-input="focusInputFindlabel" v-on:select="handleSelectedLabel" v-on:deselect="handleDeselectedLabel" v-on:clear="handleDeselectedLabel"></label-trees>
             </div>
             <div class="labels-tab__plugins">
                 @mixin('annotationsLabelsTab')

--- a/resources/views/annotations/show/tabs/labels.blade.php
+++ b/resources/views/annotations/show/tabs/labels.blade.php
@@ -1,8 +1,8 @@
-<sidebar-tab name="labels" icon="tags" title="Label trees">
-    <labels-tab v-on:select="handleSelectedLabel" v-cloak inline-template>
+<sidebar-tab name="labels" icon="tags" title="Label trees" >
+    <labels-tab v-on:select="handleSelectedLabel" :focus-input="focusInputFindlabel" v-cloak inline-template>
         <div class="labels-tab">
             <div class="labels-tab__trees">
-                <label-trees :trees="labelTrees" :show-favourites="true" v-on:select="handleSelectedLabel" v-on:deselect="handleDeselectedLabel" v-on:clear="handleDeselectedLabel"></label-trees>
+                <label-trees :trees="labelTrees" :show-favourites="true" :focus-input="focusInput" v-on:select="handleSelectedLabel" v-on:deselect="handleDeselectedLabel" v-on:clear="handleDeselectedLabel"></label-trees>
             </div>
             <div class="labels-tab__plugins">
                 @mixin('annotationsLabelsTab')

--- a/resources/views/manual/tutorials/annotations/shortcuts.blade.php
+++ b/resources/views/manual/tutorials/annotations/shortcuts.blade.php
@@ -5,7 +5,7 @@
 @section('manual-content')
     <div class="row">
         <p class="lead">
-            A list of all available shortcut keys in the image annotation tool.
+            A list of all available shortcut keys in the image annotation tool. BIN RICHTIG
         </p>
 
         <table class="table">
@@ -122,6 +122,10 @@
                 <tr>
                     <td><kbd>p</kbd></td>
                     <td>Capture a screenshot</td>
+                </tr>
+                <tr>
+                    <td><kbd>Ctrl</kbd>+<kbd>k</kbd></td>
+                    <td>Open label trees sidebar and focus the find label input field</td>
                 </tr>
             </tbody>
         </table>

--- a/resources/views/manual/tutorials/annotations/shortcuts.blade.php
+++ b/resources/views/manual/tutorials/annotations/shortcuts.blade.php
@@ -5,7 +5,7 @@
 @section('manual-content')
     <div class="row">
         <p class="lead">
-            A list of all available shortcut keys in the image annotation tool. BIN RICHTIG
+            A list of all available shortcut keys in the image annotation tool.
         </p>
 
         <table class="table">
@@ -131,7 +131,6 @@
                     <td><kbd>Ctrl</kbd>+<kbd>k</kbd></td>
                     <td>Open label trees sidebar and focus the find label input field</td>
                 </tr>
-
             </tbody>
         </table>
 

--- a/resources/views/manual/tutorials/videos/shortcuts.blade.php
+++ b/resources/views/manual/tutorials/videos/shortcuts.blade.php
@@ -115,6 +115,10 @@
                     <td><kbd>Esc</kbd></td>
                     <td>Cancel current action<br><small>e.g. drawing or moving an annotation</small></td>
                 </tr>
+                <tr>
+                    <td><kbd>Ctrl</kbd>+<kbd>k</kbd></td>
+                    <td>Open label trees sidebar and focus the find label input field</td>
+                </tr>
             </tbody>
         </table>
 

--- a/resources/views/videos/show/sidebar-labels.blade.php
+++ b/resources/views/videos/show/sidebar-labels.blade.php
@@ -1,7 +1,7 @@
 <sidebar-tab name="labels" icon="tags" title="Label trees">
     <div class="labels-tab">
         <div class="labels-tab__trees">
-            <label-trees :trees="labelTrees" :show-favourites="true" v-on:select="handleSelectedLabel" v-on:deselect="handleDeselectedLabel" v-on:clear="handleDeselectedLabel"></label-trees>
+            <label-trees :trees="labelTrees" :focus-input="focusInputFindlabel" :show-favourites="true" v-on:select="handleSelectedLabel" v-on:deselect="handleDeselectedLabel" v-on:clear="handleDeselectedLabel"></label-trees>
         </div>
     </div>
 </sidebar-tab>


### PR DESCRIPTION
Shortcut Ctrl+k to focus the "find label" input field of the label trees component in the sidebar of the annotation tools

references #476 