### PR TITLE
Make federated search index valid for a longer time

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -46,7 +46,7 @@ class Kernel extends ConsoleKernel
                     ->eachById([UpdateFederatedSearchIndex::class, 'dispatch']);
             })
             ->name('update-federated-search-index')
-            // The jobs to generate the federated search index are run hourly at 55.
+            // The jobs to generate the federated search index are run hourly at 35.
             // This should not collide with this job to request the index from another
             // instance.
             ->hourlyAt(05)

--- a/app/Jobs/GenerateFederatedSearchIndex.php
+++ b/app/Jobs/GenerateFederatedSearchIndex.php
@@ -44,7 +44,10 @@ class GenerateFederatedSearchIndex extends Job implements ShouldQueue
             });
 
         $key = config('biigle.federated_search.cache_key');
-        Cache::put($key, $index, 3600);
+        // The index is updated hourly. Make the cached value valid for 3 hours so there
+        // is plenty of time to renew it. Otherwise the index is generated on the fly when
+        // it is requested and this might time out.
+        Cache::put($key, $index, 10800);
     }
 
     /**


### PR DESCRIPTION
If the new index was not build in time within the 1.5 h time frame, the old index should be reused instead.