### PR TITLE
Fix overflowing long labeltree description

### DIFF
--- a/resources/assets/js/projects/components/labelTreeListItem.vue
+++ b/resources/assets/js/projects/components/labelTreeListItem.vue
@@ -8,7 +8,7 @@
     </li>
 </template>
 
-<style>
+<style scoped>
 .limit-text {
     word-wrap: break-word;
 }

--- a/resources/assets/js/projects/components/labelTreeListItem.vue
+++ b/resources/assets/js/projects/components/labelTreeListItem.vue
@@ -8,12 +8,6 @@
     </li>
 </template>
 
-<style scoped>
-.limit-text {
-    word-wrap: break-word;
-}
-</style>
-
 <script>
 export default {
     props: {

--- a/resources/assets/js/projects/components/labelTreeListItem.vue
+++ b/resources/assets/js/projects/components/labelTreeListItem.vue
@@ -4,9 +4,17 @@
             <button v-if="editable" v-show="editing" type="button" class="btn btn-default btn-sm pull-right" title="Detach this label tree" @click="emitRemove"><i class="fa fa-trash"></i></button>
             <a :href="url" v-text="tree.name"></a>
         </h4>
-        <p v-if="tree.description" class="list-group-item-text" v-text="tree.description"></p>
+        <p v-if="tree.description" class="list-group-item-text limit-description" v-text="tree.description"></p>
     </li>
 </template>
+
+<style>
+.limit-description {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+</style>
 
 <script>
 export default {

--- a/resources/assets/js/projects/components/labelTreeListItem.vue
+++ b/resources/assets/js/projects/components/labelTreeListItem.vue
@@ -1,18 +1,16 @@
 <template>
-    <li class="list-group-item" @mouseenter="emitEnter">
+    <li class="list-group-item limit-text" @mouseenter="emitEnter">
         <h4 class="list-group-item-heading">
             <button v-if="editable" v-show="editing" type="button" class="btn btn-default btn-sm pull-right" title="Detach this label tree" @click="emitRemove"><i class="fa fa-trash"></i></button>
             <a :href="url" v-text="tree.name"></a>
         </h4>
-        <p v-if="tree.description" class="list-group-item-text limit-description" v-text="tree.description"></p>
+        <p v-if="tree.description" class="list-group-item-text" v-text="tree.description"></p>
     </li>
 </template>
 
 <style>
-.limit-description {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+.limit-text {
+    word-wrap: break-word;
 }
 </style>
 

--- a/resources/assets/sass/_search.scss
+++ b/resources/assets/sass/_search.scss
@@ -15,6 +15,7 @@
 .search-results {
     list-style: none;
     padding: 0;
+    word-wrap: break-word;
 
     > li {
         padding: 1.5em 0;

--- a/resources/assets/sass/bootstrap/_labels.scss
+++ b/resources/assets/sass/bootstrap/_labels.scss
@@ -55,4 +55,5 @@ h3, .h3 {
   .small.label {
     font-size: 65%;
   }
+  word-wrap: break-word;
 }

--- a/resources/assets/sass/bootstrap/_labels.scss
+++ b/resources/assets/sass/bootstrap/_labels.scss
@@ -55,5 +55,8 @@ h3, .h3 {
   .small.label {
     font-size: 65%;
   }
+}
+
+.limit-text{
   word-wrap: break-word;
 }

--- a/resources/views/label-trees/show/title.blade.php
+++ b/resources/views/label-trees/show/title.blade.php
@@ -48,7 +48,7 @@
                 <input class="hidden" type="submit" name="submit">
             </div>
         </form>
-        <h2 v-else>
+        <h2 v-else class="limit-text">
             <span v-text="name">{{$tree->name}}</span>
             <small class="label label-default label-hollow" @if(!$private) v-cloak @endif title="This label tree is private" v-if="isPrivate">Private</small>
             <span v-if="hasDescription" @if(!$tree->description) v-cloak @endif>
@@ -56,7 +56,7 @@
             </span>
         </h2>
     @else
-        <h2>
+        <h2 class="limit-text">
             {{$tree->name}}
             @if ($private)
                 <small class="label label-default label-hollow" title="This label tree is private">Private</small>


### PR DESCRIPTION
Truncates long labeltree descriptions to prevent overflowing content.

Closes #925.