### PR TITLE
Add db_param_limit to manage SQL query limits

### DIFF
--- a/config/biigle.php
+++ b/config/biigle.php
@@ -61,4 +61,10 @@ return [
         'index_queue' => env('BIIGLE_FEDERATED_SEARCH_INDEX_QUEUE', 'default'),
     ],
 
+    /*
+    | Defines the maximum number of parameters allowed in a single SQL query. This is set to
+    | 65535 to prevent exceeding the database's parameter limit, which can lead to errors.
+    | Queries that need more parameters should be chunked to stay within this limit.
+    */
+    'db_param_limit' => 65535,
 ];


### PR DESCRIPTION
- Added `db_param_limit` setting with a default value of 65535.
- Includes a comment explaining its purpose and the need for chunking queries to avoid exceeding database limits.
- Helps prevent errors by ensuring queries stay within the parameter limits imposed by the database.

fix https://github.com/biigle/largo/issues/111