### PR TITLE
Annotation import for existing volumes

### DIFF
--- a/app/Http/Controllers/Api/PendingVolumeController.php
+++ b/app/Http/Controllers/Api/PendingVolumeController.php
@@ -96,6 +96,10 @@ class PendingVolumeController extends Controller
     {
         $project = Project::inCommon($request->user(), $request->volume->id, [Role::adminId()])->first();
 
+        // Delete individually to trigger deletion of metadata files.
+        PendingVolume::where('volume_id', $request->volume->id)
+            ->eachById(fn ($pv) => $pv->delete());
+
         $pv = $project->pendingVolumes()->create([
             'volume_id' => $request->volume->id,
             'media_type_id' => $request->volume->media_type_id,

--- a/app/Http/Controllers/Api/Volumes/MetadataController.php
+++ b/app/Http/Controllers/Api/Volumes/MetadataController.php
@@ -74,7 +74,7 @@ class MetadataController extends Controller
      *
      * @param StoreVolumeMetadata $request
      *
-     * @return void
+     * @return array<string, bool>|void
      */
     public function store(StoreVolumeMetadata $request)
     {

--- a/app/Http/Controllers/Api/Volumes/MetadataController.php
+++ b/app/Http/Controllers/Api/Volumes/MetadataController.php
@@ -56,7 +56,8 @@ class MetadataController extends Controller
      * @apiPermission projectAdmin
      * @apiDescription This endpoint allows adding or updating metadata such as geo
      * coordinates for volume files. The uploaded metadata file replaces any previously
-     * uploaded file.
+     * uploaded file. The JSON response indicates whether the uploaded metadata file
+     * contained annotations or file labels.
      *
      * @apiParam {Number} id The volume ID.
      *
@@ -83,6 +84,15 @@ class MetadataController extends Controller
         $request->volume->saveMetadata($request->file('file'));
         $request->volume->update(['metadata_parser' => $request->input('parser')]);
         Queue::push(new UpdateVolumeMetadata($request->volume));
+
+        if ($this->isAutomatedRequest()) {
+            $metadata = $request->volume->getMetadata();
+
+            return [
+                'has_annotations' => $metadata->hasAnnotations(),
+                'has_file_labels' => $metadata->hasFileLabels(),
+            ];
+        }
     }
 
     /**

--- a/app/Http/Requests/StorePendingVolumeFromVolume.php
+++ b/app/Http/Requests/StorePendingVolumeFromVolume.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Biigle\Http\Requests;
+
+use Biigle\Volume;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePendingVolumeFromVolume extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        $this->volume = Volume::findOrFail($this->route('id'));
+
+        return $this->user()->can('update', $this->volume);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'import_annotations' => 'bool|required_without:import_file_labels',
+            'import_file_labels' => 'bool|required_without:import_annotations',
+        ];
+    }
+
+    /**
+     * Configure the validator instance.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return void
+     */
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+            if (!$this->input('import_annotations') && !$this->input('import_file_labels')) {
+                $validator->errors()->add('id', 'Either import_annotations or import_file_labels must be set to true.');
+            }
+
+            if ($validator->errors()->isNotEmpty()) {
+                return;
+            }
+
+            $metadata = $this->volume->getMetadata();
+
+            if (is_null($metadata)) {
+                $validator->errors()->add('id', 'The volume has no metadata file.');
+                return;
+            }
+
+            if ($this->input('import_annotations') && !$metadata->hasAnnotations()) {
+                $validator->errors()->add('import_annotations', 'The volume metadata has no annotation information.');
+            }
+
+            if ($this->input('import_file_labels') && !$metadata->hasFileLabels()) {
+                $validator->errors()->add('import_file_labels', 'The volume metadata has no file label information.');
+            }
+
+        });
+    }
+}

--- a/app/Http/Requests/UpdatePendingVolume.php
+++ b/app/Http/Requests/UpdatePendingVolume.php
@@ -60,6 +60,10 @@ class UpdatePendingVolume extends FormRequest
             if (!$rule->passes('files', $files)) {
                 $validator->errors()->add('files', $rule->message());
             }
+
+            if (!is_null($this->pendingVolume->volume_id)) {
+                $validator->errors()->add('id', 'A volume was already created for this pending volume.');
+            }
         });
     }
 

--- a/app/Traits/HasMetadataFile.php
+++ b/app/Traits/HasMetadataFile.php
@@ -68,6 +68,8 @@ trait HasMetadataFile
     {
         if ($this->hasMetadata()) {
             Storage::disk($this->getMetadataFileDisk())->delete($this->metadata_file_path);
+            $disk = $this->getMetadataFileDisk();
+            Cache::store('array')->forget("metadata-{$disk}-{$this->metadata_file_path}");
             if (!$noUpdate) {
                 $this->update(['metadata_file_path' => null]);
             }

--- a/resources/assets/js/volumes/metadataUpload.vue
+++ b/resources/assets/js/volumes/metadataUpload.vue
@@ -19,6 +19,8 @@ export default {
             success: false,
             message: undefined,
             hasMetadata: false,
+            hasMetadataAnnotations: false,
+            hasMetadataFileLabels: false,
             parsers: [],
             selectedParser: null,
             importForm: {
@@ -26,6 +28,17 @@ export default {
                 importFileLabels: 0,
             },
         };
+    },
+    computed: {
+        showImportDropdown() {
+            return this.hasMetadataAnnotations && this.hasMetadataFileLabels;
+        },
+        showImportAnnotations() {
+            return this.hasMetadataAnnotations && !this.hasMetadataFileLabels;
+        },
+        showImportFileLabels() {
+            return !this.hasMetadataAnnotations && this.hasMetadataFileLabels;
+        },
     },
     methods: {
         handleSuccess() {
@@ -51,7 +64,11 @@ export default {
             data.append('file', event.target.files[0]);
             data.append('parser', this.selectedParser.parserClass);
             MetadataApi.save({id: this.volumeId}, data)
-                .then(() => this.hasMetadata = true)
+                .then((response) => {
+                    this.hasMetadata = true
+                    this.hasMetadataAnnotations = response.body.has_annotations;
+                    this.hasMetadataFileLabels = response.body.has_file_labels;
+                })
                 .then(this.handleSuccess)
                 .catch(this.handleError)
                 .finally(this.finishLoading);
@@ -64,6 +81,8 @@ export default {
         },
         handleFileDeleted() {
             this.hasMetadata = false;
+            this.hasMetadataAnnotations = false;
+            this.hasMetadataFileLabels = false;
             MessageStore.success('The metadata file was deleted.');
         },
         selectFile(parser) {
@@ -86,6 +105,8 @@ export default {
     created() {
         this.volumeId = biigle.$require('volumes.id');
         this.hasMetadata = biigle.$require('volumes.hasMetadata');
+        this.hasMetadataAnnotations = biigle.$require('volumes.hasMetadataAnnotations');
+        this.hasMetadataFileLabels = biigle.$require('volumes.hasMetadataFileLabels');
         this.parsers = biigle.$require('volumes.parsers');
     },
 };

--- a/resources/assets/js/volumes/metadataUpload.vue
+++ b/resources/assets/js/volumes/metadataUpload.vue
@@ -21,6 +21,10 @@ export default {
             hasMetadata: false,
             parsers: [],
             selectedParser: null,
+            importForm: {
+                importAnnotations: 0,
+                importFileLabels: 0,
+            },
         };
     },
     methods: {
@@ -67,6 +71,16 @@ export default {
             // Use $nextTick so the input element will have the appropriate MIME type
             // filter from the selected parser.
             this.$nextTick(() => this.$refs.fileInput.click());
+        },
+        importAnnotations() {
+            this.importForm.importAnnotations = 1;
+            this.importForm.importFileLabels = 0;
+            this.$nextTick(() => this.$refs.importForm.submit());
+        },
+        importFileLabels() {
+            this.importForm.importAnnotations = 0;
+            this.importForm.importFileLabels = 1;
+            this.$nextTick(() => this.$refs.importForm.submit());
         },
     },
     created() {

--- a/resources/views/manual/tutorials/volumes/file-metadata.blade.php
+++ b/resources/views/manual/tutorials/volumes/file-metadata.blade.php
@@ -120,7 +120,7 @@ image_1.png,2016-12-19 17:09:00,52.112,28.001,-1500.5,30.25,2.6
 image_2.png,2016-12-19 17:09:31,52.215,28.501,-1502.5,28.25,2.1
 </pre>
         <p>
-            The metadata CSV file can be uploaded when a new volume is created. For existing volumes, metadata can be uploaded by volume admins on the volume edit page that you can reach with the <button class="btn btn-default btn-xs"><span class="fa fa-pencil-alt" aria-hidden="true"></span></button> button of the volume overview. This will replace any previously imported metadata.
+            The metadata CSV file can be uploaded when a new volume is created. For existing volumes, metadata can be uploaded by volume admins on the volume edit page that you can reach with the <button class="btn btn-default btn-xs"><span class="fa fa-pencil-alt" aria-hidden="true"></span></button> button of the volume overview. This will replace any previously imported metadata. Some metadata formats also contain annotations or file labels. In this case, BIIGLE will show buttons to initiate the import as well.
         </p>
     </div>
     <div class="row">

--- a/resources/views/volumes/edit.blade.php
+++ b/resources/views/volumes/edit.blade.php
@@ -6,7 +6,9 @@
         biigle.$declare('volumes.id', {!! $volume->id !!});
         biigle.$declare('volumes.annotationSessions', {!! $annotationSessions !!});
         biigle.$declare('volumes.type', '{!! $type !!}');
-        biigle.$declare('volumes.hasMetadata', '{!! $volume->hasMetadata() !!}');
+        biigle.$declare('volumes.hasMetadata', {!! $volume->hasMetadata() ? 'true' : 'false' !!});
+        biigle.$declare('volumes.hasMetadataAnnotations', {!! ($volume->hasMetadata() && $volume->getMetadata()->hasAnnotations()) ? 'true' : 'false' !!});
+        biigle.$declare('volumes.hasMetadataFileLabels', {!! ($volume->hasMetadata() && $volume->getMetadata()->hasFileLabels()) ? 'true' : 'false' !!});
         biigle.$declare('volumes.parsers', {!! $parsers !!});
     </script>
     @mixin('volumesEditScripts')

--- a/resources/views/volumes/edit/metadata.blade.php
+++ b/resources/views/volumes/edit/metadata.blade.php
@@ -7,7 +7,7 @@
         @endif
         <span class="pull-right">
             <span class="loader" v-bind:class="{'loader--active':loading}"></span>
-            <dropdown tag="span" v-if="hasMetadata" v-cloak>
+            <dropdown tag="span" v-if="showImportDropdown" v-cloak>
                 <button class="btn btn-default btn-xs dropdown-toggle" type="button" title="Import annotations or file labels from the metadata file attached to this volume"><i class="fa fa-file-import"></i> Import <span class="caret"></span></button>
                 <template slot="dropdown">
                     <li>
@@ -18,6 +18,8 @@
                     </li>
                 </template>
             </dropdown>
+            <button v-cloak v-if="showImportAnnotations" v-on:click.prevent="importAnnotations" class="btn btn-default btn-xs" type="button" title="Import annotations from the metadata file attached to this volume"><i class="fa fa-file-import"></i> Import annotations</button>
+            <button v-cloak v-if="showImportFileLabels" v-on:click.prevent="importFileLabels" class="btn btn-default btn-xs" type="button" title="Import file labels from the metadata file attached to this volume"><i class="fa fa-file-import"></i> Import annotations</button>
             <dropdown tag="span" v-if="hasMetadata" v-cloak>
                 <button class="btn btn-default btn-xs dropdown-toggle" type="button" title="Manage the metadata file attached to this volume" :disabled="loading"><i class="fa fa-file-alt"></i> Manage file <span class="caret"></span></button>
                 <template slot="dropdown">

--- a/resources/views/volumes/edit/metadata.blade.php
+++ b/resources/views/volumes/edit/metadata.blade.php
@@ -8,6 +8,17 @@
         <span class="pull-right">
             <span class="loader" v-bind:class="{'loader--active':loading}"></span>
             <dropdown tag="span" v-if="hasMetadata" v-cloak>
+                <button class="btn btn-default btn-xs dropdown-toggle" type="button" title="Import annotations or file labels from the metadata file attached to this volume"><i class="fa fa-file-import"></i> Import <span class="caret"></span></button>
+                <template slot="dropdown">
+                    <li>
+                        <a href="#" v-on:click.prevent="importAnnotations" title="Import annotations from the metadata file attached to this volume">Annotations</a>
+                    </li>
+                    <li>
+                        <a href="#" v-on:click.prevent="importFileLabels" title="Import file labels from the metadata file attached to this volume">File labels</a>
+                    </li>
+                </template>
+            </dropdown>
+            <dropdown tag="span" v-if="hasMetadata" v-cloak>
                 <button class="btn btn-default btn-xs dropdown-toggle" type="button" title="Manage the metadata file attached to this volume" :disabled="loading"><i class="fa fa-file-alt"></i> Manage file <span class="caret"></span></button>
                 <template slot="dropdown">
                     <li>
@@ -21,12 +32,22 @@
         </span>
     </div>
     <div class="panel-body">
+        <form ref="importForm" action="{{url("api/v1/volumes/{$volume->id}/pending-volumes")}}" method="post">
+            <input type="hidden" name="_token" value="{{ csrf_token() }}">
+            <input type="hidden" name="import_annotations" v-model="importForm.importAnnotations">
+            <input type="hidden" name="import_file_labels" v-model="importForm.importFileLabels">
+        </form>
+        @if ($errors->hasAny(['import_annotations', 'import_file_labels']))
+            <p class="text-danger">
+                {{ $errors->first() }}
+            </p>
+        @endif
         <p>
             Upload a metadata file to attach it to the volume and update the @if ($volume->isImageVolume()) image @else video @endif metadata.
         </p>
         <p class="text-center">
             <dropdown tag="span">
-                <button class="btn btn-default dropdown-toggle" type="button" :disabled="loading"><i class="fa fa-file-alt"></i> Upload file <span class="caret"></span></button>
+                <button class="btn btn-default dropdown-toggle" type="button" :disabled="loading"><i class="fa fa-upload"></i> Upload file <span class="caret"></span></button>
                 <template slot="dropdown">
                     <li v-for="parser in parsers">
                         <a href="#" v-on:click.prevent="selectFile(parser)" v-text="parser.name"></a>

--- a/routes/api.php
+++ b/routes/api.php
@@ -317,6 +317,10 @@ $router->resource('volumes.files', 'VolumeFileController', [
     'parameters' => ['volumes' => 'id'],
 ]);
 
+$router->post(
+    'volumes/{id}/pending-volumes', 'PendingVolumeController@storeVolume'
+);
+
 $router->group([
     'prefix' => 'volumes',
     'namespace' => 'Volumes',

--- a/tests/php/Http/Controllers/Api/PendingVolumeControllerTest.php
+++ b/tests/php/Http/Controllers/Api/PendingVolumeControllerTest.php
@@ -844,6 +844,26 @@ class PendingVolumeControllerTest extends ApiTestCase
         ])->assertSuccessful();
     }
 
+    public function testUpdatVolumeExists()
+    {
+        config(['volumes.editor_storage_disks' => ['test']]);
+        $disk = Storage::fake('test');
+        $disk->put('images/1.jpg', 'abc');
+
+        $id = PendingVolume::factory()->create([
+            'project_id' => $this->project()->id,
+            'media_type_id' => MediaType::imageId(),
+            'user_id' => $this->admin()->id,
+            'volume_id' => $this->volume()->id,
+        ])->id;
+        $this->beAdmin();
+        $this->putJson("/api/v1/pending-volumes/{$id}", [
+            'name' => 'my volume no. 1',
+            'url' => 'test://images',
+            'files' => ['1.jpg'],
+        ])->assertStatus(422);
+    }
+
     public function testDestroy()
     {
         $pv = PendingVolume::factory()->create([

--- a/tests/php/Http/Controllers/Api/Volumes/MetadataControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Volumes/MetadataControllerTest.php
@@ -57,31 +57,39 @@ class MetadataControllerTest extends ApiTestCase
         $csv = new UploadedFile(__DIR__."/../../../../../files/image-metadata.csv", 'image-metadata.csv', 'text/csv', null, true);
         $this->beEditor();
         // no permissions
-        $this->postJson("/api/v1/volumes/{$id}/metadata", [
-            'file' => $csv,
-            'parser' => ImageCsvParser::class,
-        ])
+        $this
+            ->postJson("/api/v1/volumes/{$id}/metadata", [
+                'file' => $csv,
+                'parser' => ImageCsvParser::class,
+            ])
             ->assertStatus(403);
 
         $this->beAdmin();
         // file required
-        $this->postJson("/api/v1/volumes/{$id}/metadata", [
-            'parser' => ImageCsvParser::class,
-        ])
+        $this
+            ->postJson("/api/v1/volumes/{$id}/metadata", [
+                'parser' => ImageCsvParser::class,
+            ])
             ->assertStatus(422);
 
         // parser required
-        $this->postJson("/api/v1/volumes/{$id}/metadata", [
-            'file' => $csv,
-        ])
+        $this
+            ->postJson("/api/v1/volumes/{$id}/metadata", [
+                'file' => $csv,
+            ])
             ->assertStatus(422);
 
 
-        $this->postJson("/api/v1/volumes/{$id}/metadata", [
-            'file' => $csv,
-            'parser' => ImageCsvParser::class,
-        ])
-            ->assertStatus(200);
+        $this
+            ->postJson("/api/v1/volumes/{$id}/metadata", [
+                'file' => $csv,
+                'parser' => ImageCsvParser::class,
+            ])
+            ->assertStatus(200)
+            ->assertJson([
+                'has_annotations' => false,
+                'has_file_labels' => false,
+            ]);
 
         $this->assertSame(ImageCsvParser::class, $this->volume()->fresh()->metadata_parser);
 
@@ -126,11 +134,16 @@ class MetadataControllerTest extends ApiTestCase
         $csv = new UploadedFile(__DIR__."/../../../../../files/video-metadata.csv", 'metadata.csv', 'text/csv', null, true);
 
         $this->beAdmin();
-        $this->postJson("/api/v1/volumes/{$id}/metadata", [
-            'file' => $csv,
-            'parser' => VideoCsvParser::class,
-        ])
-            ->assertSuccessful();
+        $this
+            ->postJson("/api/v1/volumes/{$id}/metadata", [
+                'file' => $csv,
+                'parser' => VideoCsvParser::class,
+            ])
+            ->assertSuccessful()
+            ->assertJson([
+                'has_annotations' => false,
+                'has_file_labels' => false,
+            ]);
 
         $this->assertSame(VideoCsvParser::class, $this->volume()->fresh()->metadata_parser);
 
@@ -148,10 +161,11 @@ class MetadataControllerTest extends ApiTestCase
         $csv = new UploadedFile(__DIR__."/../../../../../files/image-metadata-strange-encoding.csv", 'metadata.csv', 'text/csv', null, true);
 
         $this->beAdmin();
-        $this->postJson("/api/v1/volumes/{$id}/metadata", [
-            'file' => $csv,
-            'parser' => ImageCsvParser::class,
-        ])
+        $this
+            ->postJson("/api/v1/volumes/{$id}/metadata", [
+                'file' => $csv,
+                'parser' => ImageCsvParser::class,
+            ])
             ->assertStatus(422);
     }
 


### PR DESCRIPTION
- [x] New endpoint to create pending volume for existing volume (if metadata is present). Either "import annotations" or "import file labels". If a pending volume already exists, it is discarded and a new one is created.
- [x] Assign project_id to first project the user and volume have in common and the user is admin of.
- [x] Redirect to default import workflow for pending volume.
- [x] Show import button with JS when new file was uploaded
- [x] Show import button with PHP if view is opened
- [x] Show only "import annotations" or "import file labels" if not both are present in metadata
- [x] Show no button if none of the information is present in metadata
- [x] Update manual.

Resolves #922 