### PR TITLE
Streamed annotation response

### DIFF
--- a/app/AnnotationSession.php
+++ b/app/AnnotationSession.php
@@ -65,8 +65,9 @@ class AnnotationSession extends Model
      *
      * @param VolumeFile $file The file to get the annotations from
      * @param User $user The user to whom the restrictions should apply ('own' user)
+     * @param array $load Models that should also be loaded
      *
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return Generator
      */
     public function getVolumeFileAnnotations(VolumeFile $file, User $user, array $load = [])
     {
@@ -106,6 +107,7 @@ class AnnotationSession extends Model
             $query->with('labels');
         }
 
+        // Prevent exceeding memory limit by using generator
         $yieldAnnotations = function () use ($query, $load): Generator {
             foreach ($query->with($load)->lazy() as $annotation) {
                 yield $annotation;

--- a/app/AnnotationSession.php
+++ b/app/AnnotationSession.php
@@ -2,11 +2,11 @@
 
 namespace Biigle;
 
+use Carbon\Carbon;
 use DB;
 use Generator;
-use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * An annotation session groups multiple annotations of a volume based on their

--- a/app/Http/Controllers/Api/ImageAnnotationController.php
+++ b/app/Http/Controllers/Api/ImageAnnotationController.php
@@ -2,16 +2,16 @@
 
 namespace Biigle\Http\Controllers\Api;
 
+use Biigle\Http\Requests\StoreImageAnnotation;
+use Biigle\Image;
+use Biigle\ImageAnnotation;
+use Biigle\ImageAnnotationLabel;
+use Biigle\Label;
+use Biigle\Shape;
 use DB;
 use Exception;
 use Generator;
-use Biigle\Image;
-use Biigle\Label;
-use Biigle\Shape;
-use Biigle\ImageAnnotation;
 use Illuminate\Http\Request;
-use Biigle\ImageAnnotationLabel;
-use Biigle\Http\Requests\StoreImageAnnotation;
 use Illuminate\Validation\ValidationException;
 
 class ImageAnnotationController extends Controller

--- a/app/Http/Controllers/Api/ImageAnnotationController.php
+++ b/app/Http/Controllers/Api/ImageAnnotationController.php
@@ -61,7 +61,7 @@ class ImageAnnotationController extends Controller
      *
      * @param Request $request
      * @param int $id image id
-     * @return \Illuminate\Database\Eloquent\Collection<int, ImageAnnotation>
+     * @return \Symfony\Component\HttpFoundation\StreamedJsonResponse
      */
     public function index(Request $request, $id)
     {
@@ -79,6 +79,7 @@ class ImageAnnotationController extends Controller
             'labels.user:id,firstname,lastname',
         ];
 
+        // Prevent exceeding memory limit by using generator and stream
         if ($session) {
             $yieldAnnotations = $session->getVolumeFileAnnotations($image, $user, $load);
         } else {

--- a/app/Http/Controllers/Api/ImageAnnotationController.php
+++ b/app/Http/Controllers/Api/ImageAnnotationController.php
@@ -90,7 +90,7 @@ class ImageAnnotationController extends Controller
             };
         }
     
-        return response()->streamJson($yieldAnnotations());
+        return response()->streamJson(iterator_to_array($yieldAnnotations()));
     }
 
     /**

--- a/app/Http/Controllers/Api/ImageAnnotationController.php
+++ b/app/Http/Controllers/Api/ImageAnnotationController.php
@@ -13,6 +13,7 @@ use Exception;
 use Generator;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 
 class ImageAnnotationController extends Controller
 {
@@ -90,7 +91,7 @@ class ImageAnnotationController extends Controller
             };
         }
     
-        return response()->streamJson(iterator_to_array($yieldAnnotations()));
+        return new StreamedJsonResponse($yieldAnnotations());
     }
 
     /**

--- a/app/Http/Controllers/Api/VideoAnnotationController.php
+++ b/app/Http/Controllers/Api/VideoAnnotationController.php
@@ -2,20 +2,20 @@
 
 namespace Biigle\Http\Controllers\Api;
 
-use DB;
-use Cache;
-use Queue;
-use Exception;
-use Generator;
+use Biigle\Http\Requests\StoreVideoAnnotation;
+use Biigle\Http\Requests\UpdateVideoAnnotation;
+use Biigle\Jobs\TrackObject;
 use Biigle\Label;
 use Biigle\Video;
 use Biigle\VideoAnnotation;
-use Biigle\Jobs\TrackObject;
-use Illuminate\Http\Request;
 use Biigle\VideoAnnotationLabel;
-use Biigle\Http\Requests\StoreVideoAnnotation;
+use Cache;
+use DB;
+use Exception;
+use Generator;
+use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
-use Biigle\Http\Requests\UpdateVideoAnnotation;
+use Queue;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
 class VideoAnnotationController extends Controller

--- a/app/Http/Controllers/Api/VideoAnnotationController.php
+++ b/app/Http/Controllers/Api/VideoAnnotationController.php
@@ -16,6 +16,7 @@ use Generator;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Queue;
+use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
 class VideoAnnotationController extends Controller
@@ -84,7 +85,7 @@ class VideoAnnotationController extends Controller
             };
         }
 
-        return response()->streamJson(iterator_to_array($yieldAnnotations()));
+        return new StreamedJsonResponse($yieldAnnotations());
     }
 
     /**

--- a/app/Http/Controllers/Api/VideoAnnotationController.php
+++ b/app/Http/Controllers/Api/VideoAnnotationController.php
@@ -84,7 +84,7 @@ class VideoAnnotationController extends Controller
             };
         }
 
-        return response()->streamJson($yieldAnnotations());
+        return response()->streamJson(iterator_to_array($yieldAnnotations()));
     }
 
     /**

--- a/app/Http/Controllers/Api/VideoAnnotationController.php
+++ b/app/Http/Controllers/Api/VideoAnnotationController.php
@@ -62,7 +62,7 @@ class VideoAnnotationController extends Controller
      *
      * @param Request $request
      * @param int $id Video id
-     * @return mixed
+     * @return \Symfony\Component\HttpFoundation\StreamedJsonResponse
      */
     public function index(Request $request, $id)
     {
@@ -73,6 +73,7 @@ class VideoAnnotationController extends Controller
         $session = $video->volume->getActiveAnnotationSession($user);
         $load = ['labels.label', 'labels.user'];
 
+        // Prevent exceeding memory limit by using generator and stream
         if ($session) {
             $yieldAnnotations = $session->getVolumeFileAnnotations($video, $user, $load);
         } else {

--- a/tests/php/AnnotationSessionTest.php
+++ b/tests/php/AnnotationSessionTest.php
@@ -2,12 +2,11 @@
 
 namespace Biigle\Tests;
 
-use Carbon\Carbon;
-use ModelTestCase;
-use Biigle\MediaType;
 use Biigle\AnnotationSession;
-use Illuminate\Support\Facades\Log;
+use Biigle\MediaType;
+use Carbon\Carbon;
 use Illuminate\Database\QueryException;
+use ModelTestCase;
 
 class AnnotationSessionTest extends ModelTestCase
 {
@@ -172,7 +171,7 @@ class AnnotationSessionTest extends ModelTestCase
 
         $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);
         // expand the models in the collection so we can make assertions
-       $annotations = collect($yieldAnnotations());
+        $annotations = collect($yieldAnnotations());
         $labels = $annotations->pluck('labels');
         
         $this->assertFalse($this->isPresent($al11, $labels));
@@ -213,9 +212,9 @@ class AnnotationSessionTest extends ModelTestCase
             'hide_other_users_annotations' => true,
         ]);
 
-        $yieldAnnotations = $session->getVolumeFileAnnotations($image, $ownUser);;
+        $yieldAnnotations = $session->getVolumeFileAnnotations($image, $ownUser);
         // expand the models in the collection so we can make assertions
-       $annotations = collect($yieldAnnotations());
+        $annotations = collect($yieldAnnotations());
         $labels = $annotations->pluck('labels');
 
         $this->assertTrue($annotations->contains('points', [20, 30, 40]));
@@ -254,9 +253,9 @@ class AnnotationSessionTest extends ModelTestCase
             'hide_other_users_annotations' => true,
         ]);
 
-        $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);;
+        $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);
         // expand the models in the collection so we can make assertions
-       $annotations = collect($yieldAnnotations());
+        $annotations = collect($yieldAnnotations());
         $labels = $annotations->pluck('labels');
 
         $this->assertTrue($annotations->contains('points', [[20, 30, 40]]));
@@ -295,9 +294,9 @@ class AnnotationSessionTest extends ModelTestCase
             'hide_other_users_annotations' => true,
         ]);
 
-        $yieldAnnotations = $session->getVolumeFileAnnotations($image, $ownUser);;
+        $yieldAnnotations = $session->getVolumeFileAnnotations($image, $ownUser);
         // expand the models in the collection so we can make assertions
-       $annotations = collect($yieldAnnotations());
+        $annotations = collect($yieldAnnotations());
         $labels = $annotations->pluck('labels');
 
         $this->assertTrue($annotations->contains('points', [40, 50, 60]));
@@ -336,9 +335,9 @@ class AnnotationSessionTest extends ModelTestCase
             'hide_other_users_annotations' => true,
         ]);
 
-        $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);;
+        $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);
         // expand the models in the collection so we can make assertions
-       $annotations = collect($yieldAnnotations());
+        $annotations = collect($yieldAnnotations());
         $labels = $annotations->pluck('labels');
 
         $this->assertTrue($annotations->contains('points', [[40, 50, 60]]));
@@ -378,7 +377,7 @@ class AnnotationSessionTest extends ModelTestCase
 
         $yieldAnnotations = $session->getVolumeFileAnnotations($image, $ownUser);
         // expand the models in the collection so we can make assertions
-       $annotations = collect($yieldAnnotations());
+        $annotations = collect($yieldAnnotations());
         $labels = $annotations->pluck('labels');
 
         $this->assertTrue($annotations->contains('points', [40, 50, 60]));
@@ -416,9 +415,9 @@ class AnnotationSessionTest extends ModelTestCase
             'hide_other_users_annotations' => false,
         ]);
 
-        $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);;
+        $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);
         // expand the models in the collection so we can make assertions
-       $annotations = collect($yieldAnnotations());
+        $annotations = collect($yieldAnnotations());
         $labels = $annotations->pluck('labels');
 
         $this->assertTrue($annotations->contains('points', [[40, 50, 60]]));
@@ -736,9 +735,10 @@ class AnnotationSessionTest extends ModelTestCase
         $this->assertFalse($session->annotations()->where('id', $a4->id)->exists());
     }
 
-    private function isPresent($needle, $haystack){
+    private function isPresent($needle, $haystack)
+    {
         $needle = collect($needle)->sortKeys();
-        $haystack = $haystack->flatten()->map(fn($l) => collect($l)->sortKeys());
+        $haystack = $haystack->flatten()->map(fn ($l) => collect($l)->sortKeys());
         return $haystack->contains($needle);
     }
 }

--- a/tests/php/AnnotationSessionTest.php
+++ b/tests/php/AnnotationSessionTest.php
@@ -2,11 +2,12 @@
 
 namespace Biigle\Tests;
 
-use Biigle\AnnotationSession;
-use Biigle\MediaType;
 use Carbon\Carbon;
-use Illuminate\Database\QueryException;
 use ModelTestCase;
+use Biigle\MediaType;
+use Biigle\AnnotationSession;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Database\QueryException;
 
 class AnnotationSessionTest extends ModelTestCase
 {
@@ -91,7 +92,7 @@ class AnnotationSessionTest extends ModelTestCase
         $al12 = ImageAnnotationLabelTest::create([
             'annotation_id' => $a1->id,
             'user_id' => $otherUser->id,
-            'created_at' => '2016-09-05',
+            'created_at' => '2022-09-05',
         ]);
 
         // this should be shown completely
@@ -114,16 +115,16 @@ class AnnotationSessionTest extends ModelTestCase
             'hide_other_users_annotations' => false,
         ]);
 
-        $annotations = $session->getVolumeFileAnnotations($image, $ownUser);
+        $yieldAnnotations = $session->getVolumeFileAnnotations($image, $ownUser);
         // expand the models in the collection so we can make assertions
-        $annotations = collect($annotations->toArray());
+        $annotations = collect($yieldAnnotations());
+        $labels = $annotations->pluck('labels');
 
-        $this->assertTrue($annotations->contains('points', [20, 30, 40]));
-        $this->assertFalse($annotations->contains('labels', [$al11->toArray()]));
-        $this->assertTrue($annotations->contains('labels', [$al12->toArray()]));
+        $this->assertFalse($this->isPresent($al11, $labels));
+        $this->assertTrue($this->isPresent($al12, $labels));
 
         $this->assertTrue($annotations->contains('points', [30, 40, 50]));
-        $this->assertTrue($annotations->contains('labels', [$al2->toArray()]));
+        $this->assertTrue($this->isPresent($al2, $labels));
     }
 
     public function testGetVolumeFileAnnotationsHideOwnVideo()
@@ -169,16 +170,16 @@ class AnnotationSessionTest extends ModelTestCase
             'hide_other_users_annotations' => false,
         ]);
 
-        $annotations = $session->getVolumeFileAnnotations($video, $ownUser);
+        $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);
         // expand the models in the collection so we can make assertions
-        $annotations = collect($annotations->toArray());
-
-        $this->assertTrue($annotations->contains('points', [[20, 30, 40]]));
-        $this->assertFalse($annotations->contains('labels', [$al11->toArray()]));
-        $this->assertTrue($annotations->contains('labels', [$al12->toArray()]));
+       $annotations = collect($yieldAnnotations());
+        $labels = $annotations->pluck('labels');
+        
+        $this->assertFalse($this->isPresent($al11, $labels));
+        $this->assertTrue($this->isPresent($al12, $labels));
 
         $this->assertTrue($annotations->contains('points', [[30, 40, 50]]));
-        $this->assertTrue($annotations->contains('labels', [$al2->toArray()]));
+        $this->assertTrue($this->isPresent($al2, $labels));
     }
 
     public function testGetVolumeFileAnnotationsHideOtherImage()
@@ -212,13 +213,14 @@ class AnnotationSessionTest extends ModelTestCase
             'hide_other_users_annotations' => true,
         ]);
 
-        $annotations = $session->getVolumeFileAnnotations($image, $ownUser);
+        $yieldAnnotations = $session->getVolumeFileAnnotations($image, $ownUser);;
         // expand the models in the collection so we can make assertions
-        $annotations = collect($annotations->toArray());
+       $annotations = collect($yieldAnnotations());
+        $labels = $annotations->pluck('labels');
 
         $this->assertTrue($annotations->contains('points', [20, 30, 40]));
-        $this->assertFalse($annotations->contains('labels', [$al1->toArray()]));
-        $this->assertTrue($annotations->contains('labels', [$al2->toArray()]));
+        $this->assertFalse($this->isPresent($al1, $labels));
+        $this->assertTrue($this->isPresent($al2, $labels));
     }
 
     public function testGetVolumeFileAnnotationsHideOtherVideo()
@@ -252,13 +254,14 @@ class AnnotationSessionTest extends ModelTestCase
             'hide_other_users_annotations' => true,
         ]);
 
-        $annotations = $session->getVolumeFileAnnotations($video, $ownUser);
+        $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);;
         // expand the models in the collection so we can make assertions
-        $annotations = collect($annotations->toArray());
+       $annotations = collect($yieldAnnotations());
+        $labels = $annotations->pluck('labels');
 
         $this->assertTrue($annotations->contains('points', [[20, 30, 40]]));
-        $this->assertFalse($annotations->contains('labels', [$al1->toArray()]));
-        $this->assertTrue($annotations->contains('labels', [$al2->toArray()]));
+        $this->assertFalse($this->isPresent($al1, $labels));
+        $this->assertTrue($this->isPresent($al2, $labels));
     }
 
     public function testGetVolumeFileAnnotationsHideBothImage()
@@ -292,13 +295,14 @@ class AnnotationSessionTest extends ModelTestCase
             'hide_other_users_annotations' => true,
         ]);
 
-        $annotations = $session->getVolumeFileAnnotations($image, $ownUser);
+        $yieldAnnotations = $session->getVolumeFileAnnotations($image, $ownUser);;
         // expand the models in the collection so we can make assertions
-        $annotations = collect($annotations->toArray());
+       $annotations = collect($yieldAnnotations());
+        $labels = $annotations->pluck('labels');
 
         $this->assertTrue($annotations->contains('points', [40, 50, 60]));
-        $this->assertTrue($annotations->contains('labels', [$al1->toArray()]));
-        $this->assertFalse($annotations->contains('labels', [$al2->toArray()]));
+        $this->assertTrue($this->isPresent($al1, $labels));
+        $this->assertFalse($this->isPresent($al2, $labels));
     }
 
     public function testGetVolumeFileAnnotationsHideBothVideo()
@@ -332,13 +336,14 @@ class AnnotationSessionTest extends ModelTestCase
             'hide_other_users_annotations' => true,
         ]);
 
-        $annotations = $session->getVolumeFileAnnotations($video, $ownUser);
+        $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);;
         // expand the models in the collection so we can make assertions
-        $annotations = collect($annotations->toArray());
+       $annotations = collect($yieldAnnotations());
+        $labels = $annotations->pluck('labels');
 
         $this->assertTrue($annotations->contains('points', [[40, 50, 60]]));
-        $this->assertTrue($annotations->contains('labels', [$al1->toArray()]));
-        $this->assertFalse($annotations->contains('labels', [$al2->toArray()]));
+        $this->assertTrue($this->isPresent($al1, $labels));
+        $this->assertFalse($this->isPresent($al2, $labels));
     }
 
     public function testGetVolumeFileAnnotationsHideNothingImage()
@@ -371,15 +376,14 @@ class AnnotationSessionTest extends ModelTestCase
             'hide_other_users_annotations' => false,
         ]);
 
-        $annotations = $session->getVolumeFileAnnotations($image, $ownUser);
+        $yieldAnnotations = $session->getVolumeFileAnnotations($image, $ownUser);
         // expand the models in the collection so we can make assertions
-        $annotations = collect($annotations->toArray());
+       $annotations = collect($yieldAnnotations());
+        $labels = $annotations->pluck('labels');
 
         $this->assertTrue($annotations->contains('points', [40, 50, 60]));
-        $this->assertTrue($annotations->contains('labels', [
-            $al1->toArray(),
-            $al2->toArray(),
-        ]));
+        $this->assertTrue($this->isPresent($al1, $labels));
+        $this->assertTrue($this->isPresent($al2, $labels));
     }
 
     public function testGetVolumeFileAnnotationsHideNothingVideo()
@@ -412,15 +416,14 @@ class AnnotationSessionTest extends ModelTestCase
             'hide_other_users_annotations' => false,
         ]);
 
-        $annotations = $session->getVolumeFileAnnotations($video, $ownUser);
+        $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);;
         // expand the models in the collection so we can make assertions
-        $annotations = collect($annotations->toArray());
+       $annotations = collect($yieldAnnotations());
+        $labels = $annotations->pluck('labels');
 
         $this->assertTrue($annotations->contains('points', [[40, 50, 60]]));
-        $this->assertTrue($annotations->contains('labels', [
-            $al1->toArray(),
-            $al2->toArray(),
-        ]));
+        $this->assertTrue($this->isPresent($al1, $labels));
+        $this->assertTrue($this->isPresent($al2, $labels));
     }
 
     public function testAllowsAccessImageAnnotation()
@@ -731,5 +734,11 @@ class AnnotationSessionTest extends ModelTestCase
         $this->assertFalse($session->annotations()->where('id', $a2->id)->exists());
         $this->assertFalse($session->annotations()->where('id', $a3->id)->exists());
         $this->assertFalse($session->annotations()->where('id', $a4->id)->exists());
+    }
+
+    private function isPresent($needle, $haystack){
+        $needle = collect($needle)->sortKeys();
+        $haystack = $haystack->flatten()->map(fn($l) => collect($l)->sortKeys());
+        return $haystack->contains($needle);
     }
 }

--- a/tests/php/AnnotationSessionTest.php
+++ b/tests/php/AnnotationSessionTest.php
@@ -91,7 +91,7 @@ class AnnotationSessionTest extends ModelTestCase
         $al12 = ImageAnnotationLabelTest::create([
             'annotation_id' => $a1->id,
             'user_id' => $otherUser->id,
-            'created_at' => '2022-09-05',
+            'created_at' => '2016-09-05',
         ]);
 
         // this should be shown completely
@@ -116,14 +116,14 @@ class AnnotationSessionTest extends ModelTestCase
 
         $yieldAnnotations = $session->getVolumeFileAnnotations($image, $ownUser);
         // expand the models in the collection so we can make assertions
-        $annotations = collect($yieldAnnotations());
-        $labels = $annotations->pluck('labels');
+        $annotations = collect(collect($yieldAnnotations())->toArray());
 
-        $this->assertFalse($this->isPresent($al11, $labels));
-        $this->assertTrue($this->isPresent($al12, $labels));
+        $this->assertTrue($annotations->contains('points', [20, 30, 40]));
+        $this->assertFalse($annotations->contains('labels', [$al11->toArray()]));
+        $this->assertTrue($annotations->contains('labels', [$al12->toArray()]));
 
         $this->assertTrue($annotations->contains('points', [30, 40, 50]));
-        $this->assertTrue($this->isPresent($al2, $labels));
+        $this->assertTrue($annotations->contains('labels', [$al2->toArray()]));
     }
 
     public function testGetVolumeFileAnnotationsHideOwnVideo()
@@ -171,14 +171,14 @@ class AnnotationSessionTest extends ModelTestCase
 
         $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);
         // expand the models in the collection so we can make assertions
-        $annotations = collect($yieldAnnotations());
-        $labels = $annotations->pluck('labels');
-        
-        $this->assertFalse($this->isPresent($al11, $labels));
-        $this->assertTrue($this->isPresent($al12, $labels));
+        $annotations = collect(collect($yieldAnnotations())->toArray());
+
+        $this->assertTrue($annotations->contains('points', [[20, 30, 40]]));
+        $this->assertFalse($annotations->contains('labels', [$al11->toArray()]));
+        $this->assertTrue($annotations->contains('labels', [$al12->toArray()]));
 
         $this->assertTrue($annotations->contains('points', [[30, 40, 50]]));
-        $this->assertTrue($this->isPresent($al2, $labels));
+        $this->assertTrue($annotations->contains('labels', [$al2->toArray()]));
     }
 
     public function testGetVolumeFileAnnotationsHideOtherImage()
@@ -214,12 +214,11 @@ class AnnotationSessionTest extends ModelTestCase
 
         $yieldAnnotations = $session->getVolumeFileAnnotations($image, $ownUser);
         // expand the models in the collection so we can make assertions
-        $annotations = collect($yieldAnnotations());
-        $labels = $annotations->pluck('labels');
+        $annotations = collect(collect($yieldAnnotations())->toArray());
 
         $this->assertTrue($annotations->contains('points', [20, 30, 40]));
-        $this->assertFalse($this->isPresent($al1, $labels));
-        $this->assertTrue($this->isPresent($al2, $labels));
+        $this->assertFalse($annotations->contains('labels', [$al1->toArray()]));
+        $this->assertTrue($annotations->contains('labels', [$al2->toArray()]));
     }
 
     public function testGetVolumeFileAnnotationsHideOtherVideo()
@@ -255,12 +254,11 @@ class AnnotationSessionTest extends ModelTestCase
 
         $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);
         // expand the models in the collection so we can make assertions
-        $annotations = collect($yieldAnnotations());
-        $labels = $annotations->pluck('labels');
+        $annotations = collect(collect($yieldAnnotations())->toArray());
 
         $this->assertTrue($annotations->contains('points', [[20, 30, 40]]));
-        $this->assertFalse($this->isPresent($al1, $labels));
-        $this->assertTrue($this->isPresent($al2, $labels));
+        $this->assertFalse($annotations->contains('labels', [$al1->toArray()]));
+        $this->assertTrue($annotations->contains('labels', [$al2->toArray()]));
     }
 
     public function testGetVolumeFileAnnotationsHideBothImage()
@@ -296,12 +294,11 @@ class AnnotationSessionTest extends ModelTestCase
 
         $yieldAnnotations = $session->getVolumeFileAnnotations($image, $ownUser);
         // expand the models in the collection so we can make assertions
-        $annotations = collect($yieldAnnotations());
-        $labels = $annotations->pluck('labels');
+        $annotations = collect(collect($yieldAnnotations())->toArray());
 
         $this->assertTrue($annotations->contains('points', [40, 50, 60]));
-        $this->assertTrue($this->isPresent($al1, $labels));
-        $this->assertFalse($this->isPresent($al2, $labels));
+        $this->assertTrue($annotations->contains('labels', [$al1->toArray()]));
+        $this->assertFalse($annotations->contains('labels', [$al2->toArray()]));
     }
 
     public function testGetVolumeFileAnnotationsHideBothVideo()
@@ -337,12 +334,11 @@ class AnnotationSessionTest extends ModelTestCase
 
         $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);
         // expand the models in the collection so we can make assertions
-        $annotations = collect($yieldAnnotations());
-        $labels = $annotations->pluck('labels');
+        $annotations = collect(collect($yieldAnnotations())->toArray());
 
         $this->assertTrue($annotations->contains('points', [[40, 50, 60]]));
-        $this->assertTrue($this->isPresent($al1, $labels));
-        $this->assertFalse($this->isPresent($al2, $labels));
+        $this->assertTrue($annotations->contains('labels', [$al1->toArray()]));
+        $this->assertFalse($annotations->contains('labels', [$al2->toArray()]));
     }
 
     public function testGetVolumeFileAnnotationsHideNothingImage()
@@ -377,12 +373,13 @@ class AnnotationSessionTest extends ModelTestCase
 
         $yieldAnnotations = $session->getVolumeFileAnnotations($image, $ownUser);
         // expand the models in the collection so we can make assertions
-        $annotations = collect($yieldAnnotations());
-        $labels = $annotations->pluck('labels');
+        $annotations = collect(collect($yieldAnnotations())->toArray());
 
         $this->assertTrue($annotations->contains('points', [40, 50, 60]));
-        $this->assertTrue($this->isPresent($al1, $labels));
-        $this->assertTrue($this->isPresent($al2, $labels));
+        $this->assertTrue($annotations->contains('labels', [
+            $al1->toArray(),
+            $al2->toArray(),
+        ]));
     }
 
     public function testGetVolumeFileAnnotationsHideNothingVideo()
@@ -417,12 +414,13 @@ class AnnotationSessionTest extends ModelTestCase
 
         $yieldAnnotations = $session->getVolumeFileAnnotations($video, $ownUser);
         // expand the models in the collection so we can make assertions
-        $annotations = collect($yieldAnnotations());
-        $labels = $annotations->pluck('labels');
+        $annotations = collect(collect($yieldAnnotations())->toArray());
 
         $this->assertTrue($annotations->contains('points', [[40, 50, 60]]));
-        $this->assertTrue($this->isPresent($al1, $labels));
-        $this->assertTrue($this->isPresent($al2, $labels));
+        $this->assertTrue($annotations->contains('labels', [
+            $al1->toArray(),
+            $al2->toArray(),
+        ]));
     }
 
     public function testAllowsAccessImageAnnotation()
@@ -733,12 +731,5 @@ class AnnotationSessionTest extends ModelTestCase
         $this->assertFalse($session->annotations()->where('id', $a2->id)->exists());
         $this->assertFalse($session->annotations()->where('id', $a3->id)->exists());
         $this->assertFalse($session->annotations()->where('id', $a4->id)->exists());
-    }
-
-    private function isPresent($needle, $haystack)
-    {
-        $needle = collect($needle)->sortKeys();
-        $haystack = $haystack->flatten()->map(fn ($l) => collect($l)->sortKeys());
-        return $haystack->contains($needle);
     }
 }

--- a/tests/php/Http/Controllers/Api/ImageAnnotationControllerTest.php
+++ b/tests/php/Http/Controllers/Api/ImageAnnotationControllerTest.php
@@ -2,16 +2,16 @@
 
 namespace Biigle\Tests\Http\Controllers\Api;
 
-use Cache;
 use ApiTestCase;
 use Biigle\Shape;
-use Carbon\Carbon;
-use Biigle\Tests\ImageTest;
-use Biigle\Tests\LabelTest;
-use Illuminate\Testing\TestResponse;
-use Biigle\Tests\ImageAnnotationTest;
 use Biigle\Tests\AnnotationSessionTest;
 use Biigle\Tests\ImageAnnotationLabelTest;
+use Biigle\Tests\ImageAnnotationTest;
+use Biigle\Tests\ImageTest;
+use Biigle\Tests\LabelTest;
+use Cache;
+use Carbon\Carbon;
+use Illuminate\Testing\TestResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 class ImageAnnotationControllerTest extends ApiTestCase
@@ -57,7 +57,8 @@ class ImageAnnotationControllerTest extends ApiTestCase
         $response->sendContent();
         $content = ob_get_clean();
         $response = new TestResponse(
-            new Response($content,
+            new Response(
+                $content,
                 $response->baseResponse->getStatusCode(),
                 $response->baseResponse->headers->all()
             )
@@ -108,7 +109,8 @@ class ImageAnnotationControllerTest extends ApiTestCase
         $response->sendContent();
         $content = ob_get_clean();
         $response = new TestResponse(
-            new Response($content,
+            new Response(
+                $content,
                 $response->baseResponse->getStatusCode(),
                 $response->baseResponse->headers->all()
             )
@@ -127,7 +129,8 @@ class ImageAnnotationControllerTest extends ApiTestCase
         $response->sendContent();
         $content = ob_get_clean();
         $response = new TestResponse(
-            new Response($content,
+            new Response(
+                $content,
                 $response->baseResponse->getStatusCode(),
                 $response->baseResponse->headers->all()
             )

--- a/tests/php/Http/Controllers/Api/ImageAnnotationControllerTest.php
+++ b/tests/php/Http/Controllers/Api/ImageAnnotationControllerTest.php
@@ -2,15 +2,17 @@
 
 namespace Biigle\Tests\Http\Controllers\Api;
 
+use Cache;
 use ApiTestCase;
 use Biigle\Shape;
-use Biigle\Tests\AnnotationSessionTest;
-use Biigle\Tests\ImageAnnotationLabelTest;
-use Biigle\Tests\ImageAnnotationTest;
+use Carbon\Carbon;
 use Biigle\Tests\ImageTest;
 use Biigle\Tests\LabelTest;
-use Cache;
-use Carbon\Carbon;
+use Illuminate\Testing\TestResponse;
+use Biigle\Tests\ImageAnnotationTest;
+use Biigle\Tests\AnnotationSessionTest;
+use Biigle\Tests\ImageAnnotationLabelTest;
+use Symfony\Component\HttpFoundation\Response;
 
 class ImageAnnotationControllerTest extends ApiTestCase
 {
@@ -49,11 +51,22 @@ class ImageAnnotationControllerTest extends ApiTestCase
         $response->assertStatus(403);
 
         $this->beGuest();
-        $response = $this->get("/api/v1/images/{$this->image->id}/annotations")
-            ->assertJsonFragment(['points' => [10, 20, 30, 40]])
+        $response = $this->getJson("/api/v1/images/{$this->image->id}/annotations")->assertStatus(200);
+
+        ob_start();
+        $response->sendContent();
+        $content = ob_get_clean();
+        $response = new TestResponse(
+            new Response($content,
+                $response->baseResponse->getStatusCode(),
+                $response->baseResponse->headers->all()
+            )
+        );
+
+        $response->assertJsonFragment(['points' => [10, 20, 30, 40]])
             ->assertJsonFragment(['color' => 'bada55'])
             ->assertJsonFragment(['name' => 'My label']);
-        $response->assertStatus(200);
+        
     }
 
     public function testIndexAnnotationSessionHideOwn()
@@ -89,18 +102,40 @@ class ImageAnnotationControllerTest extends ApiTestCase
         ]);
 
         $this->beEditor();
-        $response = $this->get("/api/v1/images/{$this->image->id}/annotations")
-            ->assertJsonFragment(['points' => [10, 20]])
+        $response = $this->getJson("/api/v1/images/{$this->image->id}/annotations")->assertStatus(200);
+
+        ob_start();
+        $response->sendContent();
+        $content = ob_get_clean();
+        $response = new TestResponse(
+            new Response($content,
+                $response->baseResponse->getStatusCode(),
+                $response->baseResponse->headers->all()
+            )
+        );
+
+        $response->assertJsonFragment(['points' => [10, 20]])
             ->assertJsonFragment(['points' => [20, 30]]);
-        $response->assertStatus(200);
+        
 
         $session->users()->attach($this->editor());
         Cache::flush();
 
-        $response = $this->get("/api/v1/images/{$this->image->id}/annotations")
-            ->assertJsonMissing(['points' => [10, 20]])
+        $response = $this->getJson("/api/v1/images/{$this->image->id}/annotations")->assertStatus(200);
+
+        ob_start();
+        $response->sendContent();
+        $content = ob_get_clean();
+        $response = new TestResponse(
+            new Response($content,
+                $response->baseResponse->getStatusCode(),
+                $response->baseResponse->headers->all()
+            )
+        );
+
+        $response->assertJsonMissing(['points' => [10, 20]])
             ->assertJsonFragment(['points' => [20, 30]]);
-        $response->assertStatus(200);
+        
     }
 
     public function testShow()

--- a/tests/php/Http/Controllers/Api/VideoAnnotationControllerTest.php
+++ b/tests/php/Http/Controllers/Api/VideoAnnotationControllerTest.php
@@ -2,19 +2,19 @@
 
 namespace Biigle\Tests\Http\Controllers\Api;
 
-use Cache;
-use Queue;
 use ApiTestCase;
-use Biigle\Shape;
-use Carbon\Carbon;
-use Biigle\MediaType;
-use Biigle\Tests\LabelTest;
-use Biigle\Tests\VideoTest;
 use Biigle\Jobs\TrackObject;
-use Illuminate\Testing\TestResponse;
-use Biigle\Tests\VideoAnnotationTest;
+use Biigle\MediaType;
+use Biigle\Shape;
 use Biigle\Tests\AnnotationSessionTest;
+use Biigle\Tests\LabelTest;
 use Biigle\Tests\VideoAnnotationLabelTest;
+use Biigle\Tests\VideoAnnotationTest;
+use Biigle\Tests\VideoTest;
+use Cache;
+use Carbon\Carbon;
+use Illuminate\Testing\TestResponse;
+use Queue;
 use Symfony\Component\HttpFoundation\Response;
 
 class VideoAnnotationControllerTest extends ApiTestCase
@@ -64,7 +64,8 @@ class VideoAnnotationControllerTest extends ApiTestCase
         $response->sendContent();
         $content = ob_get_clean();
         $response = new TestResponse(
-            new Response($content,
+            new Response(
+                $content,
                 $response->baseResponse->getStatusCode(),
                 $response->baseResponse->headers->all()
             )
@@ -117,7 +118,8 @@ class VideoAnnotationControllerTest extends ApiTestCase
         $response->sendContent();
         $content = ob_get_clean();
         $response = new TestResponse(
-            new Response($content,
+            new Response(
+                $content,
                 $response->baseResponse->getStatusCode(),
                 $response->baseResponse->headers->all()
             )
@@ -137,7 +139,8 @@ class VideoAnnotationControllerTest extends ApiTestCase
         $response->sendContent();
         $content = ob_get_clean();
         $response = new TestResponse(
-            new Response($content,
+            new Response(
+                $content,
                 $response->baseResponse->getStatusCode(),
                 $response->baseResponse->headers->all()
             )


### PR DESCRIPTION
Prevent exceeding memory limit for annotation get requests by using generator and stream.

Closes #946.