### PR TITLE
Add video info view

### DIFF
--- a/app/Http/Controllers/Api/VideoAnnotationController.php
+++ b/app/Http/Controllers/Api/VideoAnnotationController.php
@@ -211,12 +211,7 @@ class VideoAnnotationController extends Controller
             }
         }
 
-        // from a JSON request, the array may already be decoded
         $points = $request->input('points', []);
-
-        if (is_string($points)) {
-            $points = json_decode($points);
-        }
 
         $annotation = new VideoAnnotation([
             'video_id' => $request->video->id,

--- a/app/Http/Controllers/Views/Videos/VideoAnnotationController.php
+++ b/app/Http/Controllers/Views/Videos/VideoAnnotationController.php
@@ -18,7 +18,7 @@ class VideoAnnotationController extends Controller
         $annotation = VideoAnnotation::findOrFail($id);
         $this->authorize('access', $annotation);
 
-        return redirect()->route('video', [
+        return redirect()->route('video-annotate', [
             'id' => $annotation->video_id,
             'annotation' => $annotation->id,
         ]);

--- a/app/Http/Controllers/Views/Volumes/VideoController.php
+++ b/app/Http/Controllers/Views/Volumes/VideoController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Biigle\Http\Controllers\Views\Volumes;
+
+use Arr;
+use Biigle\Http\Controllers\Views\Controller;
+use Biigle\Video;
+
+class VideoController extends Controller
+{
+    /**
+     * Shows the video index page.
+     *
+     * @param int $id volume ID
+     */
+    public function index($id)
+    {
+        $video = Video::with('volume')->findOrFail($id);
+
+        $this->authorize('access', $video);
+
+        $metadataMap = [
+            'gps_altitude' => 'GPS Altitude',
+            'distance_to_ground' => 'Distance to ground',
+            'yaw' => 'Yaw/Heading',
+            'area' => 'Area',
+        ];
+
+        return view('volumes.videos.index', [
+            'video' => $video,
+            'volume' => $video->volume,
+            'metadata' => Arr::only($video->metadata, array_keys($metadataMap)),
+            'metadataMap' => $metadataMap,
+        ]);
+    }
+}

--- a/app/Http/Requests/StoreVideoAnnotation.php
+++ b/app/Http/Requests/StoreVideoAnnotation.php
@@ -41,6 +41,8 @@ class StoreVideoAnnotation extends FormRequest
                 'required_unless:shape_id,'.Shape::wholeFrameId(),
                 'array',
             ],
+            'points.*' => 'array',
+            'points.*.*' => 'numeric',
             'frames' => 'required|array',
             'frames.*' => 'required|numeric|min:0|max:'.$this->video->duration,
             'track' => 'filled|boolean',
@@ -67,18 +69,13 @@ class StoreVideoAnnotation extends FormRequest
                 $validator->errors()->add('frames', 'A new whole frame annotation must not have more than two frames.');
             }
 
-            $points = $this->input('points', []);
-            $allArrays = array_reduce($points, fn ($c, $i) => $c && is_array($i), true);
-
-            if (!$allArrays) {
-                $validator->errors()->add('points', 'The points must be an array of arrays.');
-            }
 
             if ($this->shouldTrack()) {
                 if ($frameCount !== 1) {
                     $validator->errors()->add('id', 'Only single frame annotations can be tracked.');
                 }
 
+                $points = $this->input('points', []);
                 if (count($points) !== 1) {
                     $validator->errors()->add('id', 'Only single frame annotations can be tracked.');
                 }

--- a/resources/assets/js/volumes/components/metadataModal.vue
+++ b/resources/assets/js/volumes/components/metadataModal.vue
@@ -1,0 +1,76 @@
+<template>
+    <modal
+        id="modal-show-metadata"
+        ref="modal"
+        v-model="show"
+        size="lg"
+        :title="name"
+        :footer="false"
+        >
+        <div class="panel panel-default table-responsive">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th v-for="time in times">{{ time }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr v-if="items">
+                        <td v-for="item in items">{{ item }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </modal>
+</template>
+
+<script>
+import { Modal } from 'uiv';
+
+export default {
+    components: {
+        modal: Modal,
+    },
+    props: {
+        showModal: {
+            required: true,
+            type: Boolean,
+        },
+        times: {
+            required: true,
+            type: Array,
+        },
+        items: {
+            required: true,
+            type: Array,
+        },
+        name: {
+            required: true,
+            type: String,
+        },
+    },
+    data() {
+        return {
+            show: false,
+        };
+    },
+    watch: {
+        // if volume-metadata-button pressed, trigger modal
+        showModal: function () {
+            if (this.showModal) {
+                this.show = true;
+            }
+        },
+        // if modal is closed, trigger the close-modal-event, which sets 'showModal' in parent container to false again
+        show: function() {
+            if (this.show === false) {
+                this.$emit('close-modal');
+            }
+        }
+    },
+    created() {
+        this.show = false;
+        this.$emit('load-modal');
+    }
+}
+</script>

--- a/resources/assets/js/volumes/components/metadataModal.vue
+++ b/resources/assets/js/volumes/components/metadataModal.vue
@@ -1,22 +1,28 @@
 <template>
     <modal
-        id="modal-show-metadata"
         ref="modal"
         v-model="show"
-        size="lg"
+        size="sm"
         :title="name"
         :footer="false"
         >
-        <div class="panel panel-default table-responsive">
+        <div class="panel panel-default">
             <table class="table">
                 <thead>
                     <tr>
-                        <th v-for="time in times">{{ time }}</th>
+                        <th class="text-center" v-if="times">{{ "Time" }}</th>
+                        <th class="text-center" v-if="name !== 'Times'">{{ name }}</th>
                     </tr>
                 </thead>
-                <tbody>
-                    <tr v-if="items">
-                        <td v-for="item in items">{{ item }}</td>
+                <tbody v-if="name === 'Times'">
+                    <tr v-for="time in times">
+                        <td class="text-center">{{ time }}</td>
+                    </tr>
+                </tbody>
+                <tbody v-else-if="times.length === items.length">
+                    <tr v-for="(item, index) in items">
+                        <td class="text-center">{{ times[index] }}</td>
+                        <td class="text-center">{{ item }}</td>
                     </tr>
                 </tbody>
             </table>
@@ -70,7 +76,6 @@ export default {
     },
     created() {
         this.show = false;
-        this.$emit('load-modal');
     }
 }
 </script>

--- a/resources/assets/js/volumes/components/metadataModal.vue
+++ b/resources/assets/js/volumes/components/metadataModal.vue
@@ -2,7 +2,7 @@
     <modal
         ref="modal"
         v-model="show"
-        size="sm"
+        size="md"
         :title="name"
         :footer="false"
         >

--- a/resources/assets/js/volumes/main.js
+++ b/resources/assets/js/volumes/main.js
@@ -14,7 +14,7 @@ import MetadataUpload from './metadataUpload';
 import ProjectsBreadcrumb from './projectsBreadcrumb';
 import SearchResults from './searchResults';
 import VolumeContainer from './volumeContainer';
-import VolumeMetadata from './volumeMetadata.vue';
+import VideoMetadata from './videoMetadata.vue';
 
 biigle.$mount('annotation-session-panel', AnnotationSessionPanel);
 biigle.$mount('create-volume-form-step-1', CreateFormStep1);
@@ -31,4 +31,4 @@ biigle.$mount('search-results', SearchResults);
 biigle.$mount('volume-container', VolumeContainer);
 biigle.$mount('volume-file-count', FileCount);
 biigle.$mount('volume-metadata-upload', MetadataUpload);
-biigle.$mount('volume-metadata-modal', VolumeMetadata);
+biigle.$mount('video-metadata-modal', VideoMetadata);

--- a/resources/assets/js/volumes/main.js
+++ b/resources/assets/js/volumes/main.js
@@ -14,6 +14,7 @@ import MetadataUpload from './metadataUpload';
 import ProjectsBreadcrumb from './projectsBreadcrumb';
 import SearchResults from './searchResults';
 import VolumeContainer from './volumeContainer';
+import VolumeMetadata from './volumeMetadata.vue';
 
 biigle.$mount('annotation-session-panel', AnnotationSessionPanel);
 biigle.$mount('create-volume-form-step-1', CreateFormStep1);
@@ -30,3 +31,4 @@ biigle.$mount('search-results', SearchResults);
 biigle.$mount('volume-container', VolumeContainer);
 biigle.$mount('volume-file-count', FileCount);
 biigle.$mount('volume-metadata-upload', MetadataUpload);
+biigle.$mount('volume-metadata-modal', VolumeMetadata);

--- a/resources/assets/js/volumes/videoMetadata.vue
+++ b/resources/assets/js/volumes/videoMetadata.vue
@@ -47,8 +47,6 @@ export default {
             this.showModal = true;
         },
         hideMetadataModal() {
-            // reset items for next metadata
-            this.items = [];
             this.showModal = false;
         },
         handleError(message) {

--- a/resources/assets/js/volumes/videoMetadata.vue
+++ b/resources/assets/js/volumes/videoMetadata.vue
@@ -16,6 +16,8 @@ export default {
     data() {
         return {
             showModal: false,
+            metadata: null,
+            metadataMap: {},
             times: [],
             items: [],
             name: "",
@@ -39,9 +41,9 @@ export default {
             this.name = "Times";
             this.showModal = true;
         },
-        getMetadata(key, data) {
-            this.name = key;
-            this.items = data;
+        showMetadata(field) {
+            this.name = this.metadataMap[field];
+            this.items = this.metadata[field];
             this.showModal = true;
         },
         hideMetadataModal() {
@@ -53,5 +55,10 @@ export default {
             Messages.danger(message);
         },
     },
+    created() {
+        this.getTimes(biigle.$require('videos.times'));
+        this.metadata = biigle.$require('videos.metadata');
+        this.metadataMap = biigle.$require('videos.metadataMap');
+    }
 };
 </script>

--- a/resources/assets/js/volumes/volumeMetadata.vue
+++ b/resources/assets/js/volumes/volumeMetadata.vue
@@ -1,0 +1,57 @@
+<script>
+import LoaderMixin from '../core/mixins/loader';
+import Messages from '../core/messages/store';
+import metadataModal from './components/metadataModal';
+
+/**
+ * The video container for metadata.
+ */
+export default {
+    mixins: [
+        LoaderMixin,
+    ],
+    components: {
+        metadataModal: metadataModal,
+    },
+    data() {
+        return {
+            showModal: false,
+            times: [],
+            items: [],
+            name: "",
+        };
+    },
+    methods: {
+        getTimes(values) {
+            // If modal has been opened before, use cached data
+            if (this.times.length === 0) {
+                let dateStrings = [];
+                const options = { year: "numeric", month: "numeric", day: "numeric", hour: '2-digit', minute:'2-digit', second:'2-digit'}
+                values.forEach(element => {
+                    dateStrings.push(new Date(element).toLocaleDateString(undefined, options));
+                });
+                this.times = dateStrings;
+            }
+        },
+        showTimes() {
+            if (this.times.length === 0)
+                this.handleError("No times data found.");
+            this.name = "Times";
+            this.showModal = true;
+        },
+        getMetadata(key, data) {
+            this.name = key;
+            this.items = data;
+            this.showModal = true;
+        },
+        hideMetadataModal() {
+            // reset items for next metadata
+            this.items = [];
+            this.showModal = false;
+        },
+        handleError(message) {
+            Messages.danger(message);
+        },
+    },
+};
+</script>

--- a/resources/views/search/videos-content.blade.php
+++ b/resources/views/search/videos-content.blade.php
@@ -3,7 +3,7 @@
 <ul id="search-results" class="row volume-search-results">
     @foreach ($results as $video)
         <li class="col-xs-4">
-            <a href="{{route('video', $video->id)}}" title="Show video {{$video->filename}}">
+            <a href="{{route('video-annotate', $video->id)}}" title="Show video {{$video->filename}}">
                 <preview-thumbnail class="preview-thumbnail" :id="{{$video->id}}" thumb-uris="{{$video->thumbnailsUrl->implode(',')}}">
                     <img src="{{ $video->thumbnailUrl }}" onerror="this.src='{{ asset(config('thumbnails.empty_url')) }}'">
                     <figcaption slot="caption">{{$video->filename}}</figcaption>

--- a/resources/views/videos/dashboardActivityItem.blade.php
+++ b/resources/views/videos/dashboardActivityItem.blade.php
@@ -1,4 +1,4 @@
-<a class="activity-item" href="{{route('video', $item->id)}}" title="Show video {{$item->name}}">
+<a class="activity-item" href="{{route('video-annotate', $item->id)}}" title="Show video {{$item->name}}">
     <figure class="activity-item-image">
         <i class="icon fas fa-film fa-lg"></i>
         <img src="{{ $item->thumbnailUrl }}" onerror="this.src='{{ asset(config('thumbnails.empty_url')) }}'">

--- a/resources/views/volumes/show.blade.php
+++ b/resources/views/volumes/show.blade.php
@@ -16,8 +16,8 @@
             biigle.$declare('volumes.infoUri', '{{ route('image', ':id') }}');
         @else
             biigle.$declare('volumes.thumbCount', {{ config('videos.thumbnail_count') }});
-            biigle.$declare('volumes.annotateUri', '{{ route('video', ':id') }}');
-            biigle.$declare('volumes.infoUri', undefined);
+            biigle.$declare('volumes.annotateUri', '{{ route('video-annotate', ':id') }}');
+            biigle.$declare('volumes.infoUri', '{{ route('video', ':id') }}');
         @endif
 
         biigle.$declare('volumes.userId', {!! $user->id !!});

--- a/resources/views/volumes/videos/index.blade.php
+++ b/resources/views/volumes/videos/index.blade.php
@@ -1,0 +1,33 @@
+@extends('app')
+@section('title', $video->filename)
+
+@section('content')
+<div class="container">
+    <div class="row">
+        <h2 class="col-lg-12 clearfix file-info-title" title="{{ $video->filename }}">
+            {{ $video->filename }}
+            <span class="pull-right">
+                <a href="{{route('volume', $volume->id)}}" title="Back to {{ $volume->name }}" class="btn btn-default">back</a>
+                @mixin('imagesIndexButtons')
+            </span>
+        </h2>
+    </div>
+    <div class="row">
+        <div class="col-sm-6 col-lg-4">
+            <div class="panel panel-default panel-image">
+                <img src="{{ $video->thumbnail_url }}" onerror="this.src='{{ asset(config('thumbnails.empty_url')) }}'">
+            </div>
+            @include('volumes.videos.index.meta')
+        </div>
+    </div>
+</div>
+@endsection
+
+@section('navbar')
+<div class="navbar-text navbar-volumes-breadcrumbs">
+    @include('volumes.partials.projectsBreadcrumb', ['projects' => $volume->projects]) /
+    <a href="{{route('volume', $volume->id)}}" class="navbar-link" title="Show volume {{$volume->name}}">{{$volume->name}}</a> /
+    <strong title="{{$video->filename}}">{{$video->filename}}</strong>
+    @include('volumes.partials.annotationSessionIndicator')
+</div>
+@endsection

--- a/resources/views/volumes/videos/index/meta.blade.php
+++ b/resources/views/volumes/videos/index/meta.blade.php
@@ -1,0 +1,49 @@
+<div class="panel panel-default table-responsive">
+    <div class="panel-heading">
+        <h3 class="panel-title">Video information</h3>
+    </div>
+    <table class="table">
+        @if ($video->width && $video->height)
+            <tr>
+                <th>Dimensions</th>
+                <td>{{ $video->width }} &times; {{ $video->height }} px </td>
+            </tr>
+        @endif
+        @if ($video->size)
+            <tr>
+                <th>Size</th>
+                <td>{{ round($video->size / 1E+6, 2) }} MBytes </td>
+            </tr>
+        @endif
+        @if ($video->mimetype)
+            <tr>
+                <th>MIME</th>
+                <td><code>{{ $video->mimetype }}</code></td>
+            </tr>
+        @endif
+        @if ($video->taken_at)
+            <tr>
+                <th>Created</th>
+                @if (is_array($video->taken_at))
+                    @foreach ($video->taken_at as $value)
+                        <td>{{ $value }}</td>
+                    @endforeach
+                @else
+                    <td>{{ $video->taken_at }}</td>
+                @endif
+            </tr>
+        @endif
+        @foreach ($metadata as $key => $field)
+            <tr>
+                <th>{{ $metadataMap[$key] }}</th>
+                @if (is_array($field))
+                    @foreach ($field as $value)
+                        <td>{{ $value }}</td>
+                    @endforeach
+                @else
+                    <td>{{ $value }}</td>
+                @endif
+            </tr>
+        @endforeach
+    </table>
+</div>

--- a/resources/views/volumes/videos/index/meta.blade.php
+++ b/resources/views/volumes/videos/index/meta.blade.php
@@ -34,7 +34,7 @@
                 <metadata-modal v-bind:show-modal="showModal" v-bind:times="times" v-bind:items="items" v-bind:name="name" v-on:close-modal="hideMetadataModal"></metadata-modal>
                 <tr>
                     <th>
-                        <a class="btn-link" v-on:click.prevent="showTimes()">Created</a>
+                        <a href="#" v-on:click.prevent="showTimes()">Created</a>
                     </th>
                     <td></td>
                 </tr>
@@ -42,7 +42,7 @@
                     <tr>
                     @if (is_array($value))
                         <th>
-                            <a class="btn-link" v-on:click.prevent="showMetadata({{ json_encode($field) }})">{{ $metadataMap[$field] }}</a>
+                            <a href="#" v-on:click.prevent="showMetadata({{ json_encode($field) }})">{{ $metadataMap[$field] }}</a>
                         </th>
                         <td></td>
                     @else

--- a/resources/views/volumes/videos/index/meta.blade.php
+++ b/resources/views/volumes/videos/index/meta.blade.php
@@ -1,4 +1,4 @@
-<div class="panel panel-default table-responsive">
+<div id="volume-metadata-modal" class="panel panel-default">
     <div class="panel-heading">
         <h3 class="panel-title">Video information</h3>
     </div>
@@ -22,28 +22,38 @@
             </tr>
         @endif
         @if ($video->taken_at)
-            <tr>
-                <th>Created</th>
-                @if (is_array($video->taken_at))
-                    @foreach ($video->taken_at as $value)
-                        <td>{{ $value }}</td>
-                    @endforeach
-                @else
+            @if (is_array($video->taken_at))
+                <metadata-modal v-bind:show-modal="showModal" v-bind:times="times" v-bind:items="items" v-bind:name="name" v-on:load-modal="getTimes({{ collect($video->taken_at) }})" v-on:close-modal="hideMetadataModal"></metadata-modal>
+                <tr>
+                    <th>Created</th>
+                    <td>
+                        <button class="btn btn-default" type="button" title="Show full timestamps" v-on:click.prevent="showTimes()">Show values</button>
+                    </td>
+                </tr>
+                @foreach ($metadata as $field => $value)
+                    <tr>
+                        <th>{{ $metadataMap[$field] }}</th>
+                        @if (is_array($value))
+                            <td>
+                                <button class="btn btn-default" type="button" title="Show full metadata array" v-on:click.prevent="getMetadata({{ json_encode($metadataMap[$field]) }}, {{ collect($value) }})">Show values</button>
+                            </td>
+                        @else
+                            <td>{{ $value }}</td>
+                        @endif
+                    </tr>
+                @endforeach
+            @else
+                <tr>
+                    <th>Created</th>
                     <td>{{ $video->taken_at }}</td>
-                @endif
-            </tr>
-        @endif
-        @foreach ($metadata as $key => $field)
-            <tr>
-                <th>{{ $metadataMap[$key] }}</th>
-                @if (is_array($field))
-                    @foreach ($field as $value)
+                </tr>
+                @foreach ($metadata as $field => $value)
+                    <tr>
+                        <th>{{ $metadataMap[$field] }}</th>
                         <td>{{ $value }}</td>
-                    @endforeach
-                @else
-                    <td>{{ $value }}</td>
-                @endif
-            </tr>
-        @endforeach
+                    </tr>
+                @endforeach
+            @endif
+        @endif
     </table>
 </div>

--- a/resources/views/volumes/videos/index/meta.blade.php
+++ b/resources/views/volumes/videos/index/meta.blade.php
@@ -1,4 +1,12 @@
-<div id="volume-metadata-modal" class="panel panel-default">
+@push('scripts')
+   <script type="text/javascript">
+        biigle.$declare('videos.times', {!! collect($video->taken_at) !!});
+        biigle.$declare('videos.metadata', {!! collect($video->metadata) !!});
+        biigle.$declare('videos.metadataMap', {!! collect($metadataMap) !!});
+   </script>
+@endpush
+
+<div id="video-metadata-modal" class="panel panel-default">
     <div class="panel-heading">
         <h3 class="panel-title">Video information</h3>
     </div>
@@ -23,23 +31,24 @@
         @endif
         @if ($video->taken_at)
             @if (is_array($video->taken_at))
-                <metadata-modal v-bind:show-modal="showModal" v-bind:times="times" v-bind:items="items" v-bind:name="name" v-on:load-modal="getTimes({{ collect($video->taken_at) }})" v-on:close-modal="hideMetadataModal"></metadata-modal>
+                <metadata-modal v-bind:show-modal="showModal" v-bind:times="times" v-bind:items="items" v-bind:name="name" v-on:close-modal="hideMetadataModal"></metadata-modal>
                 <tr>
-                    <th>Created</th>
-                    <td>
-                        <button class="btn btn-default" type="button" title="Show full timestamps" v-on:click.prevent="showTimes()">Show values</button>
-                    </td>
+                    <th>
+                        <a class="btn-link" v-on:click.prevent="showTimes()">Created</a>
+                    </th>
+                    <td></td>
                 </tr>
                 @foreach ($metadata as $field => $value)
                     <tr>
+                    @if (is_array($value))
+                        <th>
+                            <a class="btn-link" v-on:click.prevent="showMetadata({{ json_encode($field) }})">{{ $metadataMap[$field] }}</a>
+                        </th>
+                        <td></td>
+                    @else
                         <th>{{ $metadataMap[$field] }}</th>
-                        @if (is_array($value))
-                            <td>
-                                <button class="btn btn-default" type="button" title="Show full metadata array" v-on:click.prevent="getMetadata({{ json_encode($metadataMap[$field]) }}, {{ collect($value) }})">Show values</button>
-                            </td>
-                        @else
-                            <td>{{ $value }}</td>
-                        @endif
+                        <td>{{ $value }}</td>
+                    @endif
                     </tr>
                 @endforeach
             @else

--- a/routes/web.php
+++ b/routes/web.php
@@ -358,9 +358,6 @@ $router->group(['namespace' => 'Views', 'middleware' => 'auth'], function ($rout
             'as'   => 'show-video-annotation',
             'uses' => 'VideoAnnotationController@show',
         ]);
-
-        // Legacy support.
-        $router->redirect('video-annotate/{id}', '/videos/{id}/annotations');
     });
 
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -343,9 +343,14 @@ $router->group(['namespace' => 'Views', 'middleware' => 'auth'], function ($rout
         $router->redirect('annotations/{id}', '/image-annotations/{id}');
     });
 
+    $router->get('videos/{id}', [
+        'as'   => 'video',
+        'uses' => 'Volumes\VideoController@index',
+    ]);
+
     $router->group(['namespace' => 'Videos'], function ($router) {
         $router->get('videos/{id}/annotations', [
-            'as' => 'video',
+            'as' => 'video-annotate',
             'uses' => 'VideoController@show',
         ]);
 
@@ -355,7 +360,7 @@ $router->group(['namespace' => 'Views', 'middleware' => 'auth'], function ($rout
         ]);
 
         // Legacy support.
-        $router->redirect('videos/{id}', '/videos/{id}/annotations');
+        $router->redirect('video-annotate/{id}', '/videos/{id}/annotations');
     });
 
 });

--- a/tests/php/Http/Controllers/Api/VideoAnnotationControllerTest.php
+++ b/tests/php/Http/Controllers/Api/VideoAnnotationControllerTest.php
@@ -356,6 +356,19 @@ class VideoAnnotationControllerTest extends ApiTestCase
             ->assertStatus(422);
     }
 
+    public function testStoreValidatePointsArray2()
+    {
+        $this->beEditor();
+        $this
+            ->postJson("/api/v1/videos/{$this->video->id}/annotations", [
+                'shape_id' => Shape::pointId(),
+                'label_id' => $this->labelRoot()->id,
+                'points' => [[[10, 11]]],
+                'frames' => [0.0],
+            ])
+            ->assertStatus(422);
+    }
+
     public function testStoreValidateFrames()
     {
         $this->beEditor();

--- a/tests/php/Http/Controllers/Views/Videos/VideoControllerTest.php
+++ b/tests/php/Http/Controllers/Views/Videos/VideoControllerTest.php
@@ -20,10 +20,4 @@ class VideoControllerTest extends ApiTestCase
         $this->beGuest();
         $this->get("videos/{$video->id}/annotations")->assertStatus(200);
     }
-
-    public function testShowRedirect()
-    {
-        $this->beUser();
-        $this->get('videos/999')->assertRedirect('/videos/999/annotations');
-    }
 }

--- a/tests/php/Http/Controllers/Views/Volumes/VideoInfoControllerTest.php
+++ b/tests/php/Http/Controllers/Views/Volumes/VideoInfoControllerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Biigle\Tests\Http\Controllers\Views\Volumes;
+
+use Biigle\Tests\ProjectTest;
+use Biigle\Tests\UserTest;
+use Biigle\Tests\VideoTest;
+use TestCase;
+
+class VideoInfoControllerTest extends TestCase
+{
+    public function testIndex()
+    {
+        $project = ProjectTest::create();
+        $user = UserTest::create();
+        $video = VideoTest::create();
+        $project->addVolumeId($video->volume->id);
+
+        // not logged in
+        $response = $this->get('videos/'.$video->id);
+        $response->assertStatus(302);
+
+        // doesn't belong to project
+        $this->be($user);
+        $response = $this->get('videos/'.$video->id);
+        $response->assertStatus(403);
+
+        $this->be($project->creator);
+        $response = $this->get('videos/'.$video->id);
+        $response->assertStatus(200);
+
+        // doesn't exist
+        $response = $this->get('videos/-1');
+        $response->assertStatus(404);
+    }
+}


### PR DESCRIPTION
As stated in [Footprint / laser point detection for videos #70](https://github.com/biigle/laserpoints/issues/70), we would like to add a new info view for videos, as for images, with metadata and, later, computed laser points info.  