### PR TITLE
Fix issue with report CSV line count

### DIFF
--- a/app/Services/Reports/File.php
+++ b/app/Services/Reports/File.php
@@ -94,7 +94,7 @@ class File
     public function put($content)
     {
         if (is_string($content)) {
-            return fwrite($this->handle, $content);
+            return fwrite($this->handle, $content."\n");
         }
     }
 }

--- a/app/Services/Reports/Volumes/ImageAnnotations/AnnotationLocationReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageAnnotations/AnnotationLocationReportGenerator.php
@@ -143,7 +143,7 @@ class AnnotationLocationReportGenerator extends AnnotationReportGenerator
             $geometry = $this->estimateAnnotationPosition($item);
 
             $feature = new Feature($geometry, $properties);
-            $file->put(json_encode($feature)."\n");
+            $file->put(json_encode($feature));
         });
         $file->close();
 

--- a/app/Services/Reports/Volumes/ImageAnnotations/ImageLocationReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageAnnotations/ImageLocationReportGenerator.php
@@ -138,7 +138,7 @@ class ImageLocationReportGenerator extends AnnotationReportGenerator
             }
 
             $feature = new Feature(new Point([$image->lng, $image->lat]), $properties);
-            $file->put(json_encode($feature)."\n");
+            $file->put(json_encode($feature));
         });
         $file->close();
 

--- a/app/Services/Reports/Volumes/ImageLabels/ImageLocationReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageLabels/ImageLocationReportGenerator.php
@@ -151,7 +151,7 @@ class ImageLocationReportGenerator extends VolumeReportGenerator
             }
 
             $feature = new Feature(new Point([$image->lng, $image->lat]), $properties);
-            $file->put(json_encode($feature)."\n");
+            $file->put(json_encode($feature));
         });
         $file->close();
 

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationLocationReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationLocationReportGeneratorTest.php
@@ -89,7 +89,7 @@ class AnnotationLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $mock->shouldReceive('close')
             ->once();
@@ -175,7 +175,7 @@ class AnnotationLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $mock->shouldReceive('close')
             ->once();
@@ -263,7 +263,7 @@ class AnnotationLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $mock->shouldReceive('close')
             ->once();
@@ -353,7 +353,7 @@ class AnnotationLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $mock->shouldReceive('close')
             ->once();
@@ -473,7 +473,7 @@ class AnnotationLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $jsonContent['properties']['_id'] = $al2->id;
         $jsonContent['properties']['_label_name'] = $label2->name;
@@ -481,7 +481,7 @@ class AnnotationLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $mock->shouldReceive('close')
             ->twice();
@@ -577,7 +577,7 @@ class AnnotationLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $jsonContent['properties']['_id'] = $al2->id;
         $jsonContent['properties']['_label_name'] = $al2->label->name;
@@ -585,7 +585,7 @@ class AnnotationLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $mock->shouldReceive('close')
             ->twice();

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/ImageLocationReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/ImageLocationReportGeneratorTest.php
@@ -73,7 +73,7 @@ class ImageLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $mock->shouldReceive('close')
             ->once();
@@ -180,7 +180,7 @@ class ImageLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $jsonContent = [
             'type' => 'Feature',
@@ -197,7 +197,7 @@ class ImageLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $mock->shouldReceive('close')
             ->twice();
@@ -280,7 +280,7 @@ class ImageLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $jsonContent = [
             'type' => 'Feature',
@@ -298,7 +298,7 @@ class ImageLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $mock->shouldReceive('close')
             ->twice();

--- a/tests/php/Services/Reports/Volumes/ImageLabels/ImageLocationReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageLabels/ImageLocationReportGeneratorTest.php
@@ -66,7 +66,7 @@ class ImageLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $mock->shouldReceive('close')
             ->once();
@@ -171,7 +171,7 @@ class ImageLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $jsonContent = [
             'type' => 'Feature',
@@ -188,7 +188,7 @@ class ImageLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $mock->shouldReceive('close')
             ->twice();
@@ -267,7 +267,7 @@ class ImageLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $jsonContent = [
             'type' => 'Feature',
@@ -285,7 +285,7 @@ class ImageLocationReportGeneratorTest extends TestCase
 
         $mock->shouldReceive('put')
             ->once()
-            ->with(json_encode($jsonContent)."\n");
+            ->with(json_encode($jsonContent));
 
         $mock->shouldReceive('close')
             ->twice();


### PR DESCRIPTION
There was a regression where putCsv() was replaced by put() but the latter did not add a line break. This got noticed when an abundance report was requested for a volume with a single image. Since the volume title was not separated by the column titles with a newline, the CSV ended up with only two rows. The Python script assumed it to be empty.

See: https://github.com/biigle/core/commit/9f2f3957d302ccd4bc0e10bbf79b8ea26e4011e7