### PR TITLE
Implement more efficient volume URL check

### DIFF
--- a/app/Rules/VolumeUrl.php
+++ b/app/Rules/VolumeUrl.php
@@ -138,7 +138,11 @@ class VolumeUrl implements Rule
             return false;
         }
 
-        if (empty($disk->files($url[1])) && empty($disk->directories($url[1]))) {
+        // Access the adapter directly to check for contents without loading the full
+        // file/directory listing.
+        $generator = $disk->getAdapter()->listContents($url[1], false);
+
+        if ($generator->current() === null) {
             $this->message = "Unable to access '{$url[1]}'. Does it exist and you have access permissions?";
 
             return false;

--- a/app/Rules/VolumeUrl.php
+++ b/app/Rules/VolumeUrl.php
@@ -140,9 +140,14 @@ class VolumeUrl implements Rule
 
         // Access the adapter directly to check for contents without loading the full
         // file/directory listing.
-        $generator = $disk->getAdapter()->listContents($url[1], false);
+        $iterable = $disk->getAdapter()->listContents($url[1], false);
+        $hasContent = false;
+        foreach ($iterable as $item) {
+            $hasContent = true;
+            break;
+        }
 
-        if ($generator->current() === null) {
+        if (!$hasContent) {
             $this->message = "Unable to access '{$url[1]}'. Does it exist and you have access permissions?";
 
             return false;


### PR DESCRIPTION
The previous method loaded all files and dorectories in the specified path. This could run into the memory limit if there were lots of files. The new method uses a generator and checks only a single file.