### PR TITLE
Update publish migration behavior

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -61,7 +61,7 @@ return [
 
     'migrations' => [
         'table' => 'migrations',
-        'update_date_on_publish' => true,
+        'update_date_on_publish' => false,
     ],
 
     /*


### PR DESCRIPTION
There was a case with a custom instance that uses Laravel Pulse. The migration date was updated each time on build and the app thought that it was a new migration each time. This behavior does not seem to be useful here, so it is disabled.