### PR TITLE
Add a file filter using a comma-separated list for volume cloning

### DIFF
--- a/resources/views/volumes/clone.blade.php
+++ b/resources/views/volumes/clone.blade.php
@@ -74,7 +74,7 @@
                                        v-on:keydown.enter="loadFilesMatchingPattern">
                             @endif
                             <span class="help-block">
-                                Filter by using a list of comma-separated file names or pattern that matches specific file names. A pattern may contain the wildcard character * that matches any string of zero or more characters
+                                Filter by using a list of comma-separated file names or a pattern that matches specific file names. A pattern may contain the wildcard character * that matches any string of zero or more characters
                             </span>
                             <div class="volume-files-panel">
                                 <ul class="list-group files-list">

--- a/resources/views/volumes/clone.blade.php
+++ b/resources/views/volumes/clone.blade.php
@@ -74,7 +74,7 @@
                                        v-on:keydown.enter="loadFilesMatchingPattern">
                             @endif
                             <span class="help-block">
-                                Filter by using a pattern that matches specific file names. A pattern may contain the wildcard character * that matches any string of zero or more characters
+                                Filter by using a list of comma-separated file names or pattern that matches specific file names. A pattern may contain the wildcard character * that matches any string of zero or more characters
                             </span>
                             <div class="volume-files-panel">
                                 <ul class="list-group files-list">

--- a/tests/php/Http/Controllers/Api/Volumes/Filters/FilenameControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Volumes/Filters/FilenameControllerTest.php
@@ -114,4 +114,55 @@ class FilenameControllerTest extends ApiTestCase
             ->assertSimilarJson([$video->id, $video2->id, $video3->id]);
         $response->assertStatus(200);
     }
+
+    public function testIndexCommaSeparatedImageFilenames()
+    {
+        $img = $this->volume()->id;
+
+        $image = ImageTest::create([
+            'volume_id' => $img,
+            'filename' => 'a.jpg',
+        ]);
+        $image2 = ImageTest::create([
+            'volume_id' => $img,
+            'filename' => 'b.jpg',
+        ]);
+
+        $this->beGuest();
+        $response = $this->json('GET', "/api/v1/volumes/{$img}/files/filter/filename/a.jpg")
+            ->assertExactJson([$image->id]);
+        $response->assertStatus(200);
+
+        $response = $this->json('GET', "/api/v1/volumes/{$img}/files/filter/filename/a.jpg%2Cb.jpg")
+            ->assertExactJson([$image->id, $image2->id]);
+        $response->assertStatus(200);
+
+        $response = $this->json('GET', "/api/v1/volumes/{$img}/files/filter/filename/%2C%2C%20%20a.jpg%2Cb.jpg%20")
+            ->assertExactJson([$image->id, $image2->id]);
+        $response->assertStatus(200);
+    }
+
+    public function testIndexCommaSeparatedVideoFilenames()
+    {
+        $vid = $this->volume(['media_type_id' => MediaType::videoId()])->id;
+
+        $video = VideoTest::create([
+            'volume_id' => $vid,
+            'filename' => 'a.mp4',
+        ]);
+        $video2 = VideoTest::create([
+            'volume_id' => $vid,
+            'filename' => 'b.mp4',
+        ]);
+
+        $this->beGuest();
+
+        $response = $this->json('GET', "/api/v1/volumes/{$vid}/files/filter/filename/a.mp4%2Cb.mp4")
+            ->assertExactJson([$video->id, $video2->id]);
+        $response->assertStatus(200);
+
+        $response = $this->json('GET', "/api/v1/volumes/{$vid}/files/filter/filename/%2C%2C%20%20a.mp4%2Cb.mp4%20")
+            ->assertExactJson([$video->id, $video2->id]);
+        $response->assertStatus(200);
+    }
 }


### PR DESCRIPTION
When cloning volumes, the selected files can be filtered using a comma-separated list.

Closes #1052.