### PR TITLE
Pie chart HSL value format

### DIFF
--- a/resources/assets/js/projects/components/charts/IDToColor.js
+++ b/resources/assets/js/projects/components/charts/IDToColor.js
@@ -16,6 +16,5 @@ export function IDToColor(id) {
     const hue = id % 360;
     const saturation = 70 + (id % 31); // Ensure saturation is between 70 and 100
     const lightness = 70 + (id % 21);  // Ensure lightness is between 70 and 90
-
-    return `hsl(${hue} ${saturation}% ${lightness}%)`;
+    return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
 }


### PR DESCRIPTION
Using comma-separated HSL values to generate unique colors for IDs instead of space-separated ones. Although both formats should be supported ([hsl](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl)), the space-separated format causes flickering when hovering over the pie chart. Fixes #1006.