### PR TITLE
Extend abundance report

### DIFF
--- a/app/Services/Reports/Volumes/ImageAnnotations/AbundanceReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageAnnotations/AbundanceReportGenerator.php
@@ -88,15 +88,7 @@ class AbundanceReportGenerator extends AnnotationReportGenerator
      */
     protected function query()
     {
-        $query = DB::table('image_annotation_labels')
-            ->join('image_annotations', 'image_annotation_labels.annotation_id', '=', 'image_annotations.id')
-            ->rightJoin('images', 'image_annotations.image_id', '=', 'images.id')
-            ->leftJoin('labels', 'image_annotation_labels.label_id', '=', 'labels.id')
-            ->where('images.volume_id', $this->source->id)
-            ->when($this->isRestrictedToAnnotationSession(), [$this, 'restrictToAnnotationSessionQuery'])
-            ->when($this->isRestrictedToNewestLabel(), fn($query) => $this->restrictToNewestLabelQuery($query, $this->source))
-            ->when($this->isRestrictedToLabels(), fn($query) => $this->restrictToLabelsQuery($query, 'image_annotation_labels'))
-            ->orWhereNull('labels.id')
+        $query = $this->initQuery()
             ->orderBy('images.filename')
             ->select(DB::raw('images.filename, image_annotation_labels.label_id, count(image_annotation_labels.label_id) as count'))
             ->groupBy('image_annotation_labels.label_id', 'images.id');

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationReportGeneratorTest.php
@@ -357,7 +357,7 @@ class AnnotationReportGeneratorTest extends TestCase
             'separateLabelTrees' => true
         ]);
         $generator->setSource($session->volume);
-        $results = $generator->initQuery(['label_tree_id'])->get();
+        $results = $generator->initQuery()->get();
         $this->assertCount(2, $results);
         $this->assertEquals($al2->label->label_tree_id, $results[0]->label_tree_id);
         $this->assertEquals($al4->label->label_tree_id, $results[1]->label_tree_id);
@@ -422,12 +422,215 @@ class AnnotationReportGeneratorTest extends TestCase
             'annotationSession' => $session->id,
             'newestLabel' => true,
             'onlyLabels' => [$al1->label_id, $al2->label_id, $al4->label_id, $al5->label_id],
-            'separateUser' => true
+            'separateUsers' => true
         ]);
         $generator->setSource($session->volume);
-        $results = $generator->initQuery(['user_id'])->get();
+        $results = $generator->initQuery()->get();
         $this->assertCount(2, $results);
         $this->assertEquals($al2->user_id, $results[0]->user_id);
         $this->assertEquals($al4->user_id, $results[1]->user_id);
+    }
+
+    public function testAnnotationSessionNewestLabel()
+    {
+        $volume = VolumeTest::create();
+        $userId = $volume->creator_id;
+        $image = ImageTest::create(['volume_id' => $volume->id]);
+
+        $session = AnnotationSessionTest::create([
+            'starts_at' => '2016-10-05',
+            'ends_at' => '2016-10-06',
+            'volume_id' => $volume->id
+        ]);
+
+        $session->users()->attach($userId);
+
+        $a = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+            'created_at' => '2016-10-05 09:15:00',
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        // Even if there are two labels created in the same second, we only want the
+        // newest one (as determined by the ID).
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        $al3 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-05 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al4 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-05 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al5 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-04 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $generator = new AnnotationReportGenerator([
+            'annotationSession' => $session->id,
+            'newestLabel' => true,
+        ]);
+        $generator->setSource($session->volume);
+        $results = $generator->initQuery(['image_annotation_labels.id'])->get();
+        $this->assertCount(3, $results);
+        $this->assertEquals($al2->id, $results[0]->id);
+        $this->assertEquals($al3->id, $results[1]->id);
+        $this->assertEquals($al4->id, $results[2]->id);
+    }
+
+    public function testAnnotationSessionNewestLabelSeparateLabelTree()
+    {
+        $volume = VolumeTest::create();
+        $userId = $volume->creator_id;
+        $image = ImageTest::create(['volume_id' => $volume->id]);
+
+        $session = AnnotationSessionTest::create([
+            'starts_at' => '2016-10-05',
+            'ends_at' => '2016-10-06',
+            'volume_id' => $volume->id
+        ]);
+
+        $session->users()->attach($userId);
+
+        $a = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+            'created_at' => '2016-10-05 09:15:00',
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        // Even if there are two labels created in the same second, we only want the
+        // newest one (as determined by the ID).
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        $al3 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-05 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al4 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-05 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al5 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-04 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $generator = new AnnotationReportGenerator([
+            'annotationSession' => $session->id,
+            'newestLabel' => true,
+            'separateLabelTrees' => true,
+        ]);
+        $generator->setSource($session->volume);
+        $results = $generator->initQuery()->get();
+        $this->assertCount(3, $results);
+        $this->assertEquals($al2->label->label_tree_id, $results[0]->label_tree_id);
+        $this->assertEquals($al3->label->label_tree_id, $results[1]->label_tree_id);
+        $this->assertEquals($al4->label->label_tree_id, $results[2]->label_tree_id);
+    }
+
+    public function testAnnotationSessionNewestLabelSeparateUser()
+    {
+        $volume = VolumeTest::create();
+        $userId = $volume->creator_id;
+        $image = ImageTest::create(['volume_id' => $volume->id]);
+
+        $session = AnnotationSessionTest::create([
+            'starts_at' => '2016-10-05',
+            'ends_at' => '2016-10-06',
+            'volume_id' => $volume->id
+        ]);
+
+        $session->users()->attach($userId);
+
+        $a = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+            'created_at' => '2016-10-05 09:15:00',
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        // Even if there are two labels created in the same second, we only want the
+        // newest one (as determined by the ID).
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        $al3 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-05 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al4 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-05 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al5 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-04 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $generator = new AnnotationReportGenerator([
+            'annotationSession' => $session->id,
+            'newestLabel' => true,
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($session->volume);
+        $results = $generator->initQuery()->get();
+        $this->assertCount(3, $results);
+        $this->assertEquals($al2->user_id, $results[0]->user_id);
+        $this->assertEquals($al3->user_id, $results[1]->user_id);
+        $this->assertEquals($al4->user_id, $results[2]->user_id);
     }
 }

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationReportGeneratorTest.php
@@ -836,4 +836,135 @@ class AnnotationReportGeneratorTest extends TestCase
         $this->assertEquals($al2->user_id, $results[1]->user_id);
         $this->assertEquals($al4->user_id, $results[2]->user_id);
     }
+
+    public function testNewestLabelRestrictedLabel()
+    {
+        $volume = VolumeTest::create();
+        $userId = $volume->creator_id;
+        $image = ImageTest::create(['volume_id' => $volume->id]);
+
+        $a = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        // Even if there are two labels created in the same second, we only want the
+        // newest one (as determined by the ID).
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        $al3 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create(['image_id' => $image->id,])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al4 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create(['image_id' => $image->id,])->id,
+            'user_id' => $userId,
+        ]);
+
+        $generator = new AnnotationReportGenerator([
+            'newestLabel' => true,
+            'onlyLabels' => [$al1->label_id, $al2->label_id, $al4->label_id]
+        ]);
+        $generator->setSource($volume);
+        $results = $generator->initQuery(['image_annotation_labels.id'])->get();
+        $this->assertCount(2, $results);
+        $this->assertEquals($al2->id, $results[0]->id);
+        $this->assertEquals($al4->id, $results[1]->id);
+    }
+
+    public function testNewestLabelRestrictedLabelSeparateLabelTrees()
+    {
+        $volume = VolumeTest::create();
+        $userId = $volume->creator_id;
+        $image = ImageTest::create(['volume_id' => $volume->id]);
+
+        $a = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        // Even if there are two labels created in the same second, we only want the
+        // newest one (as determined by the ID).
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        $al3 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create(['image_id' => $image->id,])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al4 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create(['image_id' => $image->id,])->id,
+            'user_id' => $userId,
+        ]);
+
+        $generator = new AnnotationReportGenerator([
+            'newestLabel' => true,
+            'onlyLabels' => [$al1->label_id, $al2->label_id, $al4->label_id],
+            'separateLabelTrees' => true
+        ]);
+        $generator->setSource($volume);
+        $results = $generator->initQuery()->get();
+        $this->assertCount(2, $results);
+        $this->assertEquals($al2->label->label_tree_id, $results[0]->label_tree_id);
+        $this->assertEquals($al4->label->label_tree_id, $results[1]->label_tree_id);
+    }
+
+    public function testNewestLabelRestrictedLabelSeparateUser()
+    {
+        $volume = VolumeTest::create();
+        $userId = $volume->creator_id;
+        $image = ImageTest::create(['volume_id' => $volume->id]);
+
+        $a = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        // Even if there are two labels created in the same second, we only want the
+        // newest one (as determined by the ID).
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        $al3 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create(['image_id' => $image->id,])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al4 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create(['image_id' => $image->id,])->id,
+            'user_id' => $userId,
+        ]);
+
+        $generator = new AnnotationReportGenerator([
+            'newestLabel' => true,
+            'onlyLabels' => [$al1->label_id, $al2->label_id, $al4->label_id],
+            'separateUsers' => true
+        ]);
+        $generator->setSource($volume);
+        $results = $generator->initQuery()->get();
+        $this->assertCount(2, $results);
+        $this->assertEquals($al2->user_id, $results[0]->user_id);
+        $this->assertEquals($al4->user_id, $results[1]->user_id);
+    }
 }

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationReportGeneratorTest.php
@@ -227,4 +227,207 @@ class AnnotationReportGeneratorTest extends TestCase
         $this->assertCount(1, $results);
         $this->assertSame($al1->id, $results[0]->id);
     }
+
+    public function testAnnotationSessionNewestLabelRestrictedLabel()
+    {
+        $volume = VolumeTest::create();
+        $userId = $volume->creator_id;
+        $image = ImageTest::create(['volume_id' => $volume->id]);
+
+        $session = AnnotationSessionTest::create([
+            'starts_at' => '2016-10-05',
+            'ends_at' => '2016-10-06',
+            'volume_id' => $volume->id
+        ]);
+
+        $session->users()->attach($userId);
+
+        $a = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+            'created_at' => '2016-10-05 09:15:00',
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        // Even if there are two labels created in the same second, we only want the
+        // newest one (as determined by the ID).
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        $al3 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-05 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al4 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-05 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al5 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-04 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $generator = new AnnotationReportGenerator([
+            'annotationSession' => $session->id,
+            'newestLabel' => true,
+            'onlyLabels' => [$al1->label_id, $al2->label_id, $al4->label_id, $al5->label_id]
+        ]);
+        $generator->setSource($session->volume);
+        $results = $generator->initQuery(['image_annotation_labels.id'])->get();
+        $this->assertCount(2, $results);
+        $this->assertEquals($al2->id, $results[0]->id);
+        $this->assertEquals($al4->id, $results[1]->id);
+    }
+
+    public function testAnnotationSessionNewestLabelRestrictedLabelSeparateLabelTrees()
+    {
+        $volume = VolumeTest::create();
+        $userId = $volume->creator_id;
+        $image = ImageTest::create(['volume_id' => $volume->id]);
+
+        $session = AnnotationSessionTest::create([
+            'starts_at' => '2016-10-05',
+            'ends_at' => '2016-10-06',
+            'volume_id' => $volume->id
+        ]);
+
+        $session->users()->attach($userId);
+
+        $a = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+            'created_at' => '2016-10-05 09:15:00',
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        // Even if there are two labels created in the same second, we only want the
+        // newest one (as determined by the ID).
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        $al3 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-05 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al4 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-05 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al5 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-04 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $generator = new AnnotationReportGenerator([
+            'annotationSession' => $session->id,
+            'newestLabel' => true,
+            'onlyLabels' => [$al1->label_id, $al2->label_id, $al4->label_id, $al5->label_id],
+            'separateLabelTrees' => true
+        ]);
+        $generator->setSource($session->volume);
+        $results = $generator->initQuery(['label_tree_id'])->get();
+        $this->assertCount(2, $results);
+        $this->assertEquals($al2->label->label_tree_id, $results[0]->label_tree_id);
+        $this->assertEquals($al4->label->label_tree_id, $results[1]->label_tree_id);
+    }
+
+    public function testAnnotationSessionNewestLabelRestrictedLabelSeparateUser()
+    {
+        $volume = VolumeTest::create();
+        $userId = $volume->creator_id;
+        $image = ImageTest::create(['volume_id' => $volume->id]);
+
+        $session = AnnotationSessionTest::create([
+            'starts_at' => '2016-10-05',
+            'ends_at' => '2016-10-06',
+            'volume_id' => $volume->id
+        ]);
+
+        $session->users()->attach($userId);
+
+        $a = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+            'created_at' => '2016-10-05 09:15:00',
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        // Even if there are two labels created in the same second, we only want the
+        // newest one (as determined by the ID).
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $a->id,
+            'user_id' => $userId,
+        ]);
+
+        $al3 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-05 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al4 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-05 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $al5 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-04 09:15:00',
+            ])->id,
+            'user_id' => $userId,
+        ]);
+
+        $generator = new AnnotationReportGenerator([
+            'annotationSession' => $session->id,
+            'newestLabel' => true,
+            'onlyLabels' => [$al1->label_id, $al2->label_id, $al4->label_id, $al5->label_id],
+            'separateUser' => true
+        ]);
+        $generator->setSource($session->volume);
+        $results = $generator->initQuery(['user_id'])->get();
+        $this->assertCount(2, $results);
+        $this->assertEquals($al2->user_id, $results[0]->user_id);
+        $this->assertEquals($al4->user_id, $results[1]->user_id);
+    }
 }


### PR DESCRIPTION
- [x] Add tests for old option combinations

`Add all_labels option`
- [x] include all images for abundance report
  - [x] Add test
- [ ] use all labels for separated label trees
  - [ ] Add test
 - [ ] use all labels for separated users
    - [ ] Add test
- [ ] use all labels if label trees and users shouldn't be separated
   - [ ] Add test
- [ ] use all labels when labels should be aggregated
  - [ ]  Add test
- [ ] check option combinations with all_labels: 
  - [ ] `isRestrictedToAnnotationSession`
  - [ ] `isRestrictedToNewestLabel`
  - [ ] `isRestrictedToLabels`
- [ ] check project report generator classes
- [ ] check project report generator tests

**Volume reports view**
- [ ] add button for `all_labels` option
- [ ] check when new option should be disabled
- [ ] add rules for new option

`Project reports view`
- [ ] add button for `all_labels` option
- [ ] check when new option should be disabled
- [ ] add rules for new option

Closes #1041