### PR TITLE
Fix project invitation expires_at format

### DIFF
--- a/app/ProjectInvitation.php
+++ b/app/ProjectInvitation.php
@@ -29,7 +29,7 @@ class ProjectInvitation extends Model
      * @var array<string, string>
      */
     protected $casts = [
-        'expires_at' => 'datetime',
+        'expires_at' => "datetime:c",
         'add_to_sessions' => 'bool',
     ];
 


### PR DESCRIPTION
Without the explicit format given, the date would be returned wrong (without time zone) when the invitation is initially created.