### PR TITLE
Fix display and authorization of admin/editor storage disks

### DIFF
--- a/app/Http/Controllers/Views/Volumes/PendingVolumeController.php
+++ b/app/Http/Controllers/Views/Volumes/PendingVolumeController.php
@@ -47,7 +47,8 @@ class PendingVolumeController extends Controller
 
         if ($user->can('sudo')) {
             $disks = $disks->concat(config('volumes.admin_storage_disks'));
-        } elseif ($user->role_id === Role::editorId()) {
+        } elseif ($user->role_id === Role::editorId() || $user->role_id === Role::adminId()) {
+            // Also check admin role because admins could have disabled their sudo mode.
             $disks = $disks->concat(config('volumes.editor_storage_disks'));
         }
 

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -48,9 +48,11 @@ class AuthServiceProvider extends ServiceProvider
                 return true;
             }
 
-            if ($user->role_id === Role::adminId()) {
+            if ($user->can('sudo')) {
                 return in_array($disk, config('volumes.admin_storage_disks'));
-            } elseif ($user->role_id === Role::editorId()) {
+            } elseif ($user->role_id === Role::editorId() || $user->role_id === Role::adminId()) {
+                // Also check admin role because admins could have disabled their sudo
+                // mode.
                 return in_array($disk, config('volumes.editor_storage_disks'));
             }
 


### PR DESCRIPTION
Admins weren't shown the editor storage disks if they disabled sudo mode. The authorization logic now also respects sudo mode.