### PR TITLE
Fix NumPy 2 compatible packages

### DIFF
--- a/.docker/requirements.txt
+++ b/.docker/requirements.txt
@@ -1,8 +1,8 @@
 # This file is just used to get security alerts from GitHub. Make sure the versions match
 # in worker.dockerfile.
-numpy==1.24.*
+numpy==2.1.*
 opencv-contrib-python-headless==4.8.1.78
-scipy==1.10.*
+scipy==1.13.*
 scikit-learn==1.2.*
 matplotlib==3.6.*
 PyExcelerate==0.6.7
@@ -10,4 +10,4 @@ Pillow==10.3.0
 Shapely==1.8.1
 torch==2.6.*
 torchvision==0.21.*
-pandas==1.5.3
+pandas==2.2.*

--- a/.docker/worker.dockerfile
+++ b/.docker/worker.dockerfile
@@ -8,13 +8,10 @@ RUN LC_ALL=C.UTF-8 apt-get update \
     && apt-get install -y --no-install-recommends \
         ffmpeg \
         python3 \
-        python3-numpy \
         python3-opencv \
-        python3-scipy \
         python3-sklearn \
         python3-matplotlib \
         python3-shapely \
-        python3-pandas \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -r /var/lib/apt/lists/*
@@ -80,6 +77,8 @@ RUN LC_ALL=C.UTF-8 apt-get update \
     && pip3 install --no-cache-dir --break-system-packages \
         PyExcelerate==0.6.7 \
         Pillow==10.2.0 \
+        pandas==2.2.* \
+        scipy==1.13.* \
     && pip3 install --ignore-installed --no-cache-dir --break-system-packages --index-url https://download.pytorch.org/whl/cpu \
         torch==2.6.* \
         torchvision==0.21.* \


### PR DESCRIPTION
Torch 2.6 installs NumPy 2 so we need to update other packages for compatibility. Some other packages may not officially be compatible with NumPy 2 in the installed versions. These will be updated once errors pop up, since incomplatible methods may not be used.

See: https://github.com/numpy/numpy/issues/26191