### PR TITLE
Fix remaining Python packages for Numpy 2 compatibility

### DIFF
--- a/.docker/requirements.txt
+++ b/.docker/requirements.txt
@@ -1,13 +1,11 @@
-# This file is just used to get security alerts from GitHub. Make sure the versions match
-# in worker.dockerfile.
 numpy==2.1.*
-opencv-contrib-python-headless==4.8.1.78
+opencv-contrib-python-headless==4.10.0.*
 scipy==1.13.*
-scikit-learn==1.2.*
-matplotlib==3.6.*
+scikit-learn==1.4.*
+matplotlib==3.8.*
 PyExcelerate==0.6.7
 Pillow==10.3.0
-Shapely==1.8.1
+Shapely==2.0.*
+pandas==2.2.*
 torch==2.6.*
 torchvision==0.21.*
-pandas==2.2.*

--- a/.docker/worker.dockerfile
+++ b/.docker/worker.dockerfile
@@ -8,10 +8,6 @@ RUN LC_ALL=C.UTF-8 apt-get update \
     && apt-get install -y --no-install-recommends \
         ffmpeg \
         python3 \
-        python3-opencv \
-        python3-sklearn \
-        python3-matplotlib \
-        python3-shapely \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -r /var/lib/apt/lists/*
@@ -70,23 +66,23 @@ RUN LC_ALL=C.UTF-8 apt-get update \
 # Unset proxy configuration again.
 RUN [ -z "$HTTP_PROXY" ] || pear config-set http_proxy ""
 
+COPY .docker/requirements.txt /tmp/requirements.txt
+
 RUN LC_ALL=C.UTF-8 apt-get update \
     && apt-get install -y --no-install-recommends \
         python3-pip \
     && pip3 install --no-cache-dir --break-system-packages --upgrade pip \
-    && pip3 install --no-cache-dir --break-system-packages \
-        PyExcelerate==0.6.7 \
-        Pillow==10.2.0 \
-        pandas==2.2.* \
-        scipy==1.13.* \
+    # Install torch first to get the CPU nversion. It is also present in
+    # requirements.txt but this is only for automatic vulnerability checks.
     && pip3 install --ignore-installed --no-cache-dir --break-system-packages --index-url https://download.pytorch.org/whl/cpu \
         torch==2.6.* \
         torchvision==0.21.* \
+    && pip3 install --no-cache-dir --break-system-packages -r /tmp/requirements.txt \
     && apt-get purge -y \
         python3-pip \
     && apt-get -y autoremove \
     && apt-get clean \
-    && rm -r /var/lib/apt/lists/*
+    && rm -r /var/lib/apt/lists/* /tmp/requirements.txt
 
 WORKDIR /var/www
 

--- a/resources/scripts/reports/basic_report.py
+++ b/resources/scripts/reports/basic_report.py
@@ -18,6 +18,7 @@ data_csvs = sys.argv[3:]
 def TitleSlide(text):
     fig = plt.figure(figsize=(10, 4))
     plt.subplot2grid((3, 3), (0, 0), colspan=3)
+    plt.axis('off')
     mid = plt.subplot2grid((3, 3), (0, 0), colspan=3)
     mid.axis('off')
     btleft = plt.subplot2grid((3, 3), (2, 0))
@@ -53,7 +54,7 @@ for path in data_csvs:
     # '#'-characters to prepend to the hex color codes
     hashes = np.full(rows.shape[0], '#', dtype=str)
 
-    ax.bar(ind, counts, width, color=np.char.add(hashes, rows[:, 1]), log=counts.max() > 100)
+    ax.bar(ind, counts, width, color=np.char.add(hashes, rows[:, 1]), log=counts.max() > 100, align='edge', edgecolor='000')
 
     ax.set_xticks(ind + width / 2)
     labels = [label for label in rows[:, 0]]


### PR DESCRIPTION
Now packages are installed via the requirements.txt which was only used for automatic security checks before. The Apline system packages are no longer used because they are not compatible with Numpy 2. Numpy 2 is required by Torch 2.6.

See: https://github.com/biigle/core/pull/1138