### PR TITLE
Arrow keys navigation for single video in annotation tool

### DIFF
--- a/resources/assets/js/videos/components/videoScreen.vue
+++ b/resources/assets/js/videos/components/videoScreen.vue
@@ -643,21 +643,33 @@ export default {
             this.resetInteractionMode();
         },
         adaptKeyboardShortcuts() {
-            if(this.enableJumpByFrame) {
+            if (this.enableJumpByFrame) {
                 Keyboard.off('ArrowRight', this.emitNext, 0, this.listenerSet);
                 Keyboard.off('ArrowLeft', this.emitPrevious, 0, this.listenerSet);
-                Keyboard.on('Shift+ArrowRight', this.emitNext, 0, this.listenerSet);
-                Keyboard.on('Shift+ArrowLeft', this.emitPrevious, 0, this.listenerSet);
                 Keyboard.on('ArrowRight', this.emitNextFrame, 0, this.listenerSet);
                 Keyboard.on('ArrowLeft', this.emitPreviousFrame, 0, this.listenerSet);
+                if (this.showPrevNext) {
+                    Keyboard.on('Shift+ArrowRight', this.emitNext, 0, this.listenerSet);
+                    Keyboard.on('Shift+ArrowLeft', this.emitPrevious, 0, this.listenerSet);
+                }
+                else {
+                    Keyboard.off('Shift+ArrowRight', this.emitNext, 0, this.listenerSet);
+                    Keyboard.off('Shift+ArrowLeft', this.emitPrevious, 0, this.listenerSet);
+                }
             }
             else {
                 Keyboard.off('Shift+ArrowRight', this.emitNext, 0, this.listenerSet);
                 Keyboard.off('Shift+ArrowLeft', this.emitPrevious, 0, this.listenerSet);
                 Keyboard.off('ArrowRight', this.emitNextFrame, 0, this.listenerSet);
                 Keyboard.off('ArrowLeft', this.emitPreviousFrame, 0, this.listenerSet);
-                Keyboard.on('ArrowRight', this.emitNext, 0, this.listenerSet);
-                Keyboard.on('ArrowLeft', this.emitPrevious, 0, this.listenerSet);
+                if (this.showPrevNext) {
+                    Keyboard.on('ArrowRight', this.emitNext, 0, this.listenerSet);
+                    Keyboard.on('ArrowLeft', this.emitPrevious, 0, this.listenerSet);
+                }
+                else {
+                    Keyboard.off('ArrowRight', this.emitNext, 0, this.listenerSet);
+                    Keyboard.off('ArrowLeft', this.emitPrevious, 0, this.listenerSet);
+                }
             }
         }
     },


### PR DESCRIPTION
Conditional Keyboard Shortcuts Based on showPrevNext

- Fixes a bug where pressing the left/right arrow keys in the video annotation tool triggers a reload, even if only a single video is available
- Updated adaptKeyboardShortcuts() to conditionally add/remove navigation-related keyboard shortcuts based on the showPrevNext flag

Resolve #878 