### PR TITLE
Improve tile upload performance for S3 clients

### DIFF
--- a/app/Jobs/TileSingleImage.php
+++ b/app/Jobs/TileSingleImage.php
@@ -2,21 +2,21 @@
 
 namespace Biigle\Jobs;
 
-use File;
-use Exception;
-use FileCache;
-use Biigle\Image;
 use ArrayIterator;
+use Biigle\Image;
+use Exception;
+use File;
+use FileCache;
 use FilesystemIterator;
 use GuzzleHttp\Promise\Each;
-use RecursiveIteratorIterator;
-use RecursiveDirectoryIterator;
-use Illuminate\Support\Facades\Log;
-use Jcupitt\Vips\Image as VipsImage;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Storage;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Jcupitt\Vips\Image as VipsImage;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 class TileSingleImage extends Job implements ShouldQueue
 {

--- a/app/Jobs/TileSingleImage.php
+++ b/app/Jobs/TileSingleImage.php
@@ -2,18 +2,22 @@
 
 namespace Biigle\Jobs;
 
-use Biigle\Image;
-use Exception;
 use File;
+use Exception;
 use FileCache;
+use Biigle\Image;
 use FilesystemIterator;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
+use GuzzleHttp\Promise\Each;
+use RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
+use Illuminate\Support\Facades\Log;
+use Jcupitt\Vips\Image as VipsImage;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Storage;
-use Jcupitt\Vips\Image as VipsImage;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Filesystem\AwsS3V3Adapter;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 class TileSingleImage extends Job implements ShouldQueue
 {
@@ -63,7 +67,12 @@ class TileSingleImage extends Job implements ShouldQueue
     {
         try {
             FileCache::getOnce($this->image, [$this, 'generateTiles']);
-            $this->uploadToStorage();
+            $adapter = Storage::disk(config('image.tiles.disk'))->getAdapter();
+            if ($adapter instanceof AwsS3V3Adapter) {
+                $this->uploadToS3Storage();
+            } else {
+                $this->uploadToStorage();
+            }
             $this->image->tilingInProgress = false;
             $this->image->save();
         } finally {
@@ -104,6 +113,78 @@ class TileSingleImage extends Job implements ShouldQueue
             $disk->deleteDirectory($fragment);
             throw $e;
         }
+    }
+
+    /**
+     * Upload the tiles from temporary local storage to the tiles storage disk.
+     */
+    public function uploadToS3Storage()
+    {
+        $iterator = $this->getIterator($this->tempPath);
+        $disk = Storage::disk(config('image.tiles.disk'));
+        $fragment = fragment_uuid_path($this->image->uuid);
+        
+        try {
+            $client = $this->getClient($disk);
+            $bucket = $this->getBucket($disk);
+
+            // Logic about your requests and how to execute them
+            $uploads = function($files) use ($client, $bucket, $fragment) {
+                foreach ($files as $file) {
+                    yield $client->putObjectAsync([
+                        'Bucket'        => $bucket,
+                        'Key'           => $fragment. "/" . basename($file),
+                        'SourceFile'    => $file,
+                    ]);
+                }
+            };
+            
+            $failedUploads = [];
+            $filenames = $this->getIterator($this->tempPath);
+
+            $onFullfill = function ($res, $index) use ($filenames) {
+                $filenames->next();
+            };
+            $onReject = function ($reason, $index) use ($failedUploads, $filenames) {
+                array_push($failedUploads, $filenames->current());
+                Log::info($failedUploads);
+            };
+
+            $retry = 1;
+            $files = $uploads($iterator);
+
+            do {
+                // $failedUploads = [];
+                $this->sendRequests($files, $onFullfill, $onReject);
+                $files = $failedUploads;
+                Log::info([$failedUploads, $retry]);
+
+                $retry -= 1;
+            } while (!empty($failedUploads) && $retry > 0);
+            
+
+        } catch (Exception $e) {
+            $disk->deleteDirectory($fragment);
+            throw $e;
+        }
+    }
+
+    protected function sendRequests($files, $onFullfill, $onReject) {
+        $concurrency = config('image.tiles.nbr_concurrent_requests');
+        Each::ofLimit(
+            $files,
+            $concurrency,
+            $onFullfill,
+            $onReject
+        )->wait();
+    }
+
+    protected function getClient($disk){
+        return $disk->getClient();
+    }
+
+    protected function getBucket($disk){
+        return $disk->getClient()->getConfig('bucket');
     }
 
     /**

--- a/app/Jobs/TileSingleImage.php
+++ b/app/Jobs/TileSingleImage.php
@@ -174,7 +174,7 @@ class TileSingleImage extends Job implements ShouldQueue
     /**
      * Send requests to upload files to S3.
      *
-     * @param array $files The files to upload.
+     * @param \Iterator $files The files to upload.
      * @param callable $onFullfill Callback for successful uploads.
      * @param callable $onReject Callback for failed uploads.
      *

--- a/config/image.php
+++ b/config/image.php
@@ -29,6 +29,11 @@ return [
          | Queue on which the tile image job should run.
          */
         'queue' => env('IMAGE_TILES_QUEUE', 'default'),
+
+        /*
+         | Number of concurrent requests that should be sent when using a s3 disk
+         */
+        'nbr_concurrent_requests' => env('IMAGE_NBR_CON_REQUESTS', 10),
     ],
 
 ];

--- a/tests/php/Jobs/TileSingleImageTest.php
+++ b/tests/php/Jobs/TileSingleImageTest.php
@@ -2,21 +2,21 @@
 
 namespace Biigle\Tests\Jobs;
 
+use ArrayIterator;
+use Aws\Command;
+use Aws\MockHandler;
+use Aws\Result;
+use Aws\S3\Exception\S3Exception;
+use Aws\S3\S3Client;
+use Biigle\Jobs\TileSingleImage;
+use Biigle\Tests\ImageTest;
+use Exception;
 use File;
+use GuzzleHttp\Psr7\Response;
+use Jcupitt\Vips\Image;
 use Mockery;
 use Storage;
 use TestCase;
-use Exception;
-use Aws\Result;
-use Aws\Command;
-use ArrayIterator;
-use Aws\MockHandler;
-use Aws\S3\S3Client;
-use Jcupitt\Vips\Image;
-use Biigle\Tests\ImageTest;
-use GuzzleHttp\Psr7\Response;
-use Biigle\Jobs\TileSingleImage;
-use Aws\S3\Exception\S3Exception;
 
 class TileSingleImageTest extends TestCase
 {

--- a/tests/php/Jobs/TileSingleImageTest.php
+++ b/tests/php/Jobs/TileSingleImageTest.php
@@ -6,19 +6,17 @@ use File;
 use Mockery;
 use Storage;
 use TestCase;
+use Exception;
 use Aws\Result;
-use ArrayObject;
 use Aws\Command;
+use ArrayIterator;
 use Aws\MockHandler;
 use Aws\S3\S3Client;
 use Jcupitt\Vips\Image;
-use Aws\CommandInterface;
 use Biigle\Tests\ImageTest;
 use GuzzleHttp\Psr7\Response;
-use Aws\Exception\AwsException;
 use Biigle\Jobs\TileSingleImage;
 use Aws\S3\Exception\S3Exception;
-use Illuminate\Support\Facades\Log;
 
 class TileSingleImageTest extends TestCase
 {
@@ -68,33 +66,72 @@ class TileSingleImageTest extends TestCase
         $mock->append(
             new Result(),
             new Result(),
-            // new Result(),
-            new S3Exception("test", new Command("mockCommand"), [
-                'code' => 'mockCode',
-                'response' => new Response(400)
-            ])
+            new Result(),
         );
 
         $client = new S3Client([
             'region' => 'test',
             'handler' => $mock,
             'credentials' => [
-            'key' => 'fake-key',
-            'secret' => 'fake-secret',
+                'key' => 'fake-key',
+                'secret' => 'fake-secret',
             ],
         ]);
 
-        $files = ['test-image.jpg', 'test-image.png', 'exif-test.jpg'];
+        // Treat images as tiles for Biigle\Image
+        $tiles = ['test-image.jpg', 'test-image.png', 'exif-test.jpg'];
 
         $image = ImageTest::create();
         $job = new TileSingleImageStub($image);
         $job->client = $client;
-        $job->files = $files;
+        $job->files = $tiles;
         $job->useParentGetIterator = false;
 
         $job->uploadToS3Storage();
 
-        // $this->assertEquals($files, $job->uploadedFiles);
+        $this->assertEquals($tiles, $job->uploadedFiles);
+    }
+
+    public function testUploadToS3StorageThrowException()
+    {
+        config(['image.tiles.nbr_concurrent_requests' => 2]);
+
+        $mock = new MockHandler();
+        $mock->append(
+            new Result(),
+            new Result(),
+            new S3Exception("test", new Command("mockCommand"), [
+                'code' => 'mockCode',
+                'response' => new Response(400)
+            ]),
+        );
+
+        $client = new S3Client([
+            'region' => 'test',
+            'handler' => $mock,
+            'credentials' => [
+                'key' => 'fake-key',
+                'secret' => 'fake-secret',
+            ],
+        ]);
+
+        // Treat images as tiles for Biigle\Image
+        $tiles = ['test-image.jpg', 'test-image.png', 'exif-test.jpg'];
+
+        $image = ImageTest::create();
+        $job = new TileSingleImageStub($image);
+        $job->client = $client;
+        $job->files = $tiles;
+        $job->useParentGetIterator = false;
+
+        $fails = false;
+        try {
+            $job->uploadToS3Storage();
+        } catch (Exception $e) {
+            $fails = true;
+        }
+
+        $this->assertTrue($fails);
     }
 
     public function testQueue()
@@ -122,33 +159,42 @@ class TileSingleImageStub extends TileSingleImage
         return $this->mock;
     }
 
-    protected function getClient($disk) {
+    protected function getClient($disk)
+    {
         return $this->client;
     }
 
-    protected function getBucket($disk) {
+    protected function getBucket($disk)
+    {
         return "test-bucket";
     }
 
-    protected function getIterator($path){
-        if ($this->useParentGetIterator){
+    protected function getIterator($path)
+    {
+        if ($this->useParentGetIterator) {
             return parent::getIterator($path);
         }
 
         $files = [];
-        foreach($this->files as $file){
+        foreach ($this->files as $file) {
             $files[] = "tests/files/{$file}";
         }
 
-        return (new ArrayObject($files))->getIterator();
+        return new ArrayIterator($files);
     }
 
-    protected function sendRequests($files, $onFullfill, $onReject){
-        $onFullfill2 = function($res, $index) use ($onFullfill) {
+    protected function sendRequests($files, $onFullfill, $onReject)
+    {
+        $onFullfill2 = function ($res, $index) use ($onFullfill) {
             $onFullfill($res, $index);
             $this->uploadedFiles[$index] = basename($res->get('ObjectURL'));
         };
         parent::sendRequests($files, $onFullfill2, $onReject);
+    }
+
+    public function uploadToS3Storage($retry = 3)
+    {
+        parent::uploadToS3Storage(1);
     }
 
 }


### PR DESCRIPTION
Improve the tile upload performance for S3 clients by sending requests concurrently.

Closes #945.