### PR TITLE
Hide SASS deprecation warnings

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -37,6 +37,20 @@ export default defineConfig({
             },
         }),
     ],
+    css: {
+        preprocessorOptions: {
+            scss: {
+                // Silence deprecations by Boostrap and Fontawesome
+                silenceDeprecations: [
+                    'import',
+                    'mixed-decls',
+                    'color-functions',
+                    'global-builtin',
+                    'slash-div',
+                ],
+            },
+        },
+    },
     resolve: {
         alias: {
             '@': '/resources/assets/js',


### PR DESCRIPTION
The deprecation warnings of Bootstrap 3 and Fontawesome are irrelevant for now. I looked into migrating to Bootstrap 5 but it too has the deprecation warnings. I assume that SASS compilation will work for the time being.