### PR TITLE
Max favorites at 20

### DIFF
--- a/resources/assets/js/label-trees/constants.js
+++ b/resources/assets/js/label-trees/constants.js
@@ -1,1 +1,1 @@
-export const MAX_FAVOURITES = 10;
+export const MAX_FAVOURITES = 20;


### PR DESCRIPTION
Augment the number of favorites to 20 to ease annotation of pictures with high diversity