### PR TITLE
Safeguards when deleting a volume or project

### DIFF
--- a/resources/assets/js/projects/title.vue
+++ b/resources/assets/js/projects/title.vue
@@ -61,15 +61,12 @@ export default{
             setTimeout(() => location.href = this.redirectUrl, 2000);
         },
         deleteProject() {
-            let inputproject = prompt(`Do you want to delete ${this.project.name}?`);
+            let inputproject = prompt(`Are you scure you want to delete "${this.project.name}"? Please type the project name to confirm.`);
             if (inputproject == this.project.name) {
-                let confirmed = confirm(`Do you really want to delete the project ${this.project.name}?`);
-                if (confirmed) {
-                    this.startLoading();
-                    ProjectsApi.delete({ id: this.project.id })
-                        .then(this.projectDeleted, this.maybeForceDeleteProject)
-                        .finally(this.finishLoading);
-                }
+                this.startLoading();
+                ProjectsApi.delete({ id: this.project.id })
+                    .then(this.projectDeleted, this.maybeForceDeleteProject)
+                    .finally(this.finishLoading);
             }
         },
         maybeForceDeleteProject(response) {

--- a/resources/assets/js/projects/title.vue
+++ b/resources/assets/js/projects/title.vue
@@ -61,8 +61,8 @@ export default{
             setTimeout(() => location.href = this.redirectUrl, 2000);
         },
         deleteProject() {
-            let inputproject = prompt(`Are you scure you want to delete "${this.project.name}"? Please type the project name to confirm.`);
-            if (inputproject == this.project.name) {
+            let inputproject = prompt(`Are you sure you want to delete "${this.project.name}"? Please type the project name to confirm.`);
+            if (inputproject === this.project.name) {
                 this.startLoading();
                 ProjectsApi.delete({ id: this.project.id })
                     .then(this.projectDeleted, this.maybeForceDeleteProject)

--- a/resources/assets/js/projects/title.vue
+++ b/resources/assets/js/projects/title.vue
@@ -61,7 +61,7 @@ export default{
             setTimeout(() => location.href = this.redirectUrl, 2000);
         },
         deleteProject() {
-            let inputproject = prompt(`Do you realy want to delete ${this.project.name} ?`);
+            let inputproject = prompt(`Do you want to delete ${this.project.name}?`);
             if (inputproject == this.project.name) {
                 let confirmed = confirm(`Do you really want to delete the project ${this.project.name}?`);
                 if (confirmed) {

--- a/resources/assets/js/projects/title.vue
+++ b/resources/assets/js/projects/title.vue
@@ -61,7 +61,7 @@ export default{
             setTimeout(() => location.href = this.redirectUrl, 2000);
         },
         deleteProject() {
-            let inputproject = prompt(`Are you sure you want to delete "${this.project.name}"? \nPlease type the project name to confirm.`,this.project.name);
+            let inputproject = prompt(`Are you sure you want to delete "${this.project.name}"? Please type the project name to confirm.`);
             if (inputproject === this.project.name) {
                 this.startLoading();
                 ProjectsApi.delete({ id: this.project.id })

--- a/resources/assets/js/projects/title.vue
+++ b/resources/assets/js/projects/title.vue
@@ -61,7 +61,7 @@ export default{
             setTimeout(() => location.href = this.redirectUrl, 2000);
         },
         deleteProject() {
-            let inputproject = prompt(`Are you sure you want to delete "${this.project.name}"? Please type the project name to confirm.`);
+            let inputproject = prompt(`Are you sure you want to delete "${this.project.name}"? \nPlease type the project name to confirm.`,this.project.name);
             if (inputproject === this.project.name) {
                 this.startLoading();
                 ProjectsApi.delete({ id: this.project.id })

--- a/resources/assets/js/projects/title.vue
+++ b/resources/assets/js/projects/title.vue
@@ -62,15 +62,9 @@ export default{
             setTimeout(() => location.href = this.redirectUrl, 2000);
         },
         deleteProject() {
-            ProjectsApi.queryVolumes({ id: this.project.id }).then(
-                volumes => {
-                    this.volumes = volumes.data;
-                }
-            );
             let inputproject = prompt(`Do you realy want to delete ${this.project.name} ?`);
-            if (inputproject.replace(/\s/g, '') == this.project.name) {
+            if (inputproject == this.project.name) {
                 let confirmed = confirm(`Do you really want to delete the project ${this.project.name}?`);
-
                 if (confirmed) {
                     this.startLoading();
                     ProjectsApi.delete({ id: this.project.id })
@@ -82,20 +76,14 @@ export default{
         },
         maybeForceDeleteProject(response) {
             if (response.status === 400) {
-                let volNames = [];
-                for (let i = 0; i < this.volumes.length; i++) {
-                    volNames[i] = this.volumes[i].name;
+                let confirmed = confirm('Deleting this project will delete one or more volumes with all annotations! Do you want to continue?');
+                if (confirmed) {
+                    this.startLoading();
+                    ProjectsApi.delete({ id: this.project.id }, { force: true })
+                        .then(this.projectDeleted, handleErrorResponse)
+                        .finally(this.finishLoading);
                 }
-                let inputVolume = prompt(`Do you realy want to delete ${volNames.toString()}?`);
-                if (inputVolume.replace(/\s/g, '') == volNames.toString().replace(/\s/g, '')) {
-                    let confirmed = confirm('Deleting this project will delete one or more volumes with all annotations! Do you want to continue?');
-                    if (confirmed) {
-                        this.startLoading();
-                        ProjectsApi.delete({ id: this.project.id }, { force: true })
-                            .then(this.projectDeleted, handleErrorResponse)
-                            .finally(this.finishLoading);
-                    }
-                }
+
             } else {
                 handleErrorResponse(response);
             }

--- a/resources/assets/js/projects/title.vue
+++ b/resources/assets/js/projects/title.vue
@@ -81,7 +81,6 @@ export default{
                         .then(this.projectDeleted, handleErrorResponse)
                         .finally(this.finishLoading);
                 }
-
             } else {
                 handleErrorResponse(response);
             }

--- a/resources/assets/js/projects/title.vue
+++ b/resources/assets/js/projects/title.vue
@@ -24,7 +24,6 @@ export default{
             description: null,
             userId: null,
             redirectUrl: null,
-            volumes: [],
         };
     },
     computed: {
@@ -71,7 +70,6 @@ export default{
                         .then(this.projectDeleted, this.maybeForceDeleteProject)
                         .finally(this.finishLoading);
                 }
-
             }
         },
         maybeForceDeleteProject(response) {

--- a/resources/assets/js/projects/volumesContainer.vue
+++ b/resources/assets/js/projects/volumesContainer.vue
@@ -144,7 +144,7 @@ export default {
                     let volumeToDelete = this.volumes.find(volume => volume.id === id).name;
                     if (response.status === 400) {
                         let inputVolume = prompt(`Do you realy want to delete ${volumeToDelete} ?`);
-                        if (inputVolume.replace(/\s/g, '') == volumeToDelete) {
+                        if (inputVolume == volumeToDelete) {
                             if (confirm('The volume you are about to remove belongs only to this project and will be deleted. Are you sure you want to delete this volume?')) {
                                 this.forceRemoveVolume(id);
                             }

--- a/resources/assets/js/projects/volumesContainer.vue
+++ b/resources/assets/js/projects/volumesContainer.vue
@@ -143,7 +143,7 @@ export default {
                 .then(() => this.volumeRemoved(id), (response) => {
                     let volumeToDelete = this.volumes.find(volume => volume.id === id).name;
                     if (response.status === 400) {
-                        let inputVolume = prompt(`The volume you are about to remove belongs only to this project and will be deleted. Are you sure you want to delete "${volumeToDelete}"? Please type the volume name to confirm.`);
+                        let inputVolume = prompt(`The volume you are about to remove belongs only to this project and will be deleted. \nAre you sure you want to delete "${volumeToDelete}"? \nPlease type the volume name to confirm.`, volumeToDelete);
                         if (inputVolume === volumeToDelete) {
                             this.forceRemoveVolume(id);
                         }

--- a/resources/assets/js/projects/volumesContainer.vue
+++ b/resources/assets/js/projects/volumesContainer.vue
@@ -144,7 +144,7 @@ export default {
                     let volumeToDelete = this.volumes.find(volume => volume.id === id).name;
                     if (response.status === 400) {
                         let inputVolume = prompt(`The volume you are about to remove belongs only to this project and will be deleted. Are you sure you want to delete "${volumeToDelete}"? Please type the volume name to confirm.`);
-                        if (inputVolume == volumeToDelete) {
+                        if (inputVolume === volumeToDelete) {
                             this.forceRemoveVolume(id);
                         }
                     } else {

--- a/resources/assets/js/projects/volumesContainer.vue
+++ b/resources/assets/js/projects/volumesContainer.vue
@@ -141,8 +141,8 @@ export default {
             this.startLoading();
             ProjectsApi.detachVolume({ id: this.project.id, volume_id: id })
                 .then(() => this.volumeRemoved(id), (response) => {
-                    let volumeToDelete = this.volumes.find(volume => volume.id === id).name;
                     if (response.status === 400) {
+                        let volumeToDelete = this.volumes.find(volume => volume.id === id).name;
                         let inputVolume = prompt(`The volume you are about to remove belongs only to this project and will be deleted. Are you sure you want to delete "${volumeToDelete}"? Please type the volume name to confirm.`);
                         if (inputVolume === volumeToDelete) {
                             this.forceRemoveVolume(id);

--- a/resources/assets/js/projects/volumesContainer.vue
+++ b/resources/assets/js/projects/volumesContainer.vue
@@ -143,7 +143,7 @@ export default {
                 .then(() => this.volumeRemoved(id), (response) => {
                     let volumeToDelete = this.volumes.find(volume => volume.id === id).name;
                     if (response.status === 400) {
-                        let inputVolume = prompt(`Do you realy want to delete ${volumeToDelete} ?`);
+                        let inputVolume = prompt(`Do you want to delete ${volumeToDelete}?`);
                         if (inputVolume == volumeToDelete) {
                             if (confirm('The volume you are about to remove belongs only to this project and will be deleted. Are you sure you want to delete this volume?')) {
                                 this.forceRemoveVolume(id);

--- a/resources/assets/js/projects/volumesContainer.vue
+++ b/resources/assets/js/projects/volumesContainer.vue
@@ -139,11 +139,15 @@ export default {
     methods: {
         removeVolume(id) {
             this.startLoading();
-            ProjectsApi.detachVolume({id: this.project.id, volume_id: id})
+            ProjectsApi.detachVolume({ id: this.project.id, volume_id: id })
                 .then(() => this.volumeRemoved(id), (response) => {
+                    let volumeToDelete = this.volumes.find(volume => volume.id === id).name;
                     if (response.status === 400) {
-                        if (confirm('The volume you are about to remove belongs only to this project and will be deleted. Are you sure you want to delete this volume?')) {
-                            this.forceRemoveVolume(id);
+                        let inputVolume = prompt(`Do you realy want to delete ${volumeToDelete} ?`);
+                        if (inputVolume.replace(/\s/g, '') == volumeToDelete) {
+                            if (confirm('The volume you are about to remove belongs only to this project and will be deleted. Are you sure you want to delete this volume?')) {
+                                this.forceRemoveVolume(id);
+                            }
                         }
                     } else {
                         handleErrorResponse(response);

--- a/resources/assets/js/projects/volumesContainer.vue
+++ b/resources/assets/js/projects/volumesContainer.vue
@@ -143,7 +143,7 @@ export default {
                 .then(() => this.volumeRemoved(id), (response) => {
                     let volumeToDelete = this.volumes.find(volume => volume.id === id).name;
                     if (response.status === 400) {
-                        let inputVolume = prompt(`The volume you are about to remove belongs only to this project and will be deleted. \nAre you sure you want to delete "${volumeToDelete}"? \nPlease type the volume name to confirm.`, volumeToDelete);
+                        let inputVolume = prompt(`The volume you are about to remove belongs only to this project and will be deleted. Are you sure you want to delete "${volumeToDelete}"? Please type the volume name to confirm.`);
                         if (inputVolume === volumeToDelete) {
                             this.forceRemoveVolume(id);
                         }

--- a/resources/assets/js/projects/volumesContainer.vue
+++ b/resources/assets/js/projects/volumesContainer.vue
@@ -146,7 +146,7 @@ export default {
                         let inputVolume = prompt(`The volume you are about to remove belongs only to this project and will be deleted. Are you sure you want to delete "${volumeToDelete}"? Please type the volume name to confirm.`);
                         if (inputVolume == volumeToDelete) {
                             this.forceRemoveVolume(id);
-                        } else { Snackbar.make(view, "Volume name does not match", Snackbar.LENGTH_SHORT).show(); }
+                        }
                     } else {
                         handleErrorResponse(response);
                     }

--- a/resources/assets/js/projects/volumesContainer.vue
+++ b/resources/assets/js/projects/volumesContainer.vue
@@ -143,12 +143,10 @@ export default {
                 .then(() => this.volumeRemoved(id), (response) => {
                     let volumeToDelete = this.volumes.find(volume => volume.id === id).name;
                     if (response.status === 400) {
-                        let inputVolume = prompt(`Do you want to delete ${volumeToDelete}?`);
+                        let inputVolume = prompt(`The volume you are about to remove belongs only to this project and will be deleted. Are you sure you want to delete "${volumeToDelete}"? Please type the volume name to confirm.`);
                         if (inputVolume == volumeToDelete) {
-                            if (confirm('The volume you are about to remove belongs only to this project and will be deleted. Are you sure you want to delete this volume?')) {
-                                this.forceRemoveVolume(id);
-                            }
-                        }
+                            this.forceRemoveVolume(id);
+                        } else { Snackbar.make(view, "Volume name does not match", Snackbar.LENGTH_SHORT).show(); }
                     } else {
                         handleErrorResponse(response);
                     }


### PR DESCRIPTION
Improve deletion confirmation dialog for volumes and projects that contain annotations. Added confirmation dialog includes an input field that requires the user to manually enter the name of the volume or project to confirm the deletion.

- Updated confirmation dialog for deletion of annotated volumes/projects.
- Input prompt added that requires typing the volume/project name.
- Dialog only shown when annotations are present and would be deleted.

closes #1074