### PR TITLE
Fix the missing timeline for remote videos in firefox

### DIFF
--- a/resources/assets/js/videos/components/videoTimeline.vue
+++ b/resources/assets/js/videos/components/videoTimeline.vue
@@ -175,8 +175,9 @@ export default {
             this.currentTime = this.video.currentTime;
         },
         setDuration() {
-            // Use the video duration the from server response, since Firefox's loadedmetadata event
-            // can be fired before the final durationchange event when handeling non-standard fragmented mp4.
+            // Use the video duration the from server response, since Firefox's loadedmetadata event is not reliable.
+            // The loadedmetadata event can be fired before the final durationchange event leading to an invalid or incorrect duration
+            // when requesting remote fragmented .mp4 files.
             this.duration = this.videoDuration;
         },
         emitSeek(time) {

--- a/resources/assets/js/videos/components/videoTimeline.vue
+++ b/resources/assets/js/videos/components/videoTimeline.vue
@@ -59,6 +59,10 @@ export default {
             type: HTMLVideoElement,
             required: true,
         },
+        videoDuration: {
+            type: Number,
+            required: true
+        },
         seeking: {
             type: Boolean,
             default: false,
@@ -171,7 +175,9 @@ export default {
             this.currentTime = this.video.currentTime;
         },
         setDuration() {
-            this.duration = this.video.duration;
+            // Use the video duration the from server response, since Firefox's loadedmetadata event
+            // can be fired before the final durationchange event when handeling non-standard fragmented mp4.
+            this.duration = this.videoDuration;
         },
         emitSeek(time) {
             this.$emit('seek', time);

--- a/resources/views/videos/show/content.blade.php
+++ b/resources/views/videos/show/content.blade.php
@@ -85,6 +85,7 @@
       :show-thumbnail-preview="settings.showThumbnailPreview"
       :video-id="videoId"
       :has-error="hasError"
+      :video-duration="videoDuration"
       v-on:seek="seek"
       v-on:select="selectAnnotation"
       v-on:deselect="deselectAnnotation"


### PR DESCRIPTION
Remote fragmented .mp4 files can trigger multiple durationchange events, updating the duration incrementally. In firefox the  loadedmetadata event is fired after the first duration update. To avoid an invalid or incorrect duration, use the server-provided video duration when the loadedmetadata event fires.