### PR TITLE
Video preview thumbnails are occasionally not displayed correctly

### DIFF
--- a/app/Jobs/ProcessNewVideo.php
+++ b/app/Jobs/ProcessNewVideo.php
@@ -249,11 +249,13 @@ class ProcessNewVideo extends Job implements ShouldQueue
             return;
         }
 
-        $estimatedThumbnails = (int) floor($durationRounded / $defaultThumbnailInterval);
+        $estimatedThumbnails = floor($durationRounded / $defaultThumbnailInterval);
         // Adjust the frame time based on the number of estimated thumbnails
         $thumbnailInterval = ($estimatedThumbnails > $maxThumbnails) ? $durationRounded / $maxThumbnails
             : (($estimatedThumbnails < $minThumbnails) ? $durationRounded / $minThumbnails : $defaultThumbnailInterval);
         $frameRate = 1 / $thumbnailInterval;
+        // Update the number of estimated thumbnails
+        $estimatedThumbnails = (int) floor($durationRounded / $thumbnailInterval);
 
         $this->generateSnapshots($path, $frameRate, $destinationPath, $estimatedThumbnails);
     }

--- a/app/Jobs/ProcessNewVideo.php
+++ b/app/Jobs/ProcessNewVideo.php
@@ -249,7 +249,7 @@ class ProcessNewVideo extends Job implements ShouldQueue
             return;
         }
 
-        $estimatedThumbnails = floor($durationRounded / $defaultThumbnailInterval);
+        $estimatedThumbnails = (int) floor($durationRounded / $defaultThumbnailInterval);
         // Adjust the frame time based on the number of estimated thumbnails
         $thumbnailInterval = ($estimatedThumbnails > $maxThumbnails) ? $durationRounded / $maxThumbnails
             : (($estimatedThumbnails < $minThumbnails) ? $durationRounded / $minThumbnails : $defaultThumbnailInterval);

--- a/app/Jobs/ProcessNewVideo.php
+++ b/app/Jobs/ProcessNewVideo.php
@@ -249,7 +249,7 @@ class ProcessNewVideo extends Job implements ShouldQueue
             return;
         }
 
-        $estimatedThumbnails = $durationRounded / $defaultThumbnailInterval;
+        $estimatedThumbnails = floor($durationRounded / $defaultThumbnailInterval);
         // Adjust the frame time based on the number of estimated thumbnails
         $thumbnailInterval = ($estimatedThumbnails > $maxThumbnails) ? $durationRounded / $maxThumbnails
             : (($estimatedThumbnails < $minThumbnails) ? $durationRounded / $minThumbnails : $defaultThumbnailInterval);

--- a/app/Jobs/ProcessNewVideo.php
+++ b/app/Jobs/ProcessNewVideo.php
@@ -255,7 +255,7 @@ class ProcessNewVideo extends Job implements ShouldQueue
             : (($estimatedThumbnails < $minThumbnails) ? $durationRounded / $minThumbnails : $defaultThumbnailInterval);
         $frameRate = 1 / $thumbnailInterval;
 
-        $this->generateSnapshots($path, $frameRate, $destinationPath);
+        $this->generateSnapshots($path, $frameRate, $destinationPath, $estimatedThumbnails);
     }
 
     public function generateVideoThumbnails($disk, $fragment, $tmpDir)
@@ -311,13 +311,15 @@ class ProcessNewVideo extends Job implements ShouldQueue
     /**
      * Run the actual command to extract snapshots from the video. Separated into its own
      * method for easier testing.
+     *
+     * maxFrames = -1 means no restriction.
      */
-    protected function generateSnapshots(string $sourcePath, float $frameRate, string $targetDir): void
+    protected function generateSnapshots(string $sourcePath, float $frameRate, string $targetDir, int $maxFrames = -1): void
     {
         $format = config('thumbnails.format');
         // Leading zeros are important to prevent file sorting afterwards
         Process::forever()
-            ->run("ffmpeg -i '{$sourcePath}' -vf fps={$frameRate} {$targetDir}/%04d.{$format}")
+            ->run("ffmpeg -i '{$sourcePath}' -vf fps={$frameRate} -frames:v {$maxFrames} {$targetDir}/%04d.{$format}")
             ->throw();
     }
 

--- a/tests/php/Jobs/ProcessNewVideoTest.php
+++ b/tests/php/Jobs/ProcessNewVideoTest.php
@@ -285,7 +285,7 @@ class ProcessNewVideoStub extends ProcessNewVideo
         return $this->duration;
     }
 
-    protected function generateSnapshots(string $sourcePath, float $frameRate, string $targetDir): void
+    protected function generateSnapshots(string $sourcePath, float $frameRate, string $targetDir, int $maxFrames = -1): void
     {
         $format = config('thumbnails.format');
         $numberSnapshots = intval($this->duration * $frameRate);


### PR DESCRIPTION
This PR fixes a bug where `FFmpeg` generates more thumbnails than expected, leading to a broken thumbnail preview. 

The fix limits the number of frames generated using `-frames:v`. Closes #1199 