### PR TITLE
Fix overlapping video annotations in timeline

### DIFF
--- a/resources/assets/js/videos/components/annotationTrack.vue
+++ b/resources/assets/js/videos/components/annotationTrack.vue
@@ -36,9 +36,6 @@ export default {
         annotationCount() {
             return this.lanes.reduce((c, l) => c + l.length, 0);
         },
-        laneCount() {
-            return this.lanes.length;
-        },
         trackHeight() {
             return this.lanes.length * (KEYFRAME_HEIGHT + LANE_MARGIN_BOTTOM) - LANE_MARGIN_BOTTOM;
         },
@@ -97,8 +94,8 @@ export default {
         xFactor(factor) {
             Object.values(this.annotationCache).forEach(a => a.updateXFactor(factor));
         },
-        annotationCount(count, oldCount) {
-            if (count < oldCount) {
+        lanes() {
+            if (this.annotationCount < Object.keys(this.annotationCache).length) {
                 const annotationMap = {};
                 this.lanes.forEach(l => l.forEach(a => annotationMap[a.id] = true));
                 Object.keys(this.annotationCache)
@@ -109,9 +106,6 @@ export default {
                     });
             }
 
-            this.draw();
-        },
-        laneCount() {
             this.draw();
         },
     },

--- a/resources/assets/js/videos/components/videoTimeline.vue
+++ b/resources/assets/js/videos/components/videoTimeline.vue
@@ -187,7 +187,6 @@ export default {
             this.scrollTop = scrollTop;
         },
         getAnnotationTrackLanes(annotations) {
-            let timeRanges = [[]];
             let lanes = [[]];
 
             annotations.forEach((annotation) => {
@@ -197,36 +196,22 @@ export default {
 
                 outerloop: while (!set) {
                     if (!lanes[lane]) {
-                        timeRanges[lane] = [];
                         lanes[lane] = [];
                     } else {
-                        for (let i = timeRanges[lane].length - 1; i >= 0; i--) {
-                            if (this.rangesCollide(timeRanges[lane][i], range)) {
+                        for (let i = lanes[lane].length - 1; i >= 0; i--) {
+                            if (annotation.overlapsTime(lanes[lane][i])) {
                                 lane += 1;
                                 continue outerloop;
                             }
                         }
                     }
 
-                    timeRanges[lane].push(range);
                     lanes[lane].push(annotation);
                     set = true;
                 }
             });
 
             return lanes;
-        },
-        rangesCollide(range1, range2) {
-            // Start of range1 overlaps with range2.
-            return range1[0] >= range2[0] && range1[0] < range2[1] ||
-                // End of range1 overlaps with range2.
-                range1[1] > range2[0] && range1[1] <= range2[1] ||
-                // Start of range2 overlaps with range1.
-                range2[0] >= range1[0] && range2[0] < range1[1] ||
-                // End of range2 overlaps with range1.
-                range2[1] > range1[0] && range2[1] <= range1[1] ||
-                // range1 equals range2.
-                range1[0] === range2[0] && range1[1] === range2[1];
         },
         updateHoverTime(time) {
             this.hoverTime = time;

--- a/resources/assets/js/videos/models/Annotation.js
+++ b/resources/assets/js/videos/models/Annotation.js
@@ -296,6 +296,19 @@ export default class Annotation {
         return false;
     }
 
+    overlapsTime(other) {
+        // Start of this overlaps with other.
+        return this.startFrame >= other.startFrame && this.startFrame < other.endFrame ||
+            // End of this overlaps with other.
+            this.endFrame > other.startFrame && this.endFrame <= other.endFrame ||
+            // Start of other overlaps with this.
+            other.startFrame >= this.startFrame && other.startFrame < this.endFrame ||
+            // End of other overlaps with this.
+            other.endFrame > this.startFrame && other.endFrame <= this.endFrame ||
+            // this equals other.
+            this.startFrame === other.startFrame && this.endFrame === other.endFrame;
+    }
+
     detachAnnotationLabel(annotationLabel) {
         let index = this.labels.indexOf(annotationLabel);
         if (index !== -1) {


### PR DESCRIPTION
Some timeline lane updates were not detected by the annotationTrack component. This is now fixed and the lane computation is more efficient too.