### PR TITLE
Ignore storage/largo_cache and .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /public/build
 /storage/*.key
 /storage/largo_patches
+/storage/largo_cache
 /storage/metadata
 /storage/pending-metadata
 /vendor
@@ -24,3 +25,4 @@ yarn-error.log
 /*.phar
 /*.php-cs-fixer.cache
 /.idea
+**/.DS_Store


### PR DESCRIPTION
There are a lot of files in storage/largo_cache which should not be tracked by git.
Mac OSX creates .DS_Store files to save some folder metadata, this should also be ignored.