### PR TITLE
Reduce number of maximum shown LabelBOT popups to 1

### DIFF
--- a/config/labelbot.php
+++ b/config/labelbot.php
@@ -36,15 +36,15 @@ return [
 
     /*
     ---------------------------------------------------------------------------
-    | M: Maximum Number of LabelBOT's Requests (Vector Searches)
+    | Maximum Number of parallel LabelBOT Requests (Vector Searches)
     ---------------------------------------------------------------------------
     |
-    | The value of M specifies the maximum number of vector searches in a row.
-    | This value is only needed for the UI. Once the result of a vector search
+    | The value of specifies the maximum number of parallel vector searches.
+    | This value is mostly needed for the API. Once the result of a vector search
     | is resolved by the user, a new request can be made. A higher value means more
-    | concurrent searches and increased database workload.
+    | concurrent searches and possible increased database workload.
     */
-    'max_requests' => 5,
+    'max_requests' => 2,
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/assets/js/annotations/mixins/labelbot.vue
+++ b/resources/assets/js/annotations/mixins/labelbot.vue
@@ -8,7 +8,9 @@ import Messages from '@/core/messages/store.js';
 // DINOv2 image input size.
 const INPUT_SIZE = 224;
 
-const MAX_OVERLAY_COUNT = 5;
+// This used to be higher to allow multiple popups at the same time but we found that
+// only a single popup at a time supports a more efficient workflow.
+const MAX_OVERLAY_COUNT = 1;
 
 export const LABELBOT_STATES = {
     INITIALIZING: 'initializing',

--- a/resources/assets/sass/annotations/components/_labelbot-popup.scss
+++ b/resources/assets/sass/annotations/components/_labelbot-popup.scss
@@ -1,6 +1,12 @@
 .labelbot-popup {
     border: 1px solid $input-border;
     border-radius: $border-radius-base;
+
+    &:not(.labelbot-popup--typing) {
+        .labelbot-label:first-child {
+            border-color: $brand-info;
+        }
+    }
 }
 
 .labelbot-labels {
@@ -116,12 +122,6 @@
 
         i {
             display: block;
-        }
-    }
-
-    &:not(.labelbot-popup--typing) {
-        .labelbot-label:first-child {
-            border-color: $brand-info;
         }
     }
 }

--- a/resources/views/manual/tutorials/labelbot/labelbot.blade.php
+++ b/resources/views/manual/tutorials/labelbot/labelbot.blade.php
@@ -27,7 +27,7 @@
         </p>
 
         <p>
-            The automatic timeout for confirming the first suggested label <a href="{{route('manual-tutorials', ['annotations', 'sidebar'])}}#:~:text=The%20LabelBOT%20timeout">can be configured</a> and is cancelled on any interaction with the overlay. If multiple overlays are open at the same time, the timeout is only active in the currently focused overlay. Once more than five overlays are open at the same time, the oldest overlay will automatically close, confirming the first suggested label for the respective annotation.
+            The automatic timeout for confirming the first suggested label <a href="{{route('manual-tutorials', ['annotations', 'sidebar'])}}#:~:text=The%20LabelBOT%20timeout">can be configured</a> and is cancelled on any interaction with the overlay. The timeout is also cancelled, confirming the first suggested label, when the next annotation is created.
         </p>
         <p>
             A LabelBOT overlay can be dragged to a different position, which can be handy if you create several new annotations in a row and have to review multiple overlapping overlays. To drag an overlay, grab the top edge with the cursor and release it at a different position. A dashed line indicates which overlay belongs to which annotation.


### PR DESCRIPTION
We found that only one popup at a time supports a quicker workflow, as creating a new annotation acts as an implicit confirmation of the old LabelBOT suggestions and removing the old popup cleans up the UI.

The number of allowed parallel requests is reduced as well.

Resolves https://github.com/biigle/core/issues/1261