### PR TITLE
Disable LabelBOT kNN search with dropped index

### DIFF
--- a/app/Http/Controllers/Api/ImageAnnotationController.php
+++ b/app/Http/Controllers/Api/ImageAnnotationController.php
@@ -439,10 +439,11 @@ class ImageAnnotationController extends Controller
         // Perform ANN search.
         $topNLabels = $this->performAnnSearch($featureVector, $trees);
 
+        // TODO DISABLED BECAUSE IT REPEATEDLY KILLED OUR DATABASE DURING BACKUPS
         // Perform KNN search as a fallback if ANN search returns no results.
-        if (empty($topNLabels)) {
-            $topNLabels = $this->performKnnSearch($featureVector, $trees);
-        }
+        // if (empty($topNLabels)) {
+        //     $topNLabels = $this->performKnnSearch($featureVector, $trees);
+        // }
 
         return $topNLabels;
     }


### PR DESCRIPTION
This repeatedly caused issues during the database backup, resulting in extreme memory usage and OOM errors.