### PR TITLE
Implement iterative index scans for LabelBOT

### DIFF
--- a/app/Http/Controllers/Api/ImageAnnotationController.php
+++ b/app/Http/Controllers/Api/ImageAnnotationController.php
@@ -481,12 +481,15 @@ class ImageAnnotationController extends Controller
     }
 
     /**
-     * Perform Approximate Nearest Neighbor (ANN) search using the HNSW iterative index scan with Post-Filtering (PF).
+     * Perform Approximate Nearest Neighbor (ANN) search using the HNSW iterative index
+     * scan.
      *
-     * The search uses the HNSW iterative index scan to find the top K nearest neighbors of the input feature vector,
-     * and then applies post filtering based on the label_tree_id values. If the filtering removes all results,
-     * the iterative scan will automatically scan more of the index until enough results are found
-     * (or it reaches hnsw.max_scan_tuples, which is 20,000 by default), finally if no results are found, an empty array is returned.
+     * The search uses the HNSW iterative index scan to find the top K nearest neighbors
+     * of the input feature vector, and then applies filtering based on the label_tree_id
+     * values. If the filtering removes all results, the iterative scan will
+     * automatically scan more of the index until enough results are found (or it reaches
+     * hnsw.max_scan_tuples, which is 20,000 by default), finally if no results are
+     * found, an empty array is returned.
      *
      * @param Vector $featureVector The input feature vector to search for nearest neighbors.
      * @param int[] $trees The label tree IDs to filter the data by.


### PR DESCRIPTION
Dropping the `HNSW` index each time the ANN search does not provide results to perform exact NN search and then rolling back the transaction, is a dangerous approach (see #1264). This PR implements the [iterative index scans](https://github.com/pgvector/pgvector?tab=readme-ov-file#iterative-index-scans) approach to be used as a fallback when the ANN does not provide any results.