### PR TITLE
Split big xlsx reports

### DIFF
--- a/resources/scripts/reports/csvs_to_xlsx.py
+++ b/resources/scripts/reports/csvs_to_xlsx.py
@@ -8,8 +8,9 @@ csv.field_size_limit(sys.maxsize)
 target_file = sys.argv[2]
 csvs = sys.argv[3:]
 
-#Arbitrary limit of rows for a single sheet. See https://github.com/biigle/core/issues/1040
-ROW_LIMIT = 5000
+# Split sheets if they would have too many rows.
+# See: https://github.com/biigle/core/issues/1040
+ROW_LIMIT = 100_000
 
 workbook = Workbook()
 numSheets = 0

--- a/resources/scripts/reports/full_report.py
+++ b/resources/scripts/reports/full_report.py
@@ -10,8 +10,9 @@ target_file = sys.argv[2]
 csvs = sys.argv[3:]
 workbook = Workbook()
 
-#Arbitrary limit of rows for a single sheet. See https://github.com/biigle/core/issues/1040
-ROW_LIMIT = 5000
+# Split sheets if they would have too many rows.
+# See: https://github.com/biigle/core/issues/1040
+ROW_LIMIT = 100_000
 
 def add_sheet(csv_path, index):
     with open(csv_path, 'r') as f:
@@ -44,8 +45,7 @@ def add_sheet(csv_path, index):
 
     # rows have the content: image_filename, annotation_id, label_name, shape_name, points, image area
     celldata = [[csv_title], csv_column_labels]
-    #Ensure that the first sheet index is 0
-    sheet_idx = -1
+    sheet_idx = 0
     for filename in sorted(images):
         image = images[filename]
         for annotation_id, annotation in image['annotations'].items():
@@ -55,16 +55,15 @@ def add_sheet(csv_path, index):
             for point in points:
                 celldata.append(['', '', '', point, next(points, ''), '', ''])
             if len(celldata) // ROW_LIMIT >= 1:
-                sheet_idx += 1
                 ws = workbook.new_sheet(f"sheet {index}-{sheet_idx}", data=celldata)
                 ws.set_row_style(1, Style(font=Font(bold=True)))
                 ws.set_row_style(2, Style(font=Font(bold=True)))
+                celldata = [[csv_title], csv_column_labels]
+                sheet_idx += 1
 
-                celldata =[[csv_title], csv_column_labels]
-
-    #Avoid edge case where there is only the title and column labels
+    # Avoid edge case where there is only the title and column labels
     if len(celldata) > 2:
-        ws = workbook.new_sheet(f"sheet {index}-{sheet_idx + 1}", data=celldata)
+        ws = workbook.new_sheet(f"sheet {index}-{sheet_idx}", data=celldata)
         ws.set_row_style(1, Style(font=Font(bold=True)))
         ws.set_row_style(2, Style(font=Font(bold=True)))
 

--- a/resources/views/manual/tutorials/reports/reports-schema.blade.php
+++ b/resources/views/manual/tutorials/reports/reports-schema.blade.php
@@ -67,6 +67,10 @@
         </ol>
 
         <p>
+            Reports with more than 100,000 rows are split into multiple worksheets.
+        </p>
+
+        <p>
             If "aggregate child labels" was enabled for this report, the abundances of all child labels will be added to the abundance of the highest parent label and the child labels will be excluded from the report.
         </p>
 
@@ -139,6 +143,10 @@
             <li><strong>Annotation area (px²)</strong></li>
         </ol>
 
+        <p>
+             Reports with more than 100,000 rows are split into multiple worksheets.
+        </p>
+
         <h4><a name="annotation-basic-report"></a>Basic</h4>
         <p>
             The basic image annotation report contains a graphical plot of abundances of the different annotation labels (annotations can have multiple labels by different users). If the annotations should be separated by label tree or user, there will be one plot for each label tree or user.
@@ -195,7 +203,7 @@
         <h4><a name="annotation-extended-report"></a>Extended</h4>
 
         <p>
-            The extended image annotation report is an XLSX spreadsheet which contains a list of the abundances of each label and image. If the annotations should be separated by label tree or user, there will be one worksheet for each label tree or user. If these worksheets are over 5000 lines long, the worksheet will be split in multiple worksheets to allow it to be managable by spreadsheet programs such as Excel and Calc.
+            The extended image annotation report is an XLSX spreadsheet which contains a list of the abundances of each label and image. If the annotations should be separated by label tree or user, there will be one worksheet for each label tree or user. Reports with more than 100,000 rows are also split into multiple worksheets.
         </p>
         <p>
             For a single worksheet (not separated by label tree or user) the first line contains the volume name. For multiple worksheets the first lines contain the name of the respective label tree or user. The second line always contains the column headers. The columns are as follows:


### PR DESCRIPTION
 This PR addresses #1040 - It changes the python scripts `full_report.py` and `csvs_to_xslx.py` so that reports that are too big are split into multiple sheets.
For now, the limit of rows is set to 5000 - I am not sure if that is too low or too big. It could also be set via environment variable using `python-dotenv` potentially.