### PR TITLE
Fix generating of thumbnails after cloning a volume

### DIFF
--- a/app/Listeners/VolumeClonedListener.php
+++ b/app/Listeners/VolumeClonedListener.php
@@ -10,7 +10,7 @@ class VolumeClonedListener
 {
     public function handle(VolumeCloned $event): void
     {
-        // Give the ProcessNewVolumeFiles job (from CloneImagesorVideos) a head start so
+        // Give the ProcessCloneVolumeFiles job (from CloneImagesOrVideos) a head start so
         // the file thumbnails are generated (mostly) before the annotation thumbnails.
         $delay = now()->addSeconds(30);
 


### PR DESCRIPTION
The job and event were dispatched inside the transaction so often the cloned volume files would not exist when the job and event were handled.