### PR TITLE
Update default TrustHosts middleware

### DIFF
--- a/app/Http/Middleware/TrustHosts.php
+++ b/app/Http/Middleware/TrustHosts.php
@@ -6,15 +6,5 @@ use Illuminate\Http\Middleware\TrustHosts as Middleware;
 
 class TrustHosts extends Middleware
 {
-    /**
-     * Get the host patterns that should be trusted.
-     *
-     * @return array<int, string|null>
-     */
-    public function hosts(): array
-    {
-        return [
-            $this->allSubdomainsOfApplicationUrl(),
-        ];
-    }
+    //
 }


### PR DESCRIPTION
The base middleware already allows "allSubdomainsOfApplicationUrl" by default. The own implementation can be updated in dockerfiles to specify different trusted hosts with $alwaysTrust.