### PR TITLE
Handle edge case in volume breadcrumbs

### DIFF
--- a/resources/views/volumes/partials/projectsBreadcrumb.blade.php
+++ b/resources/views/volumes/partials/projectsBreadcrumb.blade.php
@@ -9,6 +9,8 @@
             </template>
         </dropdown>
     </span>
+@elseif (($firstProject = $projects->first()))
+    <a href="{{route('project', $firstProject->id)}}" class="navbar-link" title="Show project {{$firstProject->name}}">{{$firstProject->name}}</a>
 @else
-    <a href="{{route('project', $projects->first()->id)}}" class="navbar-link" title="Show project {{$projects->first()->name}}">{{$projects->first()->name}}</a>
+    <span class="text-muted">no project</span>
 @endif


### PR DESCRIPTION
If a volume is deleted is has no project any more but it can still exist whle the delete job is handled. If a user happens to open the volume or annotation view now, an error would be thrown. This change handles this case gracefully.