### PR TITLE
Improve announcement behavior

### DIFF
--- a/resources/assets/js/core/announcements/container.vue
+++ b/resources/assets/js/core/announcements/container.vue
@@ -12,9 +12,11 @@ export default {
         };
     },
     methods: {
+        handleShow() {
+            window.localStorage.setItem('seen-announcement', this.id);
+        },
         handleHide() {
             this.expand = false;
-            window.localStorage.setItem('seen-announcement', this.id);
         },
     },
     mounted() {

--- a/resources/views/partials/announcement.blade.php
+++ b/resources/views/partials/announcement.blade.php
@@ -1,8 +1,8 @@
-<span id="announcement" class="announcement">
-    <popover announcement-id="{{$announcement->id}}" v-on:hide="handleHide" placement="bottom">
-        <button class="btn btn-warning btn-sm">
+<span v-cloak id="announcement" class="announcement">
+    <popover announcement-id="{{$announcement->id}}" v-on:show="handleShow" v-on:hide="handleHide" placement="bottom">
+        <button class="btn btn-warning btn-sm" title="Show announcement">
             <i class="fa fa-bullhorn"></i>
-            <span v-cloak v-if="expand" class="announcement-text">
+            <span v-if="expand" class="announcement-text">
                 {{$announcement->title}}
             </span>
         </button>


### PR DESCRIPTION
Before, the announcement did not save the "seen" state if the user clicked on a link in the announcement. Also, the announcement text sometimes flickered.