### PR TITLE
Replace utif2.js with geotiff.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "core",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@biigle/ol": "^9.2.4",
@@ -16,13 +15,13 @@
         "@turf/union": "^6.5.0",
         "bootstrap-sass": "^3.3.7",
         "echarts": "^5.3.2",
+        "geotiff": "^2.1.3",
         "jsts": "^2.11.0",
         "magic-wand-tool": "^1.1.4",
         "mitt": "^3.0.1",
         "onnxruntime-web": "^1.20.1",
         "polymorph-js": "^0.2.4",
         "uiv": "^2.0.6",
-        "utif2": "^4.1.0",
         "vue": "^3.5.11",
         "vue-resource": "^1.0.3"
       },
@@ -4106,21 +4105,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/utif2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
-      "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
-      "license": "MIT",
-      "dependencies": {
-        "pako": "^1.0.11"
-      }
-    },
-    "node_modules/utif2/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "license": "(MIT AND Zlib)"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "onnxruntime-web": "^1.20.1",
     "polymorph-js": "^0.2.4",
     "uiv": "^2.0.6",
-    "utif2": "^4.1.0",
+    "geotiff": "^2.1.3",
     "vue": "^3.5.11",
     "vue-resource": "^1.0.3"
   },


### PR DESCRIPTION
utif2 had issues with TIFF files that used JPEG compression and JPEG tables. geotiff.js works better and is smaller.

See: https://github.com/orgs/biigle/discussions/1338