### PR TITLE
Use more descriptive prop name for label trees sorting

### DIFF
--- a/resources/assets/js/label-trees/components/labelTrees.vue
+++ b/resources/assets/js/label-trees/components/labelTrees.vue
@@ -141,14 +141,15 @@ export default {
             type: Number,
             default: undefined,
         },
-        projectIds: {
+        // Sorting is disabled if IDs are not provided.
+        sortingProjectIds: {
             type: Array,
             default: undefined,
-        }
+        },
     },
     computed: {
         customOrderStorageKeys() {
-            return this.projectIds.map(id => `biigle.projects.${id}.label-trees.custom-order`)
+            return this.sortingProjectIds.map(id => `biigle.projects.${id}.label-trees.custom-order`)
         },
         sortedTrees() {
             return this.customOrder.map(id => this.trees.find(tree => id === tree.id));
@@ -314,7 +315,7 @@ export default {
     created() {
         this.events = mitt();
 
-        this.sortable = this.projectIds !== undefined;
+        this.sortable = this.sortingProjectIds !== undefined;
 
         if (this.sortable) {
             //If multiple label trees appear in multiple projects, and a volume is attached to multiple projects,

--- a/resources/assets/js/volumes/components/labelsTab.vue
+++ b/resources/assets/js/volumes/components/labelsTab.vue
@@ -13,7 +13,7 @@
     </div>
     <label-trees
         :trees="labelTrees"
-        :project-ids="projectIds"
+        :sorting-project-ids="projectIds"
         :show-favourites="true"
         v-on:select="handleSelectedLabel"
         v-on:deselect="handleDeselectedLabel"

--- a/resources/views/annotations/show/tabs/labels.blade.php
+++ b/resources/views/annotations/show/tabs/labels.blade.php
@@ -51,7 +51,7 @@
             </div>
         @endif
         <div class="labels-tab__trees">
-            <label-trees ref="labelTrees" :trees="labelTrees" :project-ids="projectIds" :show-favourites="true" :focus-input="focusInputFindlabel" v-on:select="handleSelectedLabel" v-on:deselect="handleDeselectedLabel" v-on:clear="handleDeselectedLabel"></label-trees>
+            <label-trees ref="labelTrees" :trees="labelTrees" :sorting-project-ids="projectIds" :show-favourites="true" :focus-input="focusInputFindlabel" v-on:select="handleSelectedLabel" v-on:deselect="handleDeselectedLabel" v-on:clear="handleDeselectedLabel"></label-trees>
         </div>
         <div class="labels-tab__plugins">
             <example-annotations

--- a/resources/views/largo/show/content.blade.php
+++ b/resources/views/largo/show/content.blade.php
@@ -54,7 +54,7 @@
                 <power-toggle :active="forceChange" type="danger" title="Delete or replace annotation labels created by other users" v-on:on="enableForceChange" :disabled="loading || null" v-on:off="disableForceChange">Force delete/relabel</power-toggle>
             </div>
         @endcan
-        <label-trees class="largo-tab__label-trees" :trees="labelTrees" :show-favourites="true" :project-ids="projectIds" v-on:select="handleSelectedLabel" v-on:deselect="handleDeselectedLabel" v-on:clear="handleDeselectedLabel"></label-trees>
+        <label-trees class="largo-tab__label-trees" :trees="labelTrees" :show-favourites="true" :sorting-project-ids="projectIds" v-on:select="handleSelectedLabel" v-on:deselect="handleDeselectedLabel" v-on:clear="handleDeselectedLabel"></label-trees>
     </sidebar-tab>
     @include('largo.labelList')
     <sidebar-tab :disabled="isInRelabelStep || null" name="sorting" icon="exchange-alt fa-rotate-90" title="Sort patches" :highlight="sortingIsActive">

--- a/resources/views/videos/show/sidebar-labels.blade.php
+++ b/resources/views/videos/show/sidebar-labels.blade.php
@@ -3,7 +3,7 @@
         <div class="labels-tab__trees">
             <label-trees
                 :trees="labelTrees"
-                :project-ids="projectIds"
+                :sorting-project-ids="projectIds"
                 :focus-input="focusInputFindlabel"
                 :show-favourites="true"
                 :selected-favourite-label="selectedFavouriteLabel"


### PR DESCRIPTION
The prop now also controls if sorting is enabled at all for the component.

References: https://github.com/biigle/core/pull/1342