### PR TITLE
Fix new label trees not visible if previously sorted

### DIFF
--- a/resources/assets/js/label-trees/components/labelTrees.vue
+++ b/resources/assets/js/label-trees/components/labelTrees.vue
@@ -336,7 +336,7 @@ export default {
             // project.
             customOrderSet.forEach((id) => {
                 if (!this.treeIds.includes(id)) {
-                    customOrder.delete(id);
+                    customOrderSet.delete(id);
                 }
             });
         }


### PR DESCRIPTION
If a user stored a sorting order and then a new label tree was added to the project, the new label tree was not visible to the user.