### PR TITLE
Fix cleanup of pending volumes

### DIFF
--- a/app/Http/Controllers/Api/PendingVolumeController.php
+++ b/app/Http/Controllers/Api/PendingVolumeController.php
@@ -97,7 +97,7 @@ class PendingVolumeController extends Controller
         $project = Project::inCommon($request->user(), $request->volume->id, [Role::adminId()])->first();
 
         // Delete individually to trigger deletion of metadata files.
-        PendingVolume::where('volume_id', $request->volume->id)
+        $project->pendingVolumes()->where('user_id', $request->user()->id)
             ->eachById(fn ($pv) => $pv->delete());
 
         $pv = $project->pendingVolumes()->create([

--- a/tests/php/Http/Controllers/Api/PendingVolumeControllerTest.php
+++ b/tests/php/Http/Controllers/Api/PendingVolumeControllerTest.php
@@ -343,6 +343,56 @@ class PendingVolumeControllerTest extends ApiTestCase
 
         $old = PendingVolume::factory()->create([
             'volume_id' => $id,
+            'project_id' => $this->project()->id,
+            'user_id' => $this->admin()->id,
+        ]);
+
+        $this->beAdmin();
+
+        $this->volume()->update([
+            'metadata_file_path' => 'metadata.csv',
+            'metadata_parser' => ImageCsvParser::class,
+        ]);
+
+        $metadata = new VolumeMetadata;
+        $file = new ImageMetadata('1.jpg');
+        $metadata->addFile($file);
+        $label = new Label(123, 'my label');
+        $user = new User(321, 'joe user');
+        $lau = new LabelAndUser($label, $user);
+        $annotation = new ImageAnnotation(
+            shape: Shape::point(),
+            points: [10, 10],
+            labels: [$lau],
+        );
+        $file->addAnnotation($annotation);
+
+        Cache::store('array')->put('metadata-metadata-metadata.csv', $metadata);
+
+        $this->json('POST', "/api/v1/volumes/{$id}/pending-volumes", [
+            'import_annotations' => true,
+        ])->assertStatus(201);
+
+        $pv = PendingVolume::where('volume_id', $id)->first();
+        $this->assertNotSame($old->id, $pv->id);
+        $this->assertNull($old->fresh());
+    }
+
+    public function testStoreVolumeTwiceDifferentVolumes()
+    {
+        config([
+            'volumes.metadata_storage_disk' => 'metadata',
+            'volumes.pending_metadata_storage_disk' => 'pending-metadata',
+        ]);
+        $metaDisk = Storage::fake('metadata');
+        $metaDisk->put('metadata.csv', 'abc');
+        $pendingDisk = Storage::fake('pending-metadata');
+
+        $id = $this->volume()->id;
+
+        $old = PendingVolume::factory()->create([
+            'user_id' => $this->admin()->id,
+            'project_id' => $this->project()->id,
         ]);
 
         $this->beAdmin();


### PR DESCRIPTION
A user may only create one pending volume for each project. Before, it was possible to start creating multiple ones but this failed the database constraint. Now the other pending volumes are correctly cleaned up before a new one is created.