### PR TITLE
Order-agnostic result assertion

### DIFF
--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationReportGeneratorTest.php
@@ -575,7 +575,7 @@ class AnnotationReportGeneratorTest extends TestCase
             'annotation_id' => ImageAnnotationTest::create([
                 'image_id' => $image->id,
                 'created_at' => '2016-10-05 09:15:00',
-            ]),
+            ])->id,
             'user_id' => $userId,
         ]);
 

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationReportGeneratorTest.php
@@ -571,13 +571,11 @@ class AnnotationReportGeneratorTest extends TestCase
 
         $session->users()->attach($userId);
 
-        $a = ImageAnnotationTest::create([
-            'image_id' => $image->id,
-            'created_at' => '2016-10-05 09:15:00',
-        ]);
-
         $al1 = ImageAnnotationLabelTest::create([
-            'annotation_id' => $a->id,
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+                'created_at' => '2016-10-05 09:15:00',
+            ]),
             'user_id' => $userId,
         ]);
 
@@ -612,9 +610,15 @@ class AnnotationReportGeneratorTest extends TestCase
         $generator->setSource($session->volume);
         $results = $generator->initQuery()->get();
         $this->assertCount(3, $results);
-        $this->assertEquals($al1->label->label_tree_id, $results[0]->label_tree_id);
-        $this->assertEquals($al3->label->label_tree_id, $results[1]->label_tree_id);
-        $this->assertEquals($al4->label->label_tree_id, $results[2]->label_tree_id);
+       
+        $this->assertEqualsCanonicalizing(
+            [
+                $al1->label->label_tree_id,
+                $al3->label->label_tree_id,
+                $al4->label->label_tree_id,
+            ],
+            $results->pluck('label_tree_id')->all()
+        );
     }
 
     public function testAnnotationSessionNewestLabelSeparateLabelTree()


### PR DESCRIPTION
The AnnotationReportGenerator returns a list of all labels attached to an annotation within a given session. The order of the rows is undefined (no ORDER BY), so the test can't rely on it. 