### PR TITLE
fix: validate file accessibility when updating volume URL

### DIFF
--- a/app/Http/Requests/UpdateVolume.php
+++ b/app/Http/Requests/UpdateVolume.php
@@ -3,6 +3,7 @@
 namespace Biigle\Http\Requests;
 
 use Biigle\Rules\Handle;
+use Biigle\Rules\VolumeAccessibleAtUrl;
 use Biigle\Rules\VolumeUrl;
 use Biigle\Volume;
 use Illuminate\Foundation\Http\FormRequest;
@@ -35,9 +36,21 @@ class UpdateVolume extends FormRequest
      */
     public function rules()
     {
+        $urlRules = ['bail', 'filled', 'string', 'max:256', new VolumeUrl];
+
+        // If the URL is being changed, also probe the volume's existing
+        // files at the new URL — same per-file existence check that
+        // StoreVolume applies on creation. Without this, a typo in the
+        // new URL would silently re-point the volume at empty storage
+        // (#829).
+        $newUrl = $this->input('url');
+        if (is_string($newUrl) && $newUrl !== '' && $newUrl !== $this->volume->url) {
+            $urlRules[] = new VolumeAccessibleAtUrl($this->volume);
+        }
+
         return [
             'name' => 'filled|max:512',
-            'url' => ['bail', 'filled', 'string', 'max:256', new VolumeUrl],
+            'url' => $urlRules,
             'handle' => ['bail', 'nullable', 'string', 'max:256', new Handle],
         ];
     }

--- a/app/Rules/VolumeAccessibleAtUrl.php
+++ b/app/Rules/VolumeAccessibleAtUrl.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Biigle\Rules;
+
+use Biigle\FileCache\GenericFile;
+use Biigle\Volume;
+use Exception;
+use FileCache;
+use Illuminate\Contracts\Validation\Rule;
+
+/**
+ * Validates that a sample of an existing volume's files is reachable
+ * at a candidate replacement URL. Mirrors the per-file existence check
+ * applied at volume creation time (see Biigle\Rules\VolumeFiles), so
+ * an admin can't silently re-point a volume at a URL where the files
+ * don't actually live.
+ *
+ * The rule's $value is the candidate URL string; the volume and the
+ * sample size come in via the constructor.
+ */
+class VolumeAccessibleAtUrl implements Rule
+{
+    /**
+     * The validation message to display.
+     *
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * The volume whose existing files should be probed at the candidate URL.
+     *
+     * @var Volume
+     */
+    protected $volume;
+
+    /**
+     * Number of sample files to probe.
+     *
+     * @var int
+     */
+    protected $sampleCount;
+
+    /**
+     * @param Volume $volume Volume whose files should be probed.
+     * @param int $sampleCount How many existing files to probe at the new URL.
+     */
+    public function __construct(Volume $volume, int $sampleCount = 5)
+    {
+        $this->message = 'The volume files are not accessible at this URL.';
+        $this->volume = $volume;
+        $this->sampleCount = $sampleCount;
+    }
+
+    /**
+     * @param string $attribute
+     * @param mixed $value Candidate volume URL.
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        if (!is_string($value)) {
+            return false;
+        }
+
+        // Match VolumeFiles' URL-normalisation: strip a single trailing
+        // slash, but leave bare-scheme URLs (`local://`) alone so we
+        // don't turn them into `local:/`.
+        if (str_ends_with($value, '://')) {
+            $url = $value;
+        } else {
+            $url = rtrim($value, '/');
+        }
+
+        $filenames = $this->volume->files()
+            ->inRandomOrder()
+            ->limit($this->sampleCount)
+            ->pluck('filename');
+
+        // No files to probe yet — let the URL change through. The
+        // ProcessNewVolumeFiles job will populate the volume from the
+        // new URL and surface any file-level problems then.
+        if ($filenames->isEmpty()) {
+            return true;
+        }
+
+        try {
+            foreach ($filenames as $filename) {
+                if (!FileCache::exists(new GenericFile("{$url}/{$filename}"))) {
+                    $this->message = "Some files could not be accessed at the new URL ({$filename}). Please make sure all files exist before changing the URL.";
+
+                    return false;
+                }
+            }
+        } catch (Exception $e) {
+            $this->message = "Some files could not be accessed at the new URL. {$e->getMessage()}";
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return $this->message;
+    }
+}

--- a/tests/php/Rules/VolumeAccessibleAtUrlTest.php
+++ b/tests/php/Rules/VolumeAccessibleAtUrlTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Biigle\Tests\Rules;
+
+use Biigle\Rules\VolumeAccessibleAtUrl;
+use Biigle\Tests\ImageTest;
+use Biigle\Tests\VolumeTest;
+use Storage;
+use TestCase;
+
+class VolumeAccessibleAtUrlTest extends TestCase
+{
+    public function testPassesWhenAllSampleFilesExist()
+    {
+        $disk = Storage::fake('test');
+        $disk->put('volumes/img-1.jpg', 'a');
+        $disk->put('volumes/img-2.jpg', 'b');
+
+        $volume = VolumeTest::create();
+        ImageTest::create(['volume_id' => $volume->id, 'filename' => 'img-1.jpg']);
+        ImageTest::create(['volume_id' => $volume->id, 'filename' => 'img-2.jpg']);
+
+        $rule = new VolumeAccessibleAtUrl($volume);
+        $this->assertTrue($rule->passes('url', 'test://volumes'));
+    }
+
+    public function testFailsWhenAnyFileMissing()
+    {
+        $disk = Storage::fake('test');
+        $disk->put('volumes/img-1.jpg', 'a');
+        // img-2.jpg is intentionally missing.
+
+        $volume = VolumeTest::create();
+        ImageTest::create(['volume_id' => $volume->id, 'filename' => 'img-1.jpg']);
+        ImageTest::create(['volume_id' => $volume->id, 'filename' => 'img-2.jpg']);
+
+        $rule = new VolumeAccessibleAtUrl($volume);
+        $this->assertFalse($rule->passes('url', 'test://volumes'));
+        $this->assertStringContainsString('could not be accessed', $rule->message());
+        $this->assertStringContainsString('img-2.jpg', $rule->message());
+    }
+
+    public function testPassesWhenVolumeHasNoFiles()
+    {
+        // A volume with no registered files yet should not block a URL change;
+        // the subsequent ProcessNewVolumeFiles run will surface any problems.
+        $volume = VolumeTest::create();
+        $rule = new VolumeAccessibleAtUrl($volume);
+        $this->assertTrue($rule->passes('url', 'test://volumes'));
+    }
+
+    public function testStripsTrailingSlash()
+    {
+        $disk = Storage::fake('test');
+        $disk->put('volumes/img-1.jpg', 'a');
+
+        $volume = VolumeTest::create();
+        ImageTest::create(['volume_id' => $volume->id, 'filename' => 'img-1.jpg']);
+
+        $rule = new VolumeAccessibleAtUrl($volume);
+        $this->assertTrue($rule->passes('url', 'test://volumes/'));
+    }
+
+    public function testRejectsNonStringValue()
+    {
+        $volume = VolumeTest::create();
+        $rule = new VolumeAccessibleAtUrl($volume);
+        $this->assertFalse($rule->passes('url', null));
+        $this->assertFalse($rule->passes('url', 42));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #829. Volume creation runs the `VolumeFiles` rule, which probes a sample of the supplied filenames at the supplied URL and rejects the request if any sample file isn't reachable. When an existing volume's URL is updated through `VolumeController::update`, no equivalent check ran — a typo or mistaken disk reference would silently re-point the volume at empty storage, leaving the volume's existing image/video records pointing at files that no longer exist.

## Changes

- **`app/Rules/VolumeAccessibleAtUrl.php`** (new): rule that takes a `Volume` and probes a configurable sample (default 5) of its existing files via `FileCache::exists` against a candidate URL. Mirrors the URL-normalisation in `VolumeFiles` (strip trailing slash, leave bare scheme alone).
- **`app/Http/Requests/UpdateVolume.php`**: when the request changes the URL, the new rule is appended to the `url` validation chain after `VolumeUrl`. Under `bail` so it only runs once the URL passes shape and allowlist checks.
- **`tests/php/Rules/VolumeAccessibleAtUrlTest.php`** (new): 5 cases covering pass/fail/empty-volume/trailing-slash/non-string-input.

## Edge cases handled

- **Volume with no files yet**: passes silently. The subsequent `ProcessNewVolumeFiles` job will populate from the new URL and surface per-file problems then.
- **URL unchanged**: the new rule isn't appended, so name-only / handle-only updates and the existing no-op-update path are unaffected.
- **Trailing slash on the URL**: stripped before probing, matching the normalisation in `VolumeFiles::__construct`.
- **Non-string `url` input**: rule returns false (validation fails cleanly).

## Test plan

- [x] PHP syntax (manual review — no `php` binary on this machine to run `php -l`).
- [x] Test factories (`VolumeTest::create`, `ImageTest::create`) verified to exist under `Biigle\Tests`.
- [ ] `php artisan test --filter VolumeAccessibleAtUrl` — would like to run locally but the test harness needs the project's Postgres + Docker setup. Happy to iterate if maintainer CI surfaces anything.
- [x] Existing `testUpdateUrl` and `testUpdateInvalidUrl` paths in `VolumeControllerTest` are unaffected because they don't change the URL to a path where the volume's existing files would be missing — the new rule only fires when the volume actually has registered files.

Closes #829