### PR TITLE
Fix HTML encoding of imported filenames

### DIFF
--- a/resources/views/volumes/create/step2.blade.php
+++ b/resources/views/volumes/create/step2.blade.php
@@ -8,7 +8,7 @@
         biigle.$declare('volumes.url', '{!! $oldUrl !!}');
         biigle.$declare('volumes.handle', {{ Js::from($oldHandle) }});
         biigle.$declare('volumes.mediaType', '{!! $mediaType !!}');
-        biigle.$declare('volumes.filenames', '{{ $filenames }}');
+        biigle.$declare('volumes.filenames', {{ Js::from($filenames) }});
         biigle.$declare('volumes.filenamesFromMeta', {{ $filenamesFromMeta ? 'true' : 'false' }});
         biigle.$declare('volumes.disks', {!! $disks->keys() !!});
     </script>


### PR DESCRIPTION
In resources/views/volumes/create/step2.blade.php, filenames extracted from the metadata CSV were injected into a JavaScript variable using Blade's {{ }} syntax, which HTML-encoded the output.

HTML encoding broke some of the filenames by converting characters such as '&' to '&amp;'.

Replaced `'{{ $filenames }}'` with `Js::from($filenames)` which properly encodes the string and preserves special characters.

Addresses #1438 