### PR TITLE
Fix LabelBOT request vector format

### DIFF
--- a/resources/assets/js/annotations/workers/labelbot.js
+++ b/resources/assets/js/annotations/workers/labelbot.js
@@ -54,7 +54,7 @@ self.onmessage = function(event) {
                 self.postMessage({
                     type: 'run',
                     labelbotMessageID: event.data.labelbotMessageID,
-                    vector: output[Object.keys(output)[0]].data,
+                    vector: Array.from(output[Object.keys(output)[0]].data),
                 });
             }, (error) => {
                 self.postMessage({


### PR DESCRIPTION
Convert the feature vector to an array at the LabelBOT worker level