### PR TITLE
Make typahead scrollable

### DIFF
--- a/resources/assets/js/label-trees/components/labelTypeahead.vue
+++ b/resources/assets/js/label-trees/components/labelTypeahead.vue
@@ -14,6 +14,10 @@ export default {
             type: Object,
             default: () => LabelTypeaheadItem,
         },
+        scrollable: {
+            type: Boolean,
+            default: true,
+        },
     },
 };
 </script>


### PR DESCRIPTION
Resolves #1474 

Makes the typeahead for labels scrollable

https://github.com/user-attachments/assets/e7433739-6efd-47d8-880e-6f8235f75fba

