### PR TITLE
Improve Largo session error handling

### DIFF
--- a/app/Http/Controllers/Api/Projects/LargoController.php
+++ b/app/Http/Controllers/Api/Projects/LargoController.php
@@ -7,7 +7,10 @@ use Biigle\Http\Requests\StoreProjectLargoSession;
 use Biigle\Jobs\ApplyLargoSession;
 use Biigle\Label;
 use Biigle\Project;
+use DB;
+use Queue;
 use Ramsey\Uuid\Uuid;
+use Throwable;
 
 class LargoController extends Controller
 {
@@ -38,16 +41,33 @@ class LargoController extends Controller
         }
 
         $uuid = Uuid::uuid4();
+
         // Set job ID in volumes to lock them for any other Largo sessions to save while
         // this session is saved.
-        $request->volumes->each(function ($volume) use ($uuid) {
-            $attrs = $volume->attrs;
-            $attrs['largo_job_id'] = $uuid;
-            $volume->attrs = $attrs;
-            $volume->save();
+        DB::transaction(function () use ($uuid, $request) {
+            $request->volumes->each(function ($volume) use ($uuid) {
+                $attrs = $volume->attrs;
+                $attrs['largo_job_id'] = $uuid;
+                $volume->attrs = $attrs;
+                $volume->save();
+            });
         });
 
-        ApplyLargoSession::dispatch($uuid, $request->user(), $request->dismissedImageAnnotations, $request->changedImageAnnotations, $request->dismissedVideoAnnotations, $request->changedVideoAnnotations, $request->force);
+        try {
+            $job = new ApplyLargoSession($uuid, $request->user(), $request->dismissedImageAnnotations, $request->changedImageAnnotations, $request->dismissedVideoAnnotations, $request->changedVideoAnnotations, $request->force);
+            Queue::pushOn($job->queue, $job);
+        } catch (Throwable $e) {
+            // We can't use DB::transaction to roll back the changes because this would
+            // allow a situation where the queue job runs before the transaction was
+            // committed.
+            $request->volumes->each(function ($volume) {
+                $attrs = $volume->attrs;
+                unset($attrs['largo_job_id']);
+                $volume->attrs = $attrs;
+                $volume->save();
+            });
+            throw $e;
+        }
 
         return ['id' => $uuid];
     }

--- a/app/Http/Controllers/Api/Volumes/LargoController.php
+++ b/app/Http/Controllers/Api/Volumes/LargoController.php
@@ -6,7 +6,9 @@ use Biigle\Http\Controllers\Api\Controller;
 use Biigle\Http\Requests\StoreVolumeLargoSession;
 use Biigle\Jobs\ApplyLargoSession;
 use Illuminate\Http\Request;
+use Queue;
 use Ramsey\Uuid\Uuid;
+use Throwable;
 
 class LargoController extends Controller
 {
@@ -60,7 +62,19 @@ class LargoController extends Controller
         $request->volume->attrs = $attrs;
         $request->volume->save();
 
-        ApplyLargoSession::dispatch($uuid, $request->user(), $request->dismissedImageAnnotations, $request->changedImageAnnotations, $request->dismissedVideoAnnotations, $request->changedVideoAnnotations, $request->force);
+        try {
+            $job = new ApplyLargoSession($uuid, $request->user(), $request->dismissedImageAnnotations, $request->changedImageAnnotations, $request->dismissedVideoAnnotations, $request->changedVideoAnnotations, $request->force);
+            Queue::pushOn($job->queue, $job);
+        } catch (Throwable $e) {
+            // We can't use DB::transaction to roll back the changes because this would
+            // allow a situation where the queue job runs before the transaction was
+            // committed.
+            $attrs = $request->volume->attrs;
+            unset($attrs['largo_job_id']);
+            $request->volume->attrs = $attrs;
+            $request->volume->save();
+            throw $e;
+        }
 
         return ['id' => $uuid];
     }

--- a/tests/php/Http/Controllers/Api/Projects/LargoControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Projects/LargoControllerTest.php
@@ -494,4 +494,24 @@ class LargoControllerTest extends ApiTestCase
         ])->assertStatus(200);
         Queue::assertPushed(ApplyLargoSession::class);
     }
+
+    public function testQueuePushFailureClearsJobId()
+    {
+        Queue::shouldReceive('pushOn')->once()->andThrow(new \Exception('Queue error'));
+
+        $this->withoutExceptionHandling();
+        $this->beEditor();
+        try {
+            $this->postJson("/api/v1/projects/{$this->project()->id}/largo", [
+                'dismissed_image_annotations' => [
+                    $this->imageAnnotationLabel->label_id => [$this->imageAnnotation->id],
+                ],
+                'changed_image_annotations' => [],
+            ]);
+        } catch (\Exception $e) {
+            // expected
+        }
+
+        $this->assertEmpty($this->imageVolume->fresh()->attrs);
+    }
 }

--- a/tests/php/Http/Controllers/Api/Volumes/LargoControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Volumes/LargoControllerTest.php
@@ -484,4 +484,24 @@ class LargoControllerTest extends ApiTestCase
         ])->assertStatus(200);
         Queue::assertPushed(ApplyLargoSession::class);
     }
+
+    public function testQueuePushFailureClearsJobId()
+    {
+        Queue::shouldReceive('pushOn')->once()->andThrow(new \Exception('Queue error'));
+
+        $this->withoutExceptionHandling();
+        $this->beEditor();
+        try {
+            $this->postJson("/api/v1/volumes/{$this->imageVolume->id}/largo", [
+                'dismissed_image_annotations' => [
+                    $this->imageAnnotationLabel->label_id => [$this->imageAnnotation->id],
+                ],
+                'changed_image_annotations' => [],
+            ]);
+        } catch (\Exception $e) {
+            // expected
+        }
+
+        $this->assertEmpty($this->imageVolume->fresh()->attrs);
+    }
 }


### PR DESCRIPTION
If there was an error during submission of a job, the Largo ID flag could persist indefinitely.