### PR TITLE
Impove export validation

### DIFF
--- a/app/Http/Controllers/Api/Export/Controller.php
+++ b/app/Http/Controllers/Api/Export/Controller.php
@@ -3,7 +3,7 @@
 namespace Biigle\Http\Controllers\Api\Export;
 
 use Biigle\Http\Controllers\Api\Controller as BaseController;
-use Illuminate\Http\Request;
+use Biigle\Http\Requests\ShowExport;
 
 abstract class Controller extends BaseController
 {
@@ -18,22 +18,21 @@ abstract class Controller extends BaseController
     /**
      * Handle a generic export request.
      *
-     * @param Request $request
+     * @param ShowExport $request
      * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
      */
-    public function show(Request $request)
+    public function show(ShowExport $request)
     {
         if (!$this->isAllowed()) {
             abort(404);
         }
 
-        $this->validate($request, ['except' => 'filled', 'only' => 'filled']);
         $query = $this->getQuery();
 
         if ($request->filled('except')) {
-            $query = $query->whereNotIn('id', explode(',', $request->input('except')));
+            $query = $query->whereNotIn('id', $request->input('except'));
         } elseif ($request->filled('only')) {
-            $query = $query->whereIn('id', explode(',', $request->input('only')));
+            $query = $query->whereIn('id', $request->input('only'));
         }
 
         $export = $this->getExport($query->pluck('id')->toArray());

--- a/app/Http/Controllers/Api/Export/LabelTreeExportController.php
+++ b/app/Http/Controllers/Api/Export/LabelTreeExportController.php
@@ -12,9 +12,9 @@ class LabelTreeExportController extends Controller
      * @apiGroup Sync
      * @apiName ShowLabelTreeExport
      *
-     * @apiParam (Optional arguments) {String} except Comma separated IDs of the label trees that should not be included in the export file.
-     * @apiParam (Optional arguments) {String} only Comma separated IDs of the label trees that should only be included in the export file.
-     * @apiDescription The response is a ZIP archive that can be used for the label tree import. By default all label trees are exported.
+     * @apiParam (Required arguments) {String} except Comma separated IDs of the label trees that should not be included in the export file.
+     * @apiParam (Required arguments) {String} only Comma separated IDs of the label trees that should only be included in the export file.
+     * @apiDescription Either `except` or `only` must be provided. The response is a ZIP archive that can be used for the label tree import.
      * @apiPermission admin
      */
 

--- a/app/Http/Controllers/Api/Export/UserExportController.php
+++ b/app/Http/Controllers/Api/Export/UserExportController.php
@@ -12,9 +12,9 @@ class UserExportController extends Controller
      * @apiGroup Sync
      * @apiName ShowUserExport
      *
-     * @apiParam (Optional arguments) {String} except Comma separated IDs of the users that should not be included in the export file.
-     * @apiParam (Optional arguments) {String} only Comma separated IDs of the users that should only be included in the export file.
-     * @apiDescription The response is a ZIP archive that can be used for the user import. By default all users are exported.
+     * @apiParam (Required arguments) {String} except Comma separated IDs of the users that should not be included in the export file.
+     * @apiParam (Required arguments) {String} only Comma separated IDs of the users that should only be included in the export file.
+     * @apiDescription Either `except` or `only` must be provided. The response is a ZIP archive that can be used for the user import.
      * @apiPermission admin
      */
 

--- a/app/Http/Controllers/Api/Export/VolumeExportController.php
+++ b/app/Http/Controllers/Api/Export/VolumeExportController.php
@@ -12,9 +12,9 @@ class VolumeExportController extends Controller
      * @apiGroup Sync
      * @apiName ShowVolumeExport
      *
-     * @apiParam (Optional arguments) {String} except Comma separated IDs of the volumes that should not be included in the export file.
-     * @apiParam (Optional arguments) {String} only Comma separated IDs of the volumes that should only be included in the export file.
-     * @apiDescription The response is a ZIP archive that can be used for the volume import. By default all volumes are exported.
+     * @apiParam (Required arguments) {String} except Comma separated IDs of the volumes that should not be included in the export file.
+     * @apiParam (Required arguments) {String} only Comma separated IDs of the volumes that should only be included in the export file.
+     * @apiDescription Either `except` or `only` must be provided. The response is a ZIP archive that can be used for the volume import.
      * @apiPermission admin
      */
 

--- a/app/Http/Requests/ShowExport.php
+++ b/app/Http/Requests/ShowExport.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Biigle\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShowExport extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'except' => 'required_without:only|array',
+            'only' => 'required_without:except|array',
+            'except.*' => 'integer|min:1',
+            'only.*' => 'integer|min:1',
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        if ($this->filled('except')) {
+            $this->merge(['except' => array_map('intval', explode(',', $this->input('except')))]);
+        }
+
+        if ($this->filled('only')) {
+            $this->merge(['only' => array_map('intval', explode(',', $this->input('only')))]);
+        }
+    }
+}

--- a/app/Http/Requests/ShowExport.php
+++ b/app/Http/Requests/ShowExport.php
@@ -14,7 +14,7 @@ class ShowExport extends FormRequest
     public function rules()
     {
         return [
-            'except' => 'required_without:only|array',
+            'except' => 'required_without:only|prohibits:only|array',
             'only' => 'required_without:except|array',
             'except.*' => 'integer|min:1',
             'only.*' => 'integer|min:1',
@@ -23,11 +23,11 @@ class ShowExport extends FormRequest
 
     protected function prepareForValidation()
     {
-        if ($this->filled('except')) {
+        if ($this->filled('except') && !is_array($this->input('except'))) {
             $this->merge(['except' => array_map('intval', explode(',', $this->input('except')))]);
         }
 
-        if ($this->filled('only')) {
+        if ($this->filled('only') && !is_array($this->input('only'))) {
             $this->merge(['only' => array_map('intval', explode(',', $this->input('only')))]);
         }
     }

--- a/tests/php/Http/Controllers/Api/Export/LabelTreeExportControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Export/LabelTreeExportControllerTest.php
@@ -59,6 +59,14 @@ class LabelTreeExportControllerTest extends ApiTestCase
         $this->assertEquals($tree1->id, $contents->pluck('id')[0]);
     }
 
+    public function testShowOnlyAndExceptMutuallyExclusive()
+    {
+        $tree = LabelTreeTest::create();
+        $id = $tree->id;
+        $this->beGlobalAdmin();
+        $this->getJson("/api/v1/export/label-trees?only={$id}&except={$id}")->assertStatus(422);
+    }
+
     public function testShowInvalidFilter()
     {
         $this->beGlobalAdmin();
@@ -68,6 +76,36 @@ class LabelTreeExportControllerTest extends ApiTestCase
         $this->getJson('/api/v1/export/label-trees?except=,')->assertStatus(422);
         $this->getJson('/api/v1/export/label-trees?except=abc')->assertStatus(422);
         $this->getJson('/api/v1/export/label-trees?except=0')->assertStatus(422);
+    }
+
+    public function testShowOnlyArray()
+    {
+        $tree1 = LabelTreeTest::create();
+        $tree2 = LabelTreeTest::create();
+        $id = $tree1->id;
+        $this->beGlobalAdmin();
+        $response = $this->get("/api/v1/export/label-trees?only[]={$id}")->assertStatus(200);
+
+        $zip = new ZipArchive;
+        $zip->open($response->getFile()->getRealPath());
+        $contents = collect(json_decode($zip->getFromName('label_trees.json')));
+        $this->assertEquals($tree1->id, $contents->pluck('id')[0]);
+        $this->assertCount(1, $contents);
+    }
+
+    public function testShowExceptArray()
+    {
+        $tree1 = LabelTreeTest::create();
+        $tree2 = LabelTreeTest::create();
+        $id = $tree1->id;
+        $this->beGlobalAdmin();
+        $response = $this->get("/api/v1/export/label-trees?except[]={$id}")->assertStatus(200);
+
+        $zip = new ZipArchive;
+        $zip->open($response->getFile()->getRealPath());
+        $contents = collect(json_decode($zip->getFromName('label_trees.json')));
+        $this->assertEquals($tree2->id, $contents->pluck('id')[0]);
+        $this->assertCount(1, $contents);
     }
 
     public function testIsAllowed()

--- a/tests/php/Http/Controllers/Api/Export/LabelTreeExportControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Export/LabelTreeExportControllerTest.php
@@ -17,7 +17,9 @@ class LabelTreeExportControllerTest extends ApiTestCase
         $this->get('/api/v1/export/label-trees')->assertStatus(403);
 
         $this->beGlobalAdmin();
-        $response = $this->get('/api/v1/export/label-trees')
+        $this->getJson('/api/v1/export/label-trees')->assertStatus(422);
+
+        $response = $this->get("/api/v1/export/label-trees?only={$tree->id}")
             ->assertStatus(200)
             ->assertHeader('content-type', 'application/zip')
             ->assertHeader('content-disposition', 'attachment; filename=biigle_label_tree_export.zip');
@@ -57,10 +59,21 @@ class LabelTreeExportControllerTest extends ApiTestCase
         $this->assertEquals($tree1->id, $contents->pluck('id')[0]);
     }
 
+    public function testShowInvalidFilter()
+    {
+        $this->beGlobalAdmin();
+        $this->getJson('/api/v1/export/label-trees?only=,')->assertStatus(422);
+        $this->getJson('/api/v1/export/label-trees?only=abc')->assertStatus(422);
+        $this->getJson('/api/v1/export/label-trees?only=0')->assertStatus(422);
+        $this->getJson('/api/v1/export/label-trees?except=,')->assertStatus(422);
+        $this->getJson('/api/v1/export/label-trees?except=abc')->assertStatus(422);
+        $this->getJson('/api/v1/export/label-trees?except=0')->assertStatus(422);
+    }
+
     public function testIsAllowed()
     {
         config(['sync.allowed_exports' => ['volumes', 'users']]);
         $this->beGlobalAdmin();
-        $response = $this->get('/api/v1/export/label-trees')->assertStatus(404);
+        $response = $this->get('/api/v1/export/label-trees?only=1')->assertStatus(404);
     }
 }

--- a/tests/php/Http/Controllers/Api/Export/UserExportControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Export/UserExportControllerTest.php
@@ -55,6 +55,13 @@ class UserExportControllerTest extends ApiTestCase
         $this->assertEquals(collect([$id]), $contents->pluck('id'));
     }
 
+    public function testShowOnlyAndExceptMutuallyExclusive()
+    {
+        $id = $this->user()->id;
+        $this->beGlobalAdmin();
+        $this->getJson("/api/v1/export/users?only={$id}&except={$id}")->assertStatus(422);
+    }
+
     public function testShowInvalidFilter()
     {
         $this->beGlobalAdmin();
@@ -64,6 +71,31 @@ class UserExportControllerTest extends ApiTestCase
         $this->getJson('/api/v1/export/users?except=,')->assertStatus(422);
         $this->getJson('/api/v1/export/users?except=abc')->assertStatus(422);
         $this->getJson('/api/v1/export/users?except=0')->assertStatus(422);
+    }
+
+    public function testShowOnlyArray()
+    {
+        $id = $this->user()->id;
+        $this->beGlobalAdmin();
+        $response = $this->get("/api/v1/export/users?only[]={$id}")->assertStatus(200);
+
+        $zip = new ZipArchive;
+        $zip->open($response->getFile()->getRealPath());
+        $contents = collect(json_decode($zip->getFromName('users.json')));
+        $this->assertEquals(collect([$id]), $contents->pluck('id'));
+    }
+
+    public function testShowExceptArray()
+    {
+        $id = $this->user()->id;
+        $this->beGlobalAdmin();
+        $response = $this->get("/api/v1/export/users?except[]={$id}")->assertStatus(200);
+
+        $zip = new ZipArchive;
+        $zip->open($response->getFile()->getRealPath());
+        $contents = collect(json_decode($zip->getFromName('users.json')));
+        $expect = User::where('id', '!=', $id)->pluck('id');
+        $this->assertEquals($expect, $contents->pluck('id'));
     }
 
     public function testIsAllowed()

--- a/tests/php/Http/Controllers/Api/Export/UserExportControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Export/UserExportControllerTest.php
@@ -16,7 +16,10 @@ class UserExportControllerTest extends ApiTestCase
         $this->get('/api/v1/export/users')->assertStatus(403);
 
         $this->beGlobalAdmin();
-        $response = $this->get('/api/v1/export/users')
+        $this->getJson('/api/v1/export/users')->assertStatus(422);
+
+        $id = $this->user()->id;
+        $response = $this->get("/api/v1/export/users?only={$id}")
             ->assertStatus(200)
             ->assertHeader('content-type', 'application/zip')
             ->assertHeader('content-disposition', 'attachment; filename=biigle_user_export.zip');
@@ -24,8 +27,7 @@ class UserExportControllerTest extends ApiTestCase
         $zip = new ZipArchive;
         $zip->open($response->getFile()->getRealPath());
         $contents = collect(json_decode($zip->getFromName('users.json')));
-        $expect = User::orderBy('id')->pluck('id');
-        $this->assertEquals($expect, $contents->sortBy('id')->pluck('id'));
+        $this->assertEquals(collect([$id]), $contents->pluck('id'));
     }
 
     public function testShowExcept()
@@ -53,10 +55,21 @@ class UserExportControllerTest extends ApiTestCase
         $this->assertEquals(collect([$id]), $contents->pluck('id'));
     }
 
+    public function testShowInvalidFilter()
+    {
+        $this->beGlobalAdmin();
+        $this->getJson('/api/v1/export/users?only=,')->assertStatus(422);
+        $this->getJson('/api/v1/export/users?only=abc')->assertStatus(422);
+        $this->getJson('/api/v1/export/users?only=0')->assertStatus(422);
+        $this->getJson('/api/v1/export/users?except=,')->assertStatus(422);
+        $this->getJson('/api/v1/export/users?except=abc')->assertStatus(422);
+        $this->getJson('/api/v1/export/users?except=0')->assertStatus(422);
+    }
+
     public function testIsAllowed()
     {
         config(['sync.allowed_exports' => ['volumes', 'labelTrees']]);
         $this->beGlobalAdmin();
-        $response = $this->get('/api/v1/export/users')->assertStatus(404);
+        $response = $this->get('/api/v1/export/users?only=1')->assertStatus(404);
     }
 }

--- a/tests/php/Http/Controllers/Api/Export/VolumeExportControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Export/VolumeExportControllerTest.php
@@ -17,7 +17,9 @@ class VolumeExportControllerTest extends ApiTestCase
         $this->get('/api/v1/export/volumes')->assertStatus(403);
 
         $this->beGlobalAdmin();
-        $response = $this->get('/api/v1/export/volumes')
+        $this->getJson('/api/v1/export/volumes')->assertStatus(422);
+
+        $response = $this->get("/api/v1/export/volumes?only={$volume->id}")
             ->assertStatus(200)
             ->assertHeader('content-type', 'application/zip')
             ->assertHeader('content-disposition', 'attachment; filename=biigle_volume_export.zip');
@@ -66,10 +68,21 @@ class VolumeExportControllerTest extends ApiTestCase
         $this->assertEquals($volume1->id, $contents->pluck('id')[0]);
     }
 
+    public function testShowInvalidFilter()
+    {
+        $this->beGlobalAdmin();
+        $this->getJson('/api/v1/export/volumes?only=,')->assertStatus(422);
+        $this->getJson('/api/v1/export/volumes?only=abc')->assertStatus(422);
+        $this->getJson('/api/v1/export/volumes?only=0')->assertStatus(422);
+        $this->getJson('/api/v1/export/volumes?except=,')->assertStatus(422);
+        $this->getJson('/api/v1/export/volumes?except=abc')->assertStatus(422);
+        $this->getJson('/api/v1/export/volumes?except=0')->assertStatus(422);
+    }
+
     public function testIsAllowed()
     {
         config(['sync.allowed_exports' => ['labelTrees', 'users']]);
         $this->beGlobalAdmin();
-        $response = $this->get('/api/v1/export/volumes')->assertStatus(404);
+        $response = $this->get('/api/v1/export/volumes?only=1')->assertStatus(404);
     }
 }

--- a/tests/php/Http/Controllers/Api/Export/VolumeExportControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Export/VolumeExportControllerTest.php
@@ -68,6 +68,14 @@ class VolumeExportControllerTest extends ApiTestCase
         $this->assertEquals($volume1->id, $contents->pluck('id')[0]);
     }
 
+    public function testShowOnlyAndExceptMutuallyExclusive()
+    {
+        $volume = VolumeTest::create();
+        $id = $volume->id;
+        $this->beGlobalAdmin();
+        $this->getJson("/api/v1/export/volumes?only={$id}&except={$id}")->assertStatus(422);
+    }
+
     public function testShowInvalidFilter()
     {
         $this->beGlobalAdmin();
@@ -77,6 +85,36 @@ class VolumeExportControllerTest extends ApiTestCase
         $this->getJson('/api/v1/export/volumes?except=,')->assertStatus(422);
         $this->getJson('/api/v1/export/volumes?except=abc')->assertStatus(422);
         $this->getJson('/api/v1/export/volumes?except=0')->assertStatus(422);
+    }
+
+    public function testShowOnlyArray()
+    {
+        $volume1 = VolumeTest::create();
+        $volume2 = VolumeTest::create();
+        $id = $volume1->id;
+        $this->beGlobalAdmin();
+        $response = $this->get("/api/v1/export/volumes?only[]={$id}")->assertStatus(200);
+
+        $zip = new ZipArchive;
+        $zip->open($response->getFile()->getRealPath());
+        $contents = collect(json_decode($zip->getFromName('volumes.json')));
+        $this->assertEquals($volume1->id, $contents->pluck('id')[0]);
+        $this->assertCount(1, $contents);
+    }
+
+    public function testShowExceptArray()
+    {
+        $volume1 = VolumeTest::create();
+        $volume2 = VolumeTest::create();
+        $id = $volume1->id;
+        $this->beGlobalAdmin();
+        $response = $this->get("/api/v1/export/volumes?except[]={$id}")->assertStatus(200);
+
+        $zip = new ZipArchive;
+        $zip->open($response->getFile()->getRealPath());
+        $contents = collect(json_decode($zip->getFromName('volumes.json')));
+        $this->assertEquals($volume2->id, $contents->pluck('id')[0]);
+        $this->assertCount(1, $contents);
     }
 
     public function testIsAllowed()


### PR DESCRIPTION
Exporting everything does not really make sense. On large instances it is not possible and on small instances "everything" can be selected with "only".