### PR TITLE
Fix splitting of video annotations before gap

### DIFF
--- a/app/Http/Controllers/Api/SplitVideoAnnotationController.php
+++ b/app/Http/Controllers/Api/SplitVideoAnnotationController.php
@@ -89,7 +89,7 @@ class SplitVideoAnnotationController extends Controller
 
         $i = count($oldFrames) - 1;
         for (; $i >= 0 ; $i--) {
-            if ($oldFrames[$i] <= $time && $oldFrames[$i] !== null) {
+            if ($oldFrames[$i] !== null && $oldFrames[$i] <= $time) {
                 break;
             }
         }

--- a/app/VideoAnnotation.php
+++ b/app/VideoAnnotation.php
@@ -126,7 +126,9 @@ class VideoAnnotation extends Annotation
      */
     public function interpolatePoints(float $time)
     {
-        $frames = array_map('floatval', $this->frames);
+        // Keep gap frames.
+        $frames = array_map(fn ($f) => is_null($f) ? null : floatval($f), $this->frames);
+
         $startFrame = $frames[0];
         $endFrame = end($frames);
 
@@ -136,13 +138,19 @@ class VideoAnnotation extends Annotation
 
         $i = count($frames) - 1;
         for (; $i >= 0 ; $i--) {
-            if ($frames[$i] <= $time) {
+            if (!is_null($frames[$i]) && $frames[$i] <= $time) {
                 break;
             }
         }
 
+
         if ($frames[$i] === $time) {
             return $this->points[$i];
+        }
+
+        // Time is inside gap.
+        if (array_key_exists($i + 1, $frames) && is_null($frames[$i + 1])) {
+            return [];
         }
 
         $progress = ($time - $frames[$i]) / ($frames[$i + 1] - $frames[$i]);

--- a/app/VideoAnnotation.php
+++ b/app/VideoAnnotation.php
@@ -143,13 +143,12 @@ class VideoAnnotation extends Annotation
             }
         }
 
-
         if ($frames[$i] === $time) {
             return $this->points[$i];
         }
 
         // Time is inside gap.
-        if (array_key_exists($i + 1, $frames) && is_null($frames[$i + 1])) {
+        if (is_null($frames[$i + 1])) {
             return [];
         }
 

--- a/resources/assets/js/videos/models/Annotation.js
+++ b/resources/assets/js/videos/models/Annotation.js
@@ -185,7 +185,7 @@ export default class Annotation {
         }
 
         for (; i >= 0; i--) {
-            if (rtp(frames[i]) <= time && frames[i] !== null) {
+            if (frames[i] !== null && rtp(frames[i]) <= time) {
                 break;
             }
         }

--- a/tests/php/Http/Controllers/Api/SplitVideoAnnotationControllerTest.php
+++ b/tests/php/Http/Controllers/Api/SplitVideoAnnotationControllerTest.php
@@ -275,6 +275,36 @@ class SplitVideoAnnotationControllerTest extends ApiTestCase
             ->assertJsonFragment(['points' => [$expect, $points[3]]]);
     }
 
+    public function testStoreRectangleWithGap2()
+    {
+        $points = [
+            [0, 0, 10, 0, 10, 10, 0, 10],
+            [10, 0, 20, 0, 20, 10, 10, 10],
+            [],
+            [20, 0, 30, 0, 30, 10, 20, 10],
+        ];
+
+        $annotation = VideoAnnotationTest::create([
+            'shape_id' => Shape::rectangleId(),
+            'video_id' => $this->video->id,
+            'frames' => [1.0, 2.0, null, 3.0],
+            'points' => $points,
+        ]);
+
+        $expect = [5, 0, 15, 0, 15, 10, 5, 10];
+
+        $this->beEditor();
+        $this
+            ->postJson("api/v1/video-annotations/{$annotation->id}/split", [
+                'time' => 1.5,
+            ])
+            ->assertStatus(200)
+            ->assertJsonFragment(['frames' => [1.0, 1.5]])
+            ->assertJsonFragment(['points' => [$points[0], $expect]])
+            ->assertJsonFragment(['frames' => [1.5, 2.0, null, 3.0]])
+            ->assertJsonFragment(['points' => [$expect, $points[1], $points[2], $points[3]]]);
+    }
+
     public function testStoreWholeFrameAtFrame()
     {
         $annotation = VideoAnnotationTest::create([

--- a/tests/php/VideoAnnotationTest.php
+++ b/tests/php/VideoAnnotationTest.php
@@ -192,6 +192,53 @@ class VideoAnnotationTest extends ModelTestCase
         $this->model->interpolatePoints(0.5);
     }
 
+    public function testInterpolatePointsWithGapInsideGap()
+    {
+        $this->model->shape_id = Shape::rectangleId();
+        $this->model->points = [
+            [0, 0, 10, 0, 10, 10, 0, 10],
+            [],
+            [20, 20, 30, 20, 30, 30, 20, 30],
+        ];
+        $this->model->frames = [1.0, null, 3.0];
+
+        // The time falls into the gap of the annotation. There is nothing to
+        // interpolate.
+        $this->assertSame([], $this->model->interpolatePoints(2.0));
+    }
+
+    public function testInterpolatePointsWithGapBeforeGap()
+    {
+        $this->model->shape_id = Shape::rectangleId();
+        $this->model->points = [
+            [0, 0, 10, 0, 10, 10, 0, 10],
+            [10, 10, 20, 10, 20, 20, 10, 20],
+            [],
+            [20, 20, 30, 20, 30, 30, 20, 30],
+        ];
+        $this->model->frames = [1.0, 2.0, null, 3.0];
+
+        // The time falls between two real keyframes that both occur before the gap
+        // in the frames array.
+        $expect = [5.0, 5.0, 15.0, 5.0, 15.0, 15.0, 5.0, 15.0];
+        $this->assertSame($expect, $this->model->interpolatePoints(1.5));
+    }
+
+    public function testInterpolatePointsWithGapAfterGap()
+    {
+        $this->model->shape_id = Shape::rectangleId();
+        $this->model->points = [
+            [0, 0, 10, 0, 10, 10, 0, 10],
+            [],
+            [10, 10, 20, 10, 20, 20, 10, 20],
+            [20, 20, 30, 20, 30, 30, 20, 30],
+        ];
+        $this->model->frames = [1.0, null, 3.0, 4.0];
+
+        $expect = [15.0, 15.0, 25.0, 15.0, 25.0, 25.0, 15.0, 25.0];
+        $this->assertSame($expect, $this->model->interpolatePoints(3.5));
+    }
+
     public function testScopeAllowedBySessionHideOwn()
     {
         $ownUser = UserTest::create();


### PR DESCRIPTION
This adds tests that reproduce an error from production. Fix the code so the tests pass.