### PR TITLE
Fixed handling of backslashes in volume URLs

### DIFF
--- a/resources/views/volumes/create/step2.blade.php
+++ b/resources/views/volumes/create/step2.blade.php
@@ -5,7 +5,7 @@
 @push('scripts')
     <script type="module">
         biigle.$declare('volumes.name', {{ Js::from(old('name', $oldName)) }});
-        biigle.$declare('volumes.url', '{!! $oldUrl !!}');
+        biigle.$declare('volumes.url', {{ Js::from($oldUrl) }});
         biigle.$declare('volumes.handle', {{ Js::from($oldHandle) }});
         biigle.$declare('volumes.mediaType', '{!! $mediaType !!}');
         biigle.$declare('volumes.filenames', {{ Js::from($filenames ?? '') }});

--- a/tests/php/Http/Controllers/Views/Volumes/PendingVolumeControllerTest.php
+++ b/tests/php/Http/Controllers/Views/Volumes/PendingVolumeControllerTest.php
@@ -33,6 +33,25 @@ class PendingVolumeControllerTest extends ApiTestCase
         $this->get("pending-volumes/{$pv->id}")->assertStatus(200);
     }
 
+    public function testShowWithBackslashInOldUrl()
+    {
+        $pv = PendingVolume::factory()->create([
+            'user_id' => $this->admin()->id,
+            'project_id' => $this->project()->id,
+        ]);
+        $url = 'https://example.com\\0924S_ABC_1';
+
+        $this->beAdmin();
+        $response = $this
+            ->withSession(['_old_input' => ['url' => $url]])
+            ->get("pending-volumes/{$pv->id}");
+
+        $response
+            ->assertOk()
+            ->assertViewHas('oldUrl', $url)
+            ->assertSee('https:\/\/example.com\\\\0924S_ABC_1', false);
+    }
+
     public function testShowWithVolumeRedirectToSelectAnnotationLabels()
     {
         $pv = PendingVolume::factory()->create([


### PR DESCRIPTION
Fixes #1280.

Volume creation previously crashed when an invalid URL containing a backslash followed by digits, such as `https://example.com\0924S_ABC_1`, was restored after backend validation.

The old URL was inserted directly into a JavaScript string. In a module script, the backslash could be interpreted as an invalid escape sequence and cause a syntax error.

This change now uses Laravel's `Js::from()` helper to serialize the URL safely.

## Changes
- Safely serialize the previous volume URL with `Js::from()`.
- Added a test case for the change.