### PR TITLE
Handle deleted users in report generators

### DIFF
--- a/app/Services/Reports/Volumes/ImageAnnotations/AbundanceReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageAnnotations/AbundanceReportGenerator.php
@@ -64,7 +64,11 @@ class AbundanceReportGenerator extends AnnotationReportGenerator
             }
         } elseif ($this->shouldSeparateUsers()) {
             $annotatedImageRows = $annotatedImageRows->groupBy('user_id');
-            $users = User::whereIn('id', $annotatedImageRows->keys())
+            // Annotations of deleted users have a null user_id, which groupBy
+            // turns into an empty string key. Don't try to fetch their name.
+            $nullKey = '';
+            $ids = $annotatedImageRows->keys()->filter(fn ($id) => $id !== $nullKey);
+            $users = User::whereIn('id', $ids)
                 ->selectRaw("id, concat(firstname, ' ', lastname) as name")
                 ->pluck('name', 'id');
             $labels = null;
@@ -83,6 +87,18 @@ class AbundanceReportGenerator extends AnnotationReportGenerator
                 }
 
                 $this->tmpFiles[] = $this->createCsv($rowGroup, $name, $labels, $emptyImagesQueryTmp);
+            }
+
+            if ($annotatedImageRows->has($nullKey)) {
+                $usedImageIds = $annotatedImageRows->get($nullKey)->pluck('image_id')->unique();
+                $emptyImagesQueryTmp = $emptyImagesQuery->clone()->whereNotIn('id', $usedImageIds);
+                $rowGroup = $annotatedImageRows->get($nullKey);
+
+                if (!$this->shouldUseAllLabels()) {
+                    $labels = Label::whereIn('id', $rowGroup->pluck('label_id'))->get();
+                }
+
+                $this->tmpFiles[] = $this->createCsv($rowGroup, '(deleted users)', $labels, $emptyImagesQueryTmp);
             }
         } else {
             if ($this->shouldUseAllLabels()) {

--- a/app/Services/Reports/Volumes/ImageAnnotations/AnnotationLocationReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageAnnotations/AnnotationLocationReportGenerator.php
@@ -67,7 +67,11 @@ class AnnotationLocationReportGenerator extends AnnotationReportGenerator
             }
         } elseif ($this->shouldSeparateUsers() && $items->isNotEmpty()) {
             $items = $items->groupBy('user_id');
-            $users = User::whereIn('id', $items->keys())
+            // Annotations of deleted users have a null user_id, which groupBy
+            // turns into an empty string key. Don't try to fetch their name.
+            $nullKey = '';
+            $ids = $items->keys()->filter(fn ($id) => $id !== $nullKey);
+            $users = User::whereIn('id', $ids)
                 ->selectRaw("id, concat(firstname, ' ', lastname) as name")
                 ->pluck('name', 'id');
 
@@ -76,6 +80,12 @@ class AnnotationLocationReportGenerator extends AnnotationReportGenerator
                 $file = $this->createNdJSON($tmpItems);
                 $this->tmpFiles[] = $file;
                 $toZip[$file->getPath()] = $this->sanitizeFilename("{$id}-{$name}", 'ndjson');
+            }
+
+            if ($items->has($nullKey)) {
+                $file = $this->createNdJSON($items->get($nullKey));
+                $this->tmpFiles[] = $file;
+                $toZip[$file->getPath()] = 'deleted-users.ndjson';
             }
         } else {
             $file = $this->createNdJSON($items);

--- a/app/Services/Reports/Volumes/ImageAnnotations/AreaReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageAnnotations/AreaReportGenerator.php
@@ -64,12 +64,20 @@ class AreaReportGenerator extends AnnotationReportGenerator
             }
         } elseif ($this->shouldSeparateUsers() && $rows->isNotEmpty()) {
             $rows = $rows->groupBy('user_id');
-            $users = User::whereIn('id', $rows->keys())
+            // Annotations of deleted users have a null user_id, which groupBy
+            // turns into an empty string key. Don't try to fetch their name.
+            $nullKey = '';
+            $ids = $rows->keys()->filter(fn ($id) => $id !== $nullKey);
+            $users = User::whereIn('id', $ids)
                 ->selectRaw("id, concat(firstname, ' ', lastname) as name")
                 ->pluck('name', 'id');
 
             foreach ($users as $id => $name) {
                 $this->tmpFiles[] = $this->createCsv($rows->get($id), $name);
+            }
+
+            if ($rows->has($nullKey)) {
+                $this->tmpFiles[] = $this->createCsv($rows->get($nullKey), '(deleted users)');
             }
         } else {
             $this->tmpFiles[] = $this->createCsv($rows, $this->source->name);

--- a/app/Services/Reports/Volumes/ImageAnnotations/BasicReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageAnnotations/BasicReportGenerator.php
@@ -48,12 +48,20 @@ class BasicReportGenerator extends AnnotationReportGenerator
             }
         } elseif ($this->shouldSeparateUsers() && $labels->isNotEmpty()) {
             $labels = $labels->groupBy('user_id');
-            $users = User::whereIn('id', $labels->keys())
+            // Annotations of deleted users have a null user_id, which groupBy
+            // turns into an empty string key. Don't try to fetch their name.
+            $nullKey = '';
+            $ids = $labels->keys()->filter(fn ($id) => $id !== $nullKey);
+            $users = User::whereIn('id', $ids)
                 ->selectRaw("id, concat(firstname, ' ', lastname) as name")
                 ->pluck('name', 'id');
 
             foreach ($users as $id => $name) {
                 $this->tmpFiles[] = $this->createCsv($labels->get($id), $name);
+            }
+
+            if ($labels->has($nullKey)) {
+                $this->tmpFiles[] = $this->createCsv($labels->get($nullKey), '(deleted users)');
             }
         } else {
             $this->tmpFiles[] = $this->createCsv($labels);

--- a/app/Services/Reports/Volumes/ImageAnnotations/CocoReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageAnnotations/CocoReportGenerator.php
@@ -70,6 +70,13 @@ class CocoReportGenerator extends AnnotationReportGenerator
                 $this->tmpFiles[] = $csv;
                 $toZip[$csv->getPath()] = $this->sanitizeFilename("{$id}-{$name}", 'json');
             }
+
+            // Annotations of deleted users have a null user_id.
+            if ($userIds->contains(null)) {
+                $csv = $this->createCsv($this->query()->whereNull('user_id'));
+                $this->tmpFiles[] = $csv;
+                $toZip[$csv->getPath()] = 'deleted-users.json';
+            }
         } else {
             $csv = $this->createCsv($this->query());
             $this->tmpFiles[] = $csv;

--- a/app/Services/Reports/Volumes/ImageAnnotations/CsvReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageAnnotations/CsvReportGenerator.php
@@ -70,6 +70,13 @@ class CsvReportGenerator extends AnnotationReportGenerator
                 $this->tmpFiles[] = $csv;
                 $toZip[$csv->getPath()] = $this->sanitizeFilename("{$id}-{$name}", 'csv');
             }
+
+            // Annotations of deleted users have a null user_id.
+            if ($userIds->contains(null)) {
+                $csv = $this->createCsv($this->query()->whereNull('user_id'));
+                $this->tmpFiles[] = $csv;
+                $toZip[$csv->getPath()] = 'deleted-users.csv';
+            }
         } else {
             $csv = $this->createCsv($this->query());
             $this->tmpFiles[] = $csv;

--- a/app/Services/Reports/Volumes/ImageAnnotations/ExtendedReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageAnnotations/ExtendedReportGenerator.php
@@ -47,12 +47,20 @@ class ExtendedReportGenerator extends AnnotationReportGenerator
             }
         } elseif ($this->shouldSeparateUsers() && $rows->isNotEmpty()) {
             $rows = $rows->groupBy('user_id');
-            $users = User::whereIn('id', $rows->keys())
+            // Annotations of deleted users have a null user_id, which groupBy
+            // turns into an empty string key. Don't try to fetch their name.
+            $nullKey = '';
+            $ids = $rows->keys()->filter(fn ($id) => $id !== $nullKey);
+            $users = User::whereIn('id', $ids)
                 ->selectRaw("id, concat(firstname, ' ', lastname) as name")
                 ->pluck('name', 'id');
 
             foreach ($users as $id => $name) {
                 $this->tmpFiles[] = $this->createCsv($rows->get($id), $name);
+            }
+
+            if ($rows->has($nullKey)) {
+                $this->tmpFiles[] = $this->createCsv($rows->get($nullKey), '(deleted users)');
             }
         } else {
             $this->tmpFiles[] = $this->createCsv($rows, $this->source->name);

--- a/app/Services/Reports/Volumes/ImageAnnotations/FullReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageAnnotations/FullReportGenerator.php
@@ -49,12 +49,20 @@ class FullReportGenerator extends AnnotationReportGenerator
             }
         } elseif ($this->shouldSeparateUsers() && $rows->isNotEmpty()) {
             $rows = $rows->groupBy('user_id');
-            $users = User::whereIn('id', $rows->keys())
+            // Annotations of deleted users have a null user_id, which groupBy
+            // turns into an empty string key. Don't try to fetch their name.
+            $nullKey = '';
+            $ids = $rows->keys()->filter(fn ($id) => $id !== $nullKey);
+            $users = User::whereIn('id', $ids)
                 ->selectRaw("id, concat(firstname, ' ', lastname) as name")
                 ->pluck('name', 'id');
 
             foreach ($users as $id => $name) {
                 $this->tmpFiles[] = $this->createCsv($rows->get($id), $name);
+            }
+
+            if ($rows->has($nullKey)) {
+                $this->tmpFiles[] = $this->createCsv($rows->get($nullKey), '(deleted users)');
             }
         } else {
             $this->tmpFiles[] = $this->createCsv($rows, $this->source->name);

--- a/app/Services/Reports/Volumes/ImageAnnotations/ImageLocationReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageAnnotations/ImageLocationReportGenerator.php
@@ -75,7 +75,11 @@ class ImageLocationReportGenerator extends AnnotationReportGenerator
         } elseif ($this->shouldSeparateUsers() && $labels->isNotEmpty()) {
             $usedLabels = $usedLabelsQuery->pluck('labels.name', 'labels.id');
             $labels = $labels->groupBy('user_id');
-            $users = User::whereIn('id', $labels->keys())
+            // Annotations of deleted users have a null user_id, which groupBy
+            // turns into an empty string key. Don't try to fetch their name.
+            $nullKey = '';
+            $ids = $labels->keys()->filter(fn ($id) => $id !== $nullKey);
+            $users = User::whereIn('id', $ids)
                 ->selectRaw("id, concat(firstname, ' ', lastname) as name")
                 ->orderBy('id')
                 ->pluck('name', 'id');
@@ -85,6 +89,13 @@ class ImageLocationReportGenerator extends AnnotationReportGenerator
                 $file = $this->createNdJSON($images, $usedLabels, $tmpLabels);
                 $this->tmpFiles[] = $file;
                 $toZip[$file->getPath()] = $this->sanitizeFilename("{$id}-{$name}", 'ndjson');
+            }
+
+            if ($labels->has($nullKey)) {
+                $tmpLabels = $labels->get($nullKey)->groupBy('image_id');
+                $file = $this->createNdJSON($images, $usedLabels, $tmpLabels);
+                $this->tmpFiles[] = $file;
+                $toZip[$file->getPath()] = 'deleted-users.ndjson';
             }
         } else {
             $usedLabels = $usedLabelsQuery->pluck('labels.name', 'labels.id');

--- a/app/Services/Reports/Volumes/ImageLabels/BasicReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageLabels/BasicReportGenerator.php
@@ -49,12 +49,20 @@ class BasicReportGenerator extends VolumeReportGenerator
             }
         } elseif ($this->shouldSeparateUsers() && $rows->isNotEmpty()) {
             $rows = $rows->groupBy('user_id');
-            $users = User::whereIn('id', $rows->keys())
+            // Labels of deleted users have a null user_id, which groupBy turns
+            // into an empty string key. Don't try to fetch their name.
+            $nullKey = '';
+            $ids = $rows->keys()->filter(fn ($id) => $id !== $nullKey);
+            $users = User::whereIn('id', $ids)
                 ->selectRaw("id, concat(firstname, ' ', lastname) as name")
                 ->pluck('name', 'id');
 
             foreach ($users as $id => $name) {
                 $this->tmpFiles[] = $this->createCsv($rows->get($id), $name);
+            }
+
+            if ($rows->has($nullKey)) {
+                $this->tmpFiles[] = $this->createCsv($rows->get($nullKey), '(deleted users)');
             }
         } else {
             $this->tmpFiles[] = $this->createCsv($rows, $this->source->name);

--- a/app/Services/Reports/Volumes/ImageLabels/CsvReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageLabels/CsvReportGenerator.php
@@ -55,7 +55,11 @@ class CsvReportGenerator extends VolumeReportGenerator
             }
         } elseif ($this->shouldSeparateUsers() && $rows->isNotEmpty()) {
             $rows = $rows->groupBy('user_id');
-            $users = User::whereIn('id', $rows->keys())
+            // Labels of deleted users have a null user_id, which groupBy turns
+            // into an empty string key. Don't try to fetch their name.
+            $nullKey = '';
+            $ids = $rows->keys()->filter(fn ($id) => $id !== $nullKey);
+            $users = User::whereIn('id', $ids)
                 ->selectRaw("id, concat(firstname, ' ', lastname) as name")
                 ->pluck('name', 'id');
 
@@ -63,6 +67,12 @@ class CsvReportGenerator extends VolumeReportGenerator
                 $csv = $this->createCsv($rows->get($id));
                 $this->tmpFiles[] = $csv;
                 $toZip[$csv->getPath()] = $this->sanitizeFilename("{$id}-{$name}", 'csv');
+            }
+
+            if ($rows->has($nullKey)) {
+                $csv = $this->createCsv($rows->get($nullKey));
+                $this->tmpFiles[] = $csv;
+                $toZip[$csv->getPath()] = 'deleted-users.csv';
             }
         } else {
             $csv = $this->createCsv($rows);

--- a/app/Services/Reports/Volumes/ImageLabels/ImageLocationReportGenerator.php
+++ b/app/Services/Reports/Volumes/ImageLabels/ImageLocationReportGenerator.php
@@ -75,7 +75,11 @@ class ImageLocationReportGenerator extends VolumeReportGenerator
         } elseif ($this->shouldSeparateUsers() && $imageLabels->isNotEmpty()) {
             $usedImageLabels = $usedImageLabelsQuery->pluck('labels.name', 'labels.id');
             $imageLabels = $imageLabels->groupBy('user_id');
-            $users = User::whereIn('id', $imageLabels->keys())
+            // Labels of deleted users have a null user_id, which groupBy turns
+            // into an empty string key. Don't try to fetch their name.
+            $nullKey = '';
+            $ids = $imageLabels->keys()->filter(fn ($id) => $id !== $nullKey);
+            $users = User::whereIn('id', $ids)
                 ->selectRaw("id, concat(firstname, ' ', lastname) as name")
                 ->pluck('name', 'id');
 
@@ -84,6 +88,13 @@ class ImageLocationReportGenerator extends VolumeReportGenerator
                 $file = $this->createNdJSON($images, $usedImageLabels, $tmpImageLabels);
                 $this->tmpFiles[] = $file;
                 $toZip[$file->getPath()] = $this->sanitizeFilename("{$id}-{$name}", 'ndjson');
+            }
+
+            if ($imageLabels->has($nullKey)) {
+                $tmpImageLabels = $imageLabels->get($nullKey)->groupBy('image_id');
+                $file = $this->createNdJSON($images, $usedImageLabels, $tmpImageLabels);
+                $this->tmpFiles[] = $file;
+                $toZip[$file->getPath()] = 'deleted-users.ndjson';
             }
         } else {
             $usedImageLabels = $usedImageLabelsQuery->pluck('labels.name', 'labels.id');

--- a/app/Services/Reports/Volumes/VideoAnnotations/CsvReportGenerator.php
+++ b/app/Services/Reports/Volumes/VideoAnnotations/CsvReportGenerator.php
@@ -126,6 +126,13 @@ class CsvReportGenerator extends VolumeReportGenerator
                 $this->tmpFiles[] = $csv;
                 $toZip[$csv->getPath()] = $this->sanitizeFilename("{$id}-{$name}", 'csv');
             }
+
+            // Annotations of deleted users have a null user_id.
+            if ($userIds->contains(null)) {
+                $csv = $this->createCsv($this->query()->whereNull('user_id'));
+                $this->tmpFiles[] = $csv;
+                $toZip[$csv->getPath()] = 'deleted-users.csv';
+            }
         } else {
             $csv = $this->createCsv($this->query());
             $this->tmpFiles[] = $csv;

--- a/app/Services/Reports/Volumes/VideoLabels/CsvReportGenerator.php
+++ b/app/Services/Reports/Volumes/VideoLabels/CsvReportGenerator.php
@@ -55,7 +55,11 @@ class CsvReportGenerator extends VolumeReportGenerator
             }
         } elseif ($this->shouldSeparateUsers() && $rows->isNotEmpty()) {
             $rows = $rows->groupBy('user_id');
-            $users = User::whereIn('id', $rows->keys())
+            // Labels of deleted users have a null user_id, which groupBy turns
+            // into an empty string key. Don't try to fetch their name.
+            $nullKey = '';
+            $ids = $rows->keys()->filter(fn ($id) => $id !== $nullKey);
+            $users = User::whereIn('id', $ids)
                 ->selectRaw("id, concat(firstname, ' ', lastname) as name")
                 ->pluck('name', 'id');
 
@@ -63,6 +67,12 @@ class CsvReportGenerator extends VolumeReportGenerator
                 $csv = $this->createCsv($rows->get($id));
                 $this->tmpFiles[] = $csv;
                 $toZip[$csv->getPath()] = $this->sanitizeFilename("{$id}-{$name}", 'csv');
+            }
+
+            if ($rows->has($nullKey)) {
+                $csv = $this->createCsv($rows->get($nullKey));
+                $this->tmpFiles[] = $csv;
+                $toZip[$csv->getPath()] = 'deleted-users.csv';
             }
         } else {
             $csv = $this->createCsv($rows);

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/AbundanceReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/AbundanceReportGeneratorTest.php
@@ -365,6 +365,98 @@ class AbundanceReportGeneratorTest extends TestCase
         $generator->generateReport('my/path');
     }
 
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $image = ImageTest::create([
+            'filename' => 'a.jpg'
+        ]);
+        $image2 = ImageTest::create([
+            'filename' => 'b.jpg',
+            'volume_id' => $image->volume_id
+        ]);
+        // Empty images should be included in the report
+        $image3 = ImageTest::create([
+            'filename' => 'c.jpg',
+            'volume_id' => $image->volume_id
+        ]);
+
+        $l1 = LabelTest::create();
+        $l2 = LabelTest::create(['label_tree_id' => $l1->label_tree_id]);
+        // Unused label should be ignored
+        LabelTest::create(['label_tree_id' => $l1->label_tree_id]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image->id,
+            ])->id,
+            'label_id' => $l1->id
+        ]);
+
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => ImageAnnotationTest::create([
+                'image_id' => $image2->id,
+            ])->id,
+            'label_id' => $l2->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with("{$al1->user->firstname} {$al1->user->lastname}");
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with('(deleted users)');
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with(['image_filename', $l1->name]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with(['image_filename', $l2->name]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([$image->filename, 1]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([$image->filename, 0]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([$image2->filename, 0]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([$image2->filename, 1]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([$image3->filename, 0]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([$image3->filename, 0]);
+
+        $mock->shouldReceive('close')
+            ->twice();
+
+        App::singleton(CsvFile::class, fn () => $mock);
+
+        $generator = new AbundanceReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($image->volume);
+        $mock = Mockery::mock();
+        $mock->shouldReceive('run')->once();
+        $generator->setPythonScriptRunner($mock);
+        $generator->generateReport('my/path');
+    }
+
     public function testGenerateReportSeparateUsersAllLabels()
     {
         $project = ProjectTest::create();

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationLocationReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/AnnotationLocationReportGeneratorTest.php
@@ -616,4 +616,103 @@ class AnnotationLocationReportGeneratorTest extends TestCase
         $generator->setSource($image->volume);
         $generator->generateReport('my/path');
     }
+
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $user1 = UserTest::create([
+            'firstname' => 'John Jack',
+            'lastname' => 'User',
+        ]);
+
+        $image = ImageTest::create([
+            'lat' => 51.0,
+            'lng' => 0.0,
+            'attrs' => [
+                'width' => 100,
+                'height' => 100,
+                'metadata' => [
+                    'yaw' => 90,
+                    'distance_to_ground' => 10,
+                ],
+            ],
+        ]);
+
+        $annotation = ImageAnnotationTest::create([
+            'shape_id' => Shape::pointId(),
+            'points' => [10, 10],
+            'image_id' => $image->id,
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => $user1->id,
+        ]);
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+        $mock->shouldReceive('getPath')
+            ->twice()
+            ->andReturn('abc', 'def');
+
+        $jsonContent = [
+            'type' => 'Feature',
+            'geometry' => [
+                'type' => 'Point',
+                'coordinates' => [0.000114194969290087, 51.00007186522273],
+            ],
+            'properties' => [
+                '_id' => $al1->id,
+                '_image_id' => $image->id,
+                '_image_filename' => 'test-image.jpg',
+                '_image_latitude' => $image->lat,
+                '_image_longitude' => $image->lng,
+                '_label_name' => $al1->label->name,
+                '_label_id' => $al1->label->id,
+            ],
+        ];
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with(json_encode($jsonContent));
+
+        $jsonContent['properties']['_id'] = $al2->id;
+        $jsonContent['properties']['_label_name'] = $al2->label->name;
+        $jsonContent['properties']['_label_id'] = $al2->label->id;
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with(json_encode($jsonContent));
+
+        $mock->shouldReceive('close')
+            ->twice();
+
+        App::singleton(File::class, fn () => $mock);
+
+        $mock = Mockery::mock();
+
+        $mock->shouldReceive('open')
+            ->once()
+            ->andReturn(true);
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('abc', "{$al1->user->id}-john-jack-user.ndjson");
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('def', 'deleted-users.ndjson');
+
+        $mock->shouldReceive('close')->once();
+
+        App::singleton(ZipArchive::class, fn () => $mock);
+
+        $generator = new AnnotationLocationReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($image->volume);
+        $generator->generateReport('my/path');
+    }
 }

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/AreaReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/AreaReportGeneratorTest.php
@@ -499,6 +499,74 @@ class AreaReportGeneratorTest extends TestCase
         $generator->generateReport('my/path');
     }
 
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $image = ImageTest::create();
+
+        $annotation = ImageAnnotationTest::create([
+            'shape_id' => Shape::rectangleId(),
+            'image_id' => $image->id,
+            'points' => [100, 100, 100, 300, 200, 300, 200, 100],
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+        ]);
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+        $mock->shouldReceive('put')
+            ->once()
+            ->with("{$al1->user->firstname} {$al1->user->lastname}");
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with('(deleted users)');
+
+        $mock->shouldReceive('putCsv')
+            ->twice()
+            ->with($this->columns);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $annotation->id,
+                Shape::rectangleId(), 'Rectangle',
+                $al1->label_id, $al1->label->name,
+                $image->id, $image->filename,
+                '', '', '',
+                200, 100, 20000,
+            ]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $annotation->id,
+                Shape::rectangleId(), 'Rectangle',
+                $al2->label_id, $al2->label->name,
+                $image->id, $image->filename,
+                '', '', '',
+                200, 100, 20000,
+            ]);
+
+        $mock->shouldReceive('close')
+            ->twice();
+
+        App::singleton(CsvFile::class, fn () => $mock);
+
+        $generator = new AreaReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($image->volume);
+        $mock = Mockery::mock();
+        $mock->shouldReceive('run')->once();
+        $generator->setPythonScriptRunner($mock);
+        $generator->generateReport('my/path');
+    }
+
     public function testGenerateReportLineString()
     {
         $volume = VolumeTest::create([

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/BasicReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/BasicReportGeneratorTest.php
@@ -173,4 +173,53 @@ class BasicReportGeneratorTest extends TestCase
         $generator->setPythonScriptRunner($mock);
         $generator->generateReport('my/path');
     }
+
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $image = ImageTest::create();
+
+        $annotation = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+        ]);
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with("{$al1->user->firstname} {$al1->user->lastname}");
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([$al1->label->name, $al1->label->color, 1]);
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with('(deleted users)');
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([$al2->label->name, $al2->label->color, 1]);
+
+        $mock->shouldReceive('close')
+            ->twice();
+
+        App::singleton(CsvFile::class, fn () => $mock);
+
+        $generator = new BasicReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($image->volume);
+        $mock = Mockery::mock();
+        $mock->shouldReceive('run')->once();
+        $generator->setPythonScriptRunner($mock);
+        $generator->generateReport('my/path');
+    }
 }

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/CocoReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/CocoReportGeneratorTest.php
@@ -305,6 +305,100 @@ class CocoReportGeneratorTest extends TestCase
         $generator->generateReport('my/path');
     }
 
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $user1 = UserTest::create([
+            'firstname' => 'Joe Jack',
+            'lastname' => 'User',
+        ]);
+
+        $image = ImageTest::create();
+
+        $annotation = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => $user1->id,
+        ]);
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+        $mock->shouldReceive('getPath')
+            ->twice()
+            ->andReturn('abc', 'def');
+
+        $mock->shouldReceive('putCsv')
+            ->twice()
+            ->with($this->columns);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $al1->id,
+                $al1->label->id,
+                $al1->label->name,
+                $annotation->image_id,
+                $annotation->image->filename,
+                null,
+                null,
+                $annotation->shape->name,
+                json_encode($annotation->points),
+                null
+            ]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $al2->id,
+                $al2->label->id,
+                $al2->label->name,
+                $annotation->image_id,
+                $annotation->image->filename,
+                null,
+                null,
+                $annotation->shape->name,
+                json_encode($annotation->points),
+                null
+            ]);
+
+        $mock->shouldReceive('close')
+            ->twice();
+
+        App::singleton(CsvFile::class, fn () => $mock);
+
+        $mock = Mockery::mock();
+
+        $mock->shouldReceive('open')
+            ->once()
+            ->andReturn(true);
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('abc', "{$user1->id}-joe-jack-user.json");
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('def', 'deleted-users.json');
+
+        $mock->shouldReceive('close')->once();
+
+        App::singleton(ZipArchive::class, fn () => $mock);
+
+        $generator = new CocoReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($image->volume);
+        $mock = Mockery::mock();
+        $mock->shouldReceive('run')->once();
+        $generator->setPythonScriptRunner($mock);
+        $generator->generateReport('my/path');
+    }
+
     public function testGenerateReportWithDeletedUser()
     {
         $user = UserTest::create([

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/CsvReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/CsvReportGeneratorTest.php
@@ -357,6 +357,111 @@ class CsvReportGeneratorTest extends TestCase
         $generator->generateReport('my/path');
     }
 
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $user1 = UserTest::create([
+            'firstname' => 'Joe Jack',
+            'lastname' => 'User',
+        ]);
+
+        $image = ImageTest::create();
+
+        $annotation = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => $user1->id,
+        ]);
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+        $mock->shouldReceive('getPath')
+            ->twice()
+            ->andReturn('abc', 'def');
+
+        $mock->shouldReceive('putCsv')
+            ->twice()
+            ->with($this->columns);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $al1->id,
+                $al1->label->id,
+                $al1->label->name,
+                $al1->label->name,
+                $al1->user_id,
+                $al1->user->firstname,
+                $al1->user->lastname,
+                $annotation->image_id,
+                $annotation->image->filename,
+                null,
+                null,
+                $annotation->shape->id,
+                $annotation->shape->name,
+                json_encode($annotation->points),
+                null,
+                $annotation->id,
+                $al1->created_at,
+            ]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $al2->id,
+                $al2->label->id,
+                $al2->label->name,
+                $al2->label->name,
+                null,
+                null,
+                null,
+                $annotation->image_id,
+                $annotation->image->filename,
+                null,
+                null,
+                $annotation->shape->id,
+                $annotation->shape->name,
+                json_encode($annotation->points),
+                null,
+                $annotation->id,
+                $al2->created_at,
+            ]);
+
+        $mock->shouldReceive('close')
+            ->twice();
+
+        App::singleton(CsvFile::class, fn () => $mock);
+
+        $mock = Mockery::mock();
+
+        $mock->shouldReceive('open')
+            ->once()
+            ->andReturn(true);
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('abc', "{$user1->id}-joe-jack-user.csv");
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('def', 'deleted-users.csv');
+
+        $mock->shouldReceive('close')->once();
+
+        App::singleton(ZipArchive::class, fn () => $mock);
+
+        $generator = new CsvReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($image->volume);
+        $generator->generateReport('my/path');
+    }
+
     public function testGenerateReportWithDeletedUser()
     {
         $user = UserTest::create([

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/ExtendedReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/ExtendedReportGeneratorTest.php
@@ -187,4 +187,57 @@ class ExtendedReportGeneratorTest extends TestCase
         $generator->setPythonScriptRunner($mock);
         $generator->generateReport('my/path');
     }
+
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $image = ImageTest::create();
+
+        $annotation = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+        ]);
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with("{$al1->user->firstname} {$al1->user->lastname}");
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with('(deleted users)');
+
+        $mock->shouldReceive('putCsv')
+            ->twice()
+            ->with($this->columns);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([$image->filename, $al1->label->name, 1]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([$image->filename, $al2->label->name, 1]);
+
+        $mock->shouldReceive('close')
+            ->twice();
+
+        App::singleton(CsvFile::class, fn () => $mock);
+
+        $generator = new ExtendedReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($image->volume);
+        $mock = Mockery::mock();
+        $mock->shouldReceive('run')->once();
+        $generator->setPythonScriptRunner($mock);
+        $generator->generateReport('my/path');
+    }
 }

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/FullReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/FullReportGeneratorTest.php
@@ -214,4 +214,76 @@ class FullReportGeneratorTest extends TestCase
         $generator->setPythonScriptRunner($mock);
         $generator->generateReport('my/path');
     }
+
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $image = ImageTest::create([
+            'attrs' => ['some' => 'attrs'],
+        ]);
+
+        $annotation = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+        ]);
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with("{$al1->user->firstname} {$al1->user->lastname}");
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with(['image filename', 'annotation id', 'annotation shape', 'x/radius', 'y', 'labels', 'image area in m²']);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $image->filename,
+                $annotation->id,
+                $al1->label->name,
+                $annotation->shape->name,
+                json_encode($annotation->points),
+                null,
+            ]);
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with("(deleted users)");
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with(['image filename', 'annotation id', 'annotation shape', 'x/radius', 'y', 'labels', 'image area in m²']);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $image->filename,
+                $annotation->id,
+                $al2->label->name,
+                $annotation->shape->name,
+                json_encode($annotation->points),
+                null,
+            ]);
+
+        $mock->shouldReceive('close')->twice();
+
+        App::singleton(CsvFile::class, fn () => $mock);
+
+        $generator = new FullReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($image->volume);
+        $mock = Mockery::mock();
+        $mock->shouldReceive('run')->once();
+        $generator->setPythonScriptRunner($mock);
+        $generator->generateReport('my/path');
+    }
 }

--- a/tests/php/Services/Reports/Volumes/ImageAnnotations/ImageLocationReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageAnnotations/ImageLocationReportGeneratorTest.php
@@ -329,4 +329,100 @@ class ImageLocationReportGeneratorTest extends TestCase
         $generator->setSource($image->volume);
         $generator->generateReport('my/path');
     }
+
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $user1 = UserTest::create([
+            'firstname' => 'Joe Jack',
+            'lastname' => 'User',
+        ]);
+
+        $image = ImageTest::create([
+            'lng' => 80.2,
+            'lat' => 52.5,
+        ]);
+
+        $annotation = ImageAnnotationTest::create([
+            'image_id' => $image->id,
+        ]);
+
+        $al1 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => $user1->id,
+        ]);
+        $al2 = ImageAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+        $mock->shouldReceive('getPath')
+            ->twice()
+            ->andReturn('abc', 'def');
+
+        $jsonContent = [
+            'type' => 'Feature',
+            'geometry' => [
+                'type' => 'Point',
+                'coordinates' => [80.2, 52.5],
+            ],
+            'properties' => [
+                '_id' => $image->id,
+                '_filename' => $image->filename,
+                "{$al1->label->name} (#{$al1->label->id})" => 1,
+                "{$al2->label->name} (#{$al2->label->id})" => 0,
+            ],
+        ];
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with(json_encode($jsonContent));
+
+        $jsonContent = [
+            'type' => 'Feature',
+            'geometry' => [
+                'type' => 'Point',
+                'coordinates' => [80.2, 52.5],
+            ],
+            'properties' => [
+                '_id' => $image->id,
+                '_filename' => $image->filename,
+                "{$al1->label->name} (#{$al1->label->id})" => 0,
+                "{$al2->label->name} (#{$al2->label->id})" => 1,
+            ],
+        ];
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with(json_encode($jsonContent));
+
+        $mock->shouldReceive('close')
+            ->twice();
+
+        App::singleton(File::class, fn () => $mock);
+
+        $mock = Mockery::mock();
+
+        $mock->shouldReceive('open')
+            ->once()
+            ->andReturn(true);
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('abc', "{$user1->id}-joe-jack-user.ndjson");
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('def', 'deleted-users.ndjson');
+
+        $mock->shouldReceive('close')->once();
+
+        App::singleton(ZipArchive::class, fn () => $mock);
+
+        $generator = new ImageLocationReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($image->volume);
+        $generator->generateReport('my/path');
+    }
 }

--- a/tests/php/Services/Reports/Volumes/ImageLabels/BasicReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageLabels/BasicReportGeneratorTest.php
@@ -183,6 +183,54 @@ class BasicReportGeneratorTest extends TestCase
         $generator->generateReport('my/path');
     }
 
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $image = ImageTest::create();
+
+        $il1 = ImageLabelTest::create([
+            'image_id' => $image->id,
+        ]);
+        $il2 = ImageLabelTest::create([
+            'image_id' => $image->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+        $mock->shouldReceive('put')
+            ->once()
+            ->with("{$il1->user->firstname} {$il1->user->lastname}");
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with('(deleted users)');
+
+        $mock->shouldReceive('putCsv')
+            ->twice()
+            ->with($this->columns);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([$image->id, $image->filename, $il1->label->name]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([$image->id, $image->filename, $il2->label->name]);
+
+        $mock->shouldReceive('close')
+            ->twice();
+
+        App::singleton(CsvFile::class, fn () => $mock);
+
+        $generator = new BasicReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($image->volume);
+        $mock = Mockery::mock();
+        $mock->shouldReceive('run')->once();
+        $generator->setPythonScriptRunner($mock);
+        $generator->generateReport('my/path');
+    }
+
     public function testRestrictToLabels()
     {
         $image = ImageTest::create();

--- a/tests/php/Services/Reports/Volumes/ImageLabels/CsvReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageLabels/CsvReportGeneratorTest.php
@@ -306,6 +306,97 @@ class CsvReportGeneratorTest extends TestCase
         $generator->generateReport('my/path');
     }
 
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $user1 = UserTest::create([
+            'firstname' => 'Joe Jack',
+            'lastname' => 'User',
+        ]);
+
+        $image = ImageTest::create();
+
+        $il1 = ImageLabelTest::create([
+            'image_id' => $image->id,
+            'user_id' => $user1->id,
+        ]);
+        $il2 = ImageLabelTest::create([
+            'image_id' => $image->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+        $mock->shouldReceive('getPath')
+            ->twice()
+            ->andReturn('abc', 'def');
+
+        $mock->shouldReceive('putCsv')
+            ->twice()
+            ->with($this->columns);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $il1->id,
+                $image->id,
+                $image->filename,
+                null,
+                null,
+                $il1->user_id,
+                $il1->user->firstname,
+                $il1->user->lastname,
+                $il1->label->id,
+                $il1->label->name,
+                $il1->label->name,
+                $il1->created_at,
+            ]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $il2->id,
+                $image->id,
+                $image->filename,
+                null,
+                null,
+                null,
+                null,
+                null,
+                $il2->label->id,
+                $il2->label->name,
+                $il2->label->name,
+                $il2->created_at,
+            ]);
+
+        $mock->shouldReceive('close')
+            ->twice();
+
+        App::singleton(CsvFile::class, fn () => $mock);
+
+        $mock = Mockery::mock();
+
+        $mock->shouldReceive('open')
+            ->once()
+            ->andReturn(true);
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('abc', "{$user1->id}-joe-jack-user.csv");
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('def', 'deleted-users.csv');
+
+        $mock->shouldReceive('close')->once();
+
+        App::singleton(ZipArchive::class, fn () => $mock);
+
+        $generator = new CsvReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($image->volume);
+        $generator->generateReport('my/path');
+    }
+
     public function testRestrictToLabels()
     {
         $image = ImageTest::create();

--- a/tests/php/Services/Reports/Volumes/ImageLabels/ImageLocationReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/ImageLabels/ImageLocationReportGeneratorTest.php
@@ -317,6 +317,98 @@ class ImageLocationReportGeneratorTest extends TestCase
         $generator->generateReport('my/path');
     }
 
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $user1 = UserTest::create([
+            'firstname' => 'Joe Jack',
+            'lastname' => 'User',
+        ]);
+
+        $image = ImageTest::create([
+            'lng' => 80.2,
+            'lat' => 52.5,
+        ]);
+
+        $il1 = ImageLabelTest::create([
+            'image_id' => $image->id,
+            'user_id' => $user1->id,
+        ]);
+        $il2 = ImageLabelTest::create([
+            'image_id' => $image->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+        $mock->shouldReceive('getPath')
+            ->twice()
+            ->andReturn('abc', 'def');
+
+        $jsonContent = [
+            'type' => 'Feature',
+            'geometry' => [
+                'type' => 'Point',
+                'coordinates' => [80.2, 52.5],
+            ],
+            'properties' => [
+                '_id' => $image->id,
+                '_filename' => $image->filename,
+                "{$il1->label->name} (#{$il1->label->id})" => 1,
+                "{$il2->label->name} (#{$il2->label->id})" => 0,
+            ],
+        ];
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with(json_encode($jsonContent));
+
+        $jsonContent = [
+            'type' => 'Feature',
+            'geometry' => [
+                'type' => 'Point',
+                'coordinates' => [80.2, 52.5],
+            ],
+            'properties' => [
+                '_id' => $image->id,
+                '_filename' => $image->filename,
+                "{$il1->label->name} (#{$il1->label->id})" => 0,
+                "{$il2->label->name} (#{$il2->label->id})" => 1,
+            ],
+        ];
+
+        $mock->shouldReceive('put')
+            ->once()
+            ->with(json_encode($jsonContent));
+
+        $mock->shouldReceive('close')
+            ->twice();
+
+        App::singleton(File::class, fn () => $mock);
+
+        $mock = Mockery::mock();
+
+        $mock->shouldReceive('open')
+            ->once()
+            ->andReturn(true);
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('abc', "{$user1->id}-joe-jack-user.ndjson");
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('def', 'deleted-users.ndjson');
+
+        $mock->shouldReceive('close')->once();
+
+        App::singleton(ZipArchive::class, fn () => $mock);
+
+        $generator = new ImageLocationReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($image->volume);
+        $generator->generateReport('my/path');
+    }
+
     public function testRestrictToLabels()
     {
         $image = ImageTest::create();

--- a/tests/php/Services/Reports/Volumes/VideoAnnotations/CsvReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/VideoAnnotations/CsvReportGeneratorTest.php
@@ -351,6 +351,107 @@ class CsvReportGeneratorTest extends TestCase
         $generator->generateReport('my/path');
     }
 
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $user1 = UserTest::create([
+            'firstname' => 'Joe Jack',
+            'lastname' => 'User',
+        ]);
+
+        $video = VideoTest::create();
+
+        $annotation = VideoAnnotationTest::create(['video_id' => $video->id]);
+
+        $al1 = VideoAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => $user1->id,
+        ]);
+        $al2 = VideoAnnotationLabelTest::create([
+            'annotation_id' => $annotation->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+        $mock->shouldReceive('getPath')
+            ->twice()
+            ->andReturn('abc', 'def');
+
+        $mock->shouldReceive('putCsv')
+            ->twice()
+            ->with($this->columns);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $al1->id,
+                $al1->label->id,
+                $al1->label->name,
+                $al1->label->name,
+                $al1->user_id,
+                $al1->user->firstname,
+                $al1->user->lastname,
+                $annotation->video_id,
+                $annotation->video->filename,
+                $annotation->shape->id,
+                $annotation->shape->name,
+                json_encode($annotation->points),
+                json_encode($annotation->frames),
+                $annotation->id,
+                $al1->created_at,
+                json_encode($video->attrs),
+            ]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $al2->id,
+                $al2->label->id,
+                $al2->label->name,
+                $al2->label->name,
+                null,
+                null,
+                null,
+                $annotation->video_id,
+                $annotation->video->filename,
+                $annotation->shape->id,
+                $annotation->shape->name,
+                json_encode($annotation->points),
+                json_encode($annotation->frames),
+                $annotation->id,
+                $al2->created_at,
+                json_encode($video->attrs),
+            ]);
+
+        $mock->shouldReceive('close')
+            ->twice();
+
+        App::singleton(CsvFile::class, fn () => $mock);
+
+        $mock = Mockery::mock();
+
+        $mock->shouldReceive('open')
+            ->once()
+            ->andReturn(true);
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('abc', "{$user1->id}-joe-jack-user.csv");
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('def', 'deleted-users.csv');
+
+        $mock->shouldReceive('close')->once();
+
+        App::singleton(ZipArchive::class, fn () => $mock);
+
+        $generator = new CsvReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($video->volume);
+        $generator->generateReport('my/path');
+    }
+
     public function testRestrictToLabels()
     {
         $video = VideoTest::create();

--- a/tests/php/Services/Reports/Volumes/VideoLabels/CsvReportGeneratorTest.php
+++ b/tests/php/Services/Reports/Volumes/VideoLabels/CsvReportGeneratorTest.php
@@ -283,6 +283,93 @@ class CsvReportGeneratorTest extends TestCase
         $generator->generateReport('my/path');
     }
 
+    public function testGenerateReportSeparateUsersWithNullUserId()
+    {
+        $user1 = UserTest::create([
+            'firstname' => 'Joe Jack',
+            'lastname' => 'User',
+        ]);
+
+        $video = VideoTest::create();
+
+        $il1 = VideoLabelTest::create([
+            'video_id' => $video->id,
+            'user_id' => $user1->id,
+        ]);
+        $il2 = VideoLabelTest::create([
+            'video_id' => $video->id,
+            'user_id' => null,
+        ]);
+
+        $mock = Mockery::mock();
+        $mock->shouldReceive('getPath')
+            ->twice()
+            ->andReturn('abc', 'def');
+
+        $mock->shouldReceive('putCsv')
+            ->twice()
+            ->with($this->columns);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $il1->id,
+                $video->id,
+                $video->filename,
+                $il1->user_id,
+                $il1->user->firstname,
+                $il1->user->lastname,
+                $il1->label->id,
+                $il1->label->name,
+                $il1->label->name,
+                $il1->created_at,
+            ]);
+
+        $mock->shouldReceive('putCsv')
+            ->once()
+            ->with([
+                $il2->id,
+                $video->id,
+                $video->filename,
+                null,
+                null,
+                null,
+                $il2->label->id,
+                $il2->label->name,
+                $il2->label->name,
+                $il2->created_at,
+            ]);
+
+        $mock->shouldReceive('close')
+            ->twice();
+
+        App::singleton(CsvFile::class, fn () => $mock);
+
+        $mock = Mockery::mock();
+
+        $mock->shouldReceive('open')
+            ->once()
+            ->andReturn(true);
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('abc', "{$user1->id}-joe-jack-user.csv");
+
+        $mock->shouldReceive('addFile')
+            ->once()
+            ->with('def', 'deleted-users.csv');
+
+        $mock->shouldReceive('close')->once();
+
+        App::singleton(ZipArchive::class, fn () => $mock);
+
+        $generator = new CsvReportGenerator([
+            'separateUsers' => true,
+        ]);
+        $generator->setSource($video->volume);
+        $generator->generateReport('my/path');
+    }
+
     public function testRestrictToLabels()
     {
         $video = VideoTest::create();


### PR DESCRIPTION
Before, deleted users produced an error (when a coerced `''` key was invalid in the SQL query) or were silently dropped. This PR implements proper handling of deleted users so their annotations still show up in reports.