### PR TITLE
1240 improve control button active state

### DIFF
--- a/resources/assets/js/annotations/components/controlButton.vue
+++ b/resources/assets/js/annotations/components/controlButton.vue
@@ -108,6 +108,7 @@ export default {
         classObject() {
             return {
                 active: this.active,
+                'control-button--has-sub-controls': this.hasSubControls,
                 'control-button--open': this.showSubControls,
             };
         },

--- a/resources/assets/js/annotations/components/controlButton.vue
+++ b/resources/assets/js/annotations/components/controlButton.vue
@@ -108,7 +108,6 @@ export default {
         classObject() {
             return {
                 active: this.active,
-                'control-button--has-sub-controls': this.hasSubControls,
                 'control-button--open': this.showSubControls,
             };
         },

--- a/resources/assets/sass/annotations/components/_control-button.scss
+++ b/resources/assets/sass/annotations/components/_control-button.scss
@@ -1,3 +1,5 @@
+$control-button-active-color: #ff5e00;
+
 .control-button {
     position: relative;
     border-radius: 2px;
@@ -11,6 +13,14 @@
     &:hover, &.active {
         color: white;
         background-color: fade-out($ol-control-color, 0.3);
+    }
+
+    &:not(.control-button--danger):not(.control-button--has-sub-controls) {
+        transition: background-color 0.25s ease, box-shadow 0.25s ease;
+
+        &.active {
+            box-shadow: inset 0 0 0 2px $control-button-active-color;
+        }
     }
 
     &:focus {

--- a/resources/assets/sass/annotations/components/_control-button.scss
+++ b/resources/assets/sass/annotations/components/_control-button.scss
@@ -1,5 +1,3 @@
-$control-button-active-color: #ff5e00;
-
 .control-button {
     position: relative;
     border-radius: 2px;
@@ -15,9 +13,9 @@ $control-button-active-color: #ff5e00;
         background-color: fade-out($ol-control-color, 0.3);
     }
 
-    &:not(.control-button--danger):not(.control-button--has-sub-controls) {
+    &:not(.control-button--danger) {
         &.active {
-            background-color: $control-button-active-color;
+            background-color: $brand-info;
         }
     }
 

--- a/resources/assets/sass/annotations/components/_control-button.scss
+++ b/resources/assets/sass/annotations/components/_control-button.scss
@@ -16,10 +16,8 @@ $control-button-active-color: #ff5e00;
     }
 
     &:not(.control-button--danger):not(.control-button--has-sub-controls) {
-        transition: background-color 0.25s ease, box-shadow 0.25s ease;
-
         &.active {
-            box-shadow: inset 0 0 0 2px $control-button-active-color;
+            background-color: $control-button-active-color;
         }
     }
 


### PR DESCRIPTION
Fixes #1240

## Summary

- Use the annotation-selection orange as the background for active control buttons.
- Kept the grouped parent buttons unchanged while highlighting the selected sub-control.
- Preserved the existing styling of danger controls.