### PR TITLE
235 annotation guideline backend annotation controllers

### DIFF
--- a/app/AnnotationGuideline.php
+++ b/app/AnnotationGuideline.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Biigle;
 
 use DB;
@@ -68,5 +67,40 @@ class AnnotationGuideline extends Model
         return $this->belongsToMany(Label::class)
             ->using(AnnotationGuidelineLabel::class)
             ->withPivot('shape_id', 'description', 'uuid', 'reference_image_path');
+    }
+
+    /**
+     * Validates whether an annotation is compatible with an annotation guideline.
+     *
+     * @param int $labelId The ID of the desired annotation label
+     * @param int $shapeId The ID of the desired annotation shape
+     *
+     * @return bool
+     */
+    public function validate(int $labelId, int $shapeId): bool
+    {
+        if ($this->enforced) {
+            $labelInAnnotationGuideline = true;
+
+            $annotationLabels = $this->labels();
+            if ($annotationLabels->exists()) {
+                $labelInAnnotationGuideline = $annotationLabels
+                    ->wherePivot("label_id", $labelId)
+                    ->where(function ($query) use ($shapeId, $annotationLabels) {
+                        $pivotColumn = $annotationLabels->qualifyPivotColumn('shape_id');
+                        $query->where($pivotColumn, $shapeId)
+                            ->orWhereNull($pivotColumn);
+                    })
+                    ->exists();
+            }
+
+            $shapeInAnnotation = true;
+
+            if (!is_null($this->only_shapes) && count($this->only_shapes) > 0) {
+                $shapeInAnnotation = in_array($shapeId, $this->only_shapes);
+            }
+            return $labelInAnnotationGuideline && $shapeInAnnotation;
+        }
+        return true;
     }
 }

--- a/app/Http/Controllers/Api/ImageAnnotationBulkController.php
+++ b/app/Http/Controllers/Api/ImageAnnotationBulkController.php
@@ -2,6 +2,7 @@
 
 namespace Biigle\Http\Controllers\Api;
 
+use Biigle\AnnotationGuideline;
 use Biigle\Http\Requests\StoreImageAnnotations;
 use Biigle\ImageAnnotation;
 use Biigle\ImageAnnotationLabel;
@@ -61,7 +62,8 @@ class ImageAnnotationBulkController extends Controller
      *        "shape_id": 1,
      *        "label_id": 1,
      *        "confidence": 1.00,
-     *        "points": [10, 11]
+     *        "points": [10, 11],
+     *        "annotation_guideline_id": 48
      *     },
      *     {
      *        "image_id": 321,
@@ -78,9 +80,24 @@ class ImageAnnotationBulkController extends Controller
      */
     public function store(StoreImageAnnotations $request)
     {
-        $annotations = collect($request->all())->map(function ($input) {
+        //Avoid having to find guideline repeatedly
+        $annotationGuidelines = [];
+        $annotations = collect($request->all())->map(function ($input) use ($annotationGuidelines) {
+            $annotationGuideline = null;
+            if (($annotationGuidelineId = $input['annotation_guideline_id'] ?? null) !== null) {
+                /** @phpstan-ignore nullCoalesce.offset */
+                $annotationGuidelines[$annotationGuidelineId] ??= AnnotationGuideline::findOrFail($annotationGuidelineId);
+                $annotationGuideline = $annotationGuidelines[$annotationGuidelineId];
+            }
+            $shapeId = $input['shape_id'];
+            $labelId = $input['label_id'];
+
+            if (!is_null($annotationGuideline) && !$annotationGuideline->validate($labelId, $shapeId)) {
+                abort(422, "Annotation uncompatible with enforced Annotation Guideline");
+            }
+
             $annotation = new ImageAnnotation;
-            $annotation->shape_id = $input['shape_id'];
+            $annotation->shape_id = $shapeId;
 
             try {
                 $annotation->validatePoints($input['points']);
@@ -88,10 +105,11 @@ class ImageAnnotationBulkController extends Controller
                 throw ValidationException::withMessages(['points' => [$e->getMessage()]]);
             }
 
+
             $annotation->points = $input['points'];
             $annotation->image_id = $input['image_id'];
             /** @phpstan-ignore property.notFound */
-            $annotation->label_id = $input['label_id'];
+            $annotation->label_id = $labelId;
             /** @phpstan-ignore property.notFound */
             $annotation->confidence = $input['confidence'];
 

--- a/app/Http/Controllers/Api/ImageAnnotationController.php
+++ b/app/Http/Controllers/Api/ImageAnnotationController.php
@@ -114,7 +114,6 @@ class ImageAnnotationController extends Controller
      * }
      */
 
-
     /**
      * Displays the annotation.
      *

--- a/app/Http/Controllers/Api/ImageAnnotationController.php
+++ b/app/Http/Controllers/Api/ImageAnnotationController.php
@@ -96,6 +96,26 @@ class ImageAnnotationController extends Controller
     }
 
     /**
+     * @api {get} annotations/:id Get an annotation
+     * @apiDeprecated use now (#ImageAnnotations:ShowImageAnnotation).
+     * @apiGroup Annotations
+     * @apiName ShowAnnotation
+     * @apiParam {Number} id The annotation ID.
+     * @apiPermission projectMember
+     * @apiDescription Access may be denied by an active annotation session of the volume, the annotation belongs to.
+     * @apiSuccessExample {json} Success response:
+     * {
+     *    "id":1,
+     *    "image_id":1,
+     *    "shape_id":1,
+     *    "created_at":"2015-02-13 11:59:23",
+     *    "updated_at":"2015-02-13 11:59:23",
+     *    "points": [100, 100]
+     * }
+     */
+
+
+    /**
      * Displays the annotation.
      *
      * @api {get} image-annotations/:id Get an annotation

--- a/app/Http/Controllers/Api/ImageAnnotationController.php
+++ b/app/Http/Controllers/Api/ImageAnnotationController.php
@@ -2,6 +2,7 @@
 
 namespace Biigle\Http\Controllers\Api;
 
+use Biigle\AnnotationGuideline;
 use Biigle\Http\Requests\StoreImageAnnotation;
 use Biigle\Image;
 use Biigle\ImageAnnotation;
@@ -95,25 +96,6 @@ class ImageAnnotationController extends Controller
     }
 
     /**
-     * @api {get} annotations/:id Get an annotation
-     * @apiDeprecated use now (#ImageAnnotations:ShowImageAnnotation).
-     * @apiGroup Annotations
-     * @apiName ShowAnnotation
-     * @apiParam {Number} id The annotation ID.
-     * @apiPermission projectMember
-     * @apiDescription Access may be denied by an active annotation session of the volume, the annotation belongs to.
-     * @apiSuccessExample {json} Success response:
-     * {
-     *    "id":1,
-     *    "image_id":1,
-     *    "shape_id":1,
-     *    "created_at":"2015-02-13 11:59:23",
-     *    "updated_at":"2015-02-13 11:59:23",
-     *    "points": [100, 100]
-     * }
-     */
-
-    /**
      * Displays the annotation.
      *
      * @api {get} image-annotations/:id Get an annotation
@@ -166,6 +148,7 @@ class ImageAnnotationController extends Controller
      * **LineString:** Like rectangle with one or more vertices.
      * **Circle:** The first point is the center of the circle. The third value of the points array is the radius of the circle. A valid points array of a circle might look like this: `[10, 10, 5]`.
      * **Ellipse:** The four points specify the end points of the semi-major and semi-minor axes of the ellipse in (counter-)clockwise ordering (depending on how the ellipse was drawn). So the first point is the end point of axis 1, the second is the end point of axis 2, the third is the other end point of axis 1 and the fourth is the other end point of axis 2.
+     * @apiParam (Optional arguments) {Number} annotation_guideline_id ID of the guideline associated with the annotation.
      *
      * @apiParamExample {JSON} Request example (JSON):
      * {
@@ -212,7 +195,8 @@ class ImageAnnotationController extends Controller
         $points = $request->input('points');
 
         $annotation = new ImageAnnotation;
-        $annotation->shape_id = $request->input('shape_id');
+        $shapeId = $request->input('shape_id');
+        $annotation->shape_id = $shapeId;
         $image = $request->image;
         $annotation->image()->associate($image);
         try {
@@ -223,10 +207,19 @@ class ImageAnnotationController extends Controller
 
         $annotation->points = $points;
 
+        $annotationGuideline = null;
+
+        if ($request->has('annotation_guideline_id')) {
+            $annotationGuideline = AnnotationGuideline::findOrFail($request->input('annotation_guideline_id'));
+        }
+
         if ($request->has('label_id')) {
             $label = Label::findOrFail($request->input('label_id'));
+            if (!is_null($annotationGuideline) && !$annotationGuideline->validate($label->id, $annotation->shape_id)) {
+                abort(422, "Annotation uncompatible with enforced Annotation Guideline");
+            }
         } else {
-            $labels = $labelBotService->getLabelsForAnnotation($annotation, $image->volume_id, $request);
+            $labels = $labelBotService->getLabelsForAnnotation($annotation, $image->volume_id, $request, $annotationGuideline, $shapeId);
             // Add labelBOTlabels attribute to the response.
             $annotation->append('labelBOTLabels');
             $label = array_shift($labels);
@@ -235,6 +228,7 @@ class ImageAnnotationController extends Controller
                 $annotation->labelBOTLabels = $labels;
             }
         }
+
 
         $this->authorize('attach-label', [$annotation, $label]);
 
@@ -262,6 +256,7 @@ class ImageAnnotationController extends Controller
      * @apiParam {Number} id The annotation ID.
      * @apiParam (Attributes that can be updated) {Number} shape_id ID of the new shape of the annotation.
      * @apiParam (Attributes that can be updated) {Number[]} points Array of new points of the annotation. The new points will replace the old points. See the "Create a new annotation" endpoint for how the points are interpreted for different shapes.
+     * @apiParam (Optional arguments) {Number} annotation_guideline_id ID of the guideline associated with the annotation.
      * @apiParamExample {json} Request example (JSON):
      * {
      *    "points": [10, 11, 20, 21],
@@ -280,10 +275,12 @@ class ImageAnnotationController extends Controller
      * @apiParam {Number} id The annotation ID.
      * @apiParam (Attributes that can be updated) {Number} shape_id ID of the new shape of the annotation.
      * @apiParam (Attributes that can be updated) {Number[]} points Array of new points of the annotation. The new points will replace the old points. See the "Create a new annotation" endpoint for how the points are interpreted for different shapes.
+     * @apiParam (Optional arguments) {Number} annotation_guideline_id ID of the guideline associated with the annotation.
      * @apiParamExample {json} Request example (JSON):
      * {
      *    "points": [10, 11, 20, 21],
-     *    "shape_id": 3
+     *    "shape_id": 3,
+     *    "annotation_guideline_id": 4
      * }
      *
      * @param Request $request
@@ -300,7 +297,19 @@ class ImageAnnotationController extends Controller
 
         // from a JSON request, the array may already be decoded
         $points = $request->input('points', $annotation->points);
-        $annotation->shape_id = $request->input('shape_id', $annotation->shape_id);
+        $shapeId = $request->input('shape_id', $annotation->shape_id);
+
+        $annotationGuideline = null;
+        if ($request->has('annotation_guideline_id')) {
+            $annotationGuideline = AnnotationGuideline::findOrFail($request->input('annotation_guideline_id'));
+            $labels = $annotation->labels()->get();
+            foreach ($labels as $label) {
+                if (!$annotationGuideline->validate($label->label_id, $shapeId)) {
+                    abort(422, "Annotation uncompatible with enforced Annotation Guideline");
+                }
+            }
+        }
+        $annotation->shape_id = $shapeId;
 
         try {
             $annotation->validatePoints($points);

--- a/app/Http/Controllers/Api/ImageAnnotationLabelController.php
+++ b/app/Http/Controllers/Api/ImageAnnotationLabelController.php
@@ -2,11 +2,11 @@
 
 namespace Biigle\Http\Controllers\Api;
 
+use Biigle\AnnotationGuideline;
 use Biigle\Events\AnnotationLabelAttached;
 use Biigle\Http\Requests\StoreImageAnnotationLabel;
 use Biigle\ImageAnnotation;
 use Biigle\ImageAnnotationLabel;
-use Biigle\Label;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
 use Str;
@@ -102,6 +102,7 @@ class ImageAnnotationLabelController extends Controller
      * @apiParam {Number} id The annotation ID.
      * @apiParam (Required arguments) {Number} label_id The ID of the label category to attach to the annotation.
      * @apiParam (Required arguments) {Number} confidence The level of confidence for this annotation label.
+     * @apiParam (Optional arguments) {Number} annotation_guideline_id ID of the guideline associated with the annotation.
      * @apiParamExample {String} Request example:
      * label_id: 1
      * confidence: 0.75
@@ -138,6 +139,7 @@ class ImageAnnotationLabelController extends Controller
      * @apiParam {Number} id The annotation ID.
      * @apiParam (Required arguments) {Number} label_id The ID of the label category to attach to the annotation.
      * @apiParam (Required arguments) {Number} confidence The level of confidence for this annotation label.
+     * @apiParam (Optional arguments) {Number} annotation_guideline_id ID of the guideline associated with the annotation.
      * @apiParamExample {String} Request example:
      * label_id: 1
      * confidence: 0.75
@@ -178,6 +180,15 @@ class ImageAnnotationLabelController extends Controller
 
         if ($exists) {
             abort(400, 'The user already attached this label to the annotation.');
+        }
+
+        if ($request->has('annotation_guideline_id')) {
+            $annotationGuideline = AnnotationGuideline::findOrFail($request->input('annotation_guideline_id'));
+            $shapeId = $annotationLabel->annotation()->first()->shape_id;
+
+            if (!$annotationGuideline->validate($annotationLabel->label_id, $shapeId)) {
+                abort(422, "Annotation uncompatible with enforced Annotation Guideline");
+            }
         }
 
         try {

--- a/app/Http/Controllers/Api/VideoAnnotationController.php
+++ b/app/Http/Controllers/Api/VideoAnnotationController.php
@@ -2,6 +2,7 @@
 
 namespace Biigle\Http\Controllers\Api;
 
+use Biigle\AnnotationGuideline;
 use Biigle\Http\Requests\StoreVideoAnnotation;
 use Biigle\Http\Requests\UpdateVideoAnnotation;
 use Biigle\Jobs\TrackObject;
@@ -163,6 +164,7 @@ class VideoAnnotationController extends Controller
      * **Ellipse:** The four points specify the end points of the semi-major and semi-minor axes of the ellipse in (counter-)clockwise ordering (depending on how the ellipse was drawn). So the first point is the end point of axis 1, the second is the end point of axis 2, the third is the other end point of axis 1 and the fourth is the other end point of axis 2.
      * **WholeFrame:** The points array must be empty for this shape.
      * @apiParam (Optional arguments) {Boolean} track Set to true to start automatic object tracking for the new annotation. This can only be done for single frame point or circle annotations. Poll the show video annotation endpoint to see when the object tracking is finished. On success, the annotation gets additional frames. On failure the annotation is deleted.
+     * @apiParam (Optional arguments) {Number} annotation_guideline_id ID of the guideline associated with the annotation.
      *
      * @apiParamExample {JSON} Request example (JSON):
      * {
@@ -215,9 +217,10 @@ class VideoAnnotationController extends Controller
 
         $points = $request->input('points', []);
 
+        $shapeId = $request->input('shape_id');
         $annotation = new VideoAnnotation([
             'video_id' => $request->video->id,
-            'shape_id' => $request->input('shape_id'),
+            'shape_id' => $shapeId,
             'points' => $points,
             'frames' => $request->input('frames'),
         ]);
@@ -228,10 +231,21 @@ class VideoAnnotationController extends Controller
             throw ValidationException::withMessages(['points' => [$e->getMessage()]]);
         }
 
+
         if ($request->has('label_id')) {
             $label = Label::findOrFail($request->input('label_id'));
+            if ($request->has('annotation_guideline_id')) {
+                $annotationGuideline = AnnotationGuideline::findOrFail($request->input('annotation_guideline_id'));
+                if (!$annotationGuideline->validate($label->id, $annotation->shape_id)) {
+                    abort(422, "Annotation uncompatible with enforced Annotation Guideline");
+                }
+            }
         } else {
-            $labels = $labelBotService->getLabelsForAnnotation($annotation, $request->video->volume_id, $request);
+            $annotationGuideline = null;
+            if ($request->has('annotation_guideline_id')) {
+                $annotationGuideline = AnnotationGuideline::findOrFail($request->input('annotation_guideline_id'));
+            }
+            $labels = $labelBotService->getLabelsForAnnotation($annotation, $request->video->volume_id, $request, $annotationGuideline, $shapeId);
             // Add labelBOTlabels attribute to the response.
             $annotation->append('labelBOTLabels');
             $label = array_shift($labels);
@@ -298,6 +312,7 @@ class VideoAnnotationController extends Controller
 
         $request->annotation->points = $points;
         $request->annotation->frames = $request->input('frames');
+
 
         try {
             $request->annotation->validatePoints();

--- a/app/Http/Controllers/Api/VideoAnnotationLabelController.php
+++ b/app/Http/Controllers/Api/VideoAnnotationLabelController.php
@@ -2,6 +2,7 @@
 
 namespace Biigle\Http\Controllers\Api;
 
+use Biigle\AnnotationGuideline;
 use Biigle\Events\AnnotationLabelAttached;
 use Biigle\Http\Requests\DestroyVideoAnnotationLabel;
 use Biigle\Http\Requests\StoreVideoAnnotationLabel;
@@ -24,6 +25,7 @@ class VideoAnnotationLabelController extends Controller
      * @apiParam {Number} id The video annotation ID.
      *
      * @apiParam (Required arguments) {Number} label_id ID of the label to be attached to the annotation.
+     * @apiParam (Optional arguments) {Number} annotation_guideline_id ID of the guideline associated with the annotation.
      *
      * @apiSuccessExample {json} Success response:
      * {
@@ -59,6 +61,15 @@ class VideoAnnotationLabelController extends Controller
 
         if ($exists) {
             abort(400, 'The user already attached this label to the annotation.');
+        }
+
+        if ($request->has('annotation_guideline_id')) {
+            $annotationGuideline = AnnotationGuideline::findOrFail($request->input('annotation_guideline_id'));
+            $shapeId = $annotationLabel->annotation()->first()->shape_id;
+
+            if (!$annotationGuideline->validate($annotationLabel->label_id, $shapeId)) {
+                abort(422, "Annotation uncompatible with enforced Annotation Guideline");
+            }
         }
 
         try {

--- a/app/Http/Requests/StoreImageAnnotationLabel.php
+++ b/app/Http/Requests/StoreImageAnnotationLabel.php
@@ -47,6 +47,9 @@ class StoreImageAnnotationLabel extends FormRequest
         return [
             // The label_id is already validated above.
             'confidence'  => 'required|numeric|between:0,1',
+            'annotation_guideline_id' => 'nullable|integer',
+
+
         ];
     }
 }

--- a/app/Http/Requests/StoreImageAnnotations.php
+++ b/app/Http/Requests/StoreImageAnnotations.php
@@ -76,6 +76,7 @@ class StoreImageAnnotations extends FormRequest
             '*.confidence' => 'required|numeric|between:0,1',
             '*.shape_id' => 'required|integer|exists:shapes,id',
             '*.points' => 'required|array',
+            '*.annotation_guideline_id' => 'nullable|integer',
         ];
     }
 

--- a/app/Http/Requests/StoreVideoAnnotation.php
+++ b/app/Http/Requests/StoreVideoAnnotation.php
@@ -48,6 +48,7 @@ class StoreVideoAnnotation extends FormRequest
             'frames' => 'required|array',
             'frames.*' => 'required|numeric|min:0|max:'.$this->video->duration,
             'track' => 'filled|boolean',
+            'annotation_guideline_id' => 'nullable|integer',
         ];
     }
 

--- a/app/Http/Requests/StoreVideoAnnotationLabel.php
+++ b/app/Http/Requests/StoreVideoAnnotationLabel.php
@@ -46,6 +46,7 @@ class StoreVideoAnnotationLabel extends FormRequest
     {
         return [
             // The label_id is already validated above.
+            'annotation_guideline_id' => 'nullable|integer',
         ];
     }
 

--- a/app/Services/LabelBot/LabelBotService.php
+++ b/app/Services/LabelBot/LabelBotService.php
@@ -3,6 +3,7 @@
 namespace Biigle\Services\LabelBot;
 
 use Biigle\Annotation;
+use Biigle\AnnotationGuideline;
 use Biigle\ImageAnnotation;
 use Biigle\ImageAnnotationLabelFeatureVector;
 use Biigle\Label;
@@ -28,6 +29,8 @@ class LabelBotService
         Annotation $annotation,
         int $volumeId,
         Request $request,
+        AnnotationGuideline | null $annotationGuideline,
+        int $shapeId,
     ): array {
         $user = $request->user();
         $topNLabels = [];
@@ -45,6 +48,9 @@ class LabelBotService
         Cache::increment($cacheKey);
         try {
             $topNLabels = $this->performVectorSearch($featureVector, $treeIds, $model);
+            if (!is_null($annotationGuideline)) {
+                $topNLabels = array_filter($topNLabels, fn ($labelId) => $annotationGuideline->validate($labelId, $shapeId));
+            }
         } finally {
             $count = Cache::decrement($cacheKey);
             if ($count <= 0) {

--- a/tests/php/AnnotationGuidelineTest.php
+++ b/tests/php/AnnotationGuidelineTest.php
@@ -4,6 +4,7 @@ namespace Biigle\Tests;
 
 use Biigle\AnnotationGuideline;
 use Biigle\AnnotationGuidelineLabel;
+use Biigle\Shape;
 use Illuminate\Database\QueryException;
 use ModelTestCase;
 use Storage;
@@ -74,5 +75,46 @@ class AnnotationGuidelineTest extends ModelTestCase
         $this->model->delete();
         $this->assertFalse($this->model->labels()->exists());
         $this->assertNotNull($label->fresh());
+    }
+
+    public function testValidate()
+    {
+        $label = LabelTest::create();
+        $label2 = LabelTest::create();
+
+        $this->assertTrue($this->model->validate($label->id, Shape::pointId()));
+
+        $this->model->update(['enforced' => true]);
+        $this->assertTrue($this->model->validate($label->id, Shape::pointId()));
+
+        $this->model->update(['only_shapes' => [Shape::lineId()]]);
+        $this->assertFalse($this->model->validate($label->id, Shape::pointId()));
+
+        $this->model->update(['only_shapes' => [Shape::lineId(), Shape::pointId()]]);
+        $this->assertTrue($this->model->validate($label->id, Shape::pointId()));
+
+        AnnotationGuidelineLabel::factory()->create([
+            'annotation_guideline_id' => $this->model->id,
+            'label_id' => $label2->id,
+        ]);
+        $this->assertFalse($this->model->validate($label->id, Shape::pointId()));
+
+        $annotationGuidelineLabel = AnnotationGuidelineLabel::factory()->create([
+            'annotation_guideline_id' => $this->model->id,
+            'label_id' => $label->id,
+        ]);
+        $this->assertTrue($this->model->validate($label->id, Shape::pointId()));
+
+        $annotationGuidelineLabel->update([
+            'shape_id' => Shape::circleId(),
+        ]);
+
+        $this->assertFalse($this->model->validate($label->id, Shape::pointId()));
+
+        $annotationGuidelineLabel->update([
+            'shape_id' => Shape::pointId(),
+        ]);
+
+        $this->assertTrue($this->model->validate($label->id, Shape::pointId()));
     }
 }

--- a/tests/php/Http/Controllers/Api/ImageAnnotationBulkControllerTest.php
+++ b/tests/php/Http/Controllers/Api/ImageAnnotationBulkControllerTest.php
@@ -3,6 +3,8 @@
 namespace Biigle\Tests\Http\Controllers\Api;
 
 use ApiTestCase;
+use Biigle\AnnotationGuideline;
+use Biigle\AnnotationGuidelineLabel;
 use Biigle\Shape;
 use Biigle\Tests\ImageAnnotationTest;
 use Biigle\Tests\ImageTest;
@@ -276,5 +278,140 @@ class ImageAnnotationBulkControllerTest extends ApiTestCase
                 ],
             ])
             ->assertStatus(422);
+    }
+
+    public function storeWithAnnotationGuideline($url)
+    {
+
+        $label = LabelTest::create();
+        $label2 = LabelTest::create();
+        $image = ImageTest::create();
+        $this->project()->addVolumeId($image->volume_id);
+
+        $this->project()->labelTrees()->attach($label->label_tree_id);
+        $this->project()->labelTrees()->attach($label2->label_tree_id);
+
+        $lineId = Shape::lineId();
+        $pointId = Shape::pointId();
+
+        $annotationGuideline = AnnotationGuideline::create([
+            'project_id' => $this->project()->id,
+        ]);
+
+        $requestData = [[
+            'image_id' => $image->id,
+            'shape_id' => $pointId,
+            'label_id' => $label->id,
+            'confidence' => 0.5,
+            'points' => [10, 11],
+        ],
+            [
+                'image_id' => $image->id,
+                'shape_id' => $pointId,
+                'label_id' => $label->id,
+                'confidence' => 0.5,
+                'points' => [100, 101],
+            ]];
+
+        $requestDataAnnotationGuideline = [[
+            'image_id' => $image->id,
+            'shape_id' => $pointId,
+            'label_id' => $label->id,
+            'confidence' => 0.5,
+            'points' => [10, 11],
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ],
+            [
+                'image_id' => $image->id,
+                'shape_id' => $pointId,
+                'label_id' => $label->id,
+                'confidence' => 0.5,
+                'points' => [100, 101],
+                'annotation_guideline_id' => $annotationGuideline->id,
+            ]];
+
+        $this->beEditor();
+
+        // Base case with guideline
+        $response = $this->postJson($url, $requestData);
+        $response->assertSuccessful();
+
+        // No enforcement
+        $response = $this->postJson($url, $requestDataAnnotationGuideline);
+        $response->assertSuccessful();
+
+        // Enforcement - No shapes
+        $annotationGuideline->update(['enforced' => true]);
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        $response = $this->post($url, $requestDataAnnotationGuideline);
+        $response->assertSuccessful();
+
+        // Enforcement - one shape - wrong shape
+        $annotationGuideline->update(['only_shapes' => [$lineId]]);
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        $response = $this->post($url, $requestDataAnnotationGuideline);
+        $response->assertStatus(422);
+
+        // Enforcement - one shape - correct shape
+        $annotationGuideline->update(['only_shapes' => [$pointId]]);
+        $response = $this->post($url, $requestDataAnnotationGuideline);
+        $response->assertSuccessful();
+
+        // Enforcement - with wrong label - no shape specified
+        $annotationGuideline->update(['only_shapes' => [$lineId, $pointId]]);
+        $annotationGuidelineLabel2 = AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $label2->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'c796ccec-c746-308f-8009-9f1f68e2aa62',
+            ]
+        );
+
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        $response = $this->post($url, $requestDataAnnotationGuideline);
+        $response->assertStatus(422);
+
+        // Enforcement - with correct label - no shape specified
+        $annotationGuidelineLabel = AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $label->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'c796ccec-c748-308f-8009-9f1f68e2aa62',
+            ]
+        );
+
+        $response = $this->post($url, $requestDataAnnotationGuideline);
+        $response->assertSuccessful();
+
+        // Enforcement - with correct label - wrong shape
+        $annotationGuidelineLabel->update(['shape_id' => $lineId]);
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        $response = $this->post($url, $requestDataAnnotationGuideline);
+        $response->assertStatus(422);
+
+        // Enforcement - with correct label - correct shape
+        $annotationGuidelineLabel->update(['shape_id' => $pointId]);
+        $response = $this->post($url, $requestDataAnnotationGuideline);
+        $response->assertSuccessful();
+    }
+
+    public function testStoreWithAnnotationGuideline()
+    {
+        $this->storeWithAnnotationGuideline('api/v1/image-annotations');
+    }
+
+    public function testStoreWithAnnotationGuidelineLegacy()
+    {
+        $this->storeWithAnnotationGuideline('api/v1/annotations');
     }
 }

--- a/tests/php/Http/Controllers/Api/ImageAnnotationControllerTest.php
+++ b/tests/php/Http/Controllers/Api/ImageAnnotationControllerTest.php
@@ -1,8 +1,9 @@
 <?php
-
 namespace Biigle\Tests\Http\Controllers\Api;
 
 use ApiTestCase;
+use Biigle\AnnotationGuideline;
+use Biigle\AnnotationGuidelineLabel;
 use Biigle\ImageAnnotationLabelFeatureVector;
 use Biigle\Shape;
 use Biigle\Tests\AnnotationSessionTest;
@@ -18,6 +19,8 @@ use Symfony\Component\HttpFoundation\Response;
 class ImageAnnotationControllerTest extends ApiTestCase
 {
     private $image;
+    private $annotation;
+    private $label;
 
     public function setUp(): void
     {
@@ -29,6 +32,14 @@ class ImageAnnotationControllerTest extends ApiTestCase
         $this->annotation = ImageAnnotationTest::create([
             'image_id' => $this->image->id,
             'points' => [10, 20, 30, 40],
+        ]);
+
+        $this->label = LabelTest::create();
+
+        ImageAnnotationLabelTest::create([
+            'label_id' => $this->label->id,
+            'annotation_id' => $this->annotation->id,
+            'user_id' => $this->editor()->id,
         ]);
     }
 
@@ -118,7 +129,7 @@ class ImageAnnotationControllerTest extends ApiTestCase
 
         $response->assertJsonFragment(['points' => [10, 20]])
             ->assertJsonFragment(['points' => [20, 30]]);
-        
+
 
         $session->users()->attach($this->editor());
         Cache::flush();
@@ -138,7 +149,7 @@ class ImageAnnotationControllerTest extends ApiTestCase
 
         $response->assertJsonMissing(['points' => [10, 20]])
             ->assertJsonFragment(['points' => [20, 30]]);
-        
+
     }
 
     public function testShow()
@@ -327,6 +338,115 @@ class ImageAnnotationControllerTest extends ApiTestCase
         $this->assertSame(1, $annotation->labels()->count());
     }
 
+    public function testStoreWithAnnotationGuideline()
+    {
+        $this->annotation->delete();
+        $label = LabelTest::create();
+        $label2 = LabelTest::create();
+        $this->project()->labelTrees()->attach($label->label_tree_id);
+        $this->project()->labelTrees()->attach($label2->label_tree_id);
+
+        $lineId = Shape::lineId();
+        $pointId = Shape::pointId();
+
+        $annotationGuideline = AnnotationGuideline::create([
+            'project_id' => $this->project()->id,
+        ]);
+        $url = "/api/v1/images/{$this->image->id}/annotations";
+        $requestData = [
+            'shape_id' => Shape::pointId(),
+            'label_id' => $label->id,
+            'confidence' => 0.5,
+            'points' => [10, 11],
+        ];
+
+        $requestDataWithGuideline = [
+            'shape_id' => Shape::pointId(),
+            'label_id' => $label->id,
+            'confidence' => 0.5,
+            'points' => [10, 11],
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ];
+
+        $this->doTestApiRoute('POST', "/api/v1/images/{$this->image->id}/annotations");
+
+        $this->beEditor();
+
+        // No enforcement
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        $response = $this->post($url, $requestDataWithGuideline);
+        $response->assertSuccessful();
+
+        // Enforcement - No shapes
+        $annotationGuideline->update(['enforced' => true]);
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        $response = $this->post($url, $requestDataWithGuideline);
+        $response->assertSuccessful();
+
+        // Enforcement - one shape
+        $annotationGuideline->update(['only_shapes' => [$lineId]]);
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        $annotationGuideline->update(['only_shapes' => [$lineId]]);
+        $response = $this->post($url, $requestDataWithGuideline);
+        $response->assertStatus(422);
+
+        // Enforcement - one shape - correct shape
+        $annotationGuideline->update(['only_shapes' => [$pointId]]);
+        $response = $this->post($url, $requestDataWithGuideline);
+        $response->assertSuccessful();
+
+        // Enforcement - with wrong label - no shape specified
+        $annotationGuideline->update(['only_shapes' => [$lineId, $pointId]]);
+        $annotationGuidelineLabel2 = AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $label2->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'c796ccec-c746-308f-8009-9f1f68e2aa62',
+            ]
+        );
+
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        $annotationGuideline->update(['only_shapes' => [$lineId]]);
+        $response = $this->post($url, $requestDataWithGuideline);
+        $response->assertStatus(422);
+
+        // Enforcement - with correct label - no shape specified
+        $annotationGuidelineLabel = AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $label->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'c796ccec-c748-308f-8009-9f1f68e2aa62',
+            ]
+        );
+
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        // Enforcement - with correct label - wrong shape
+        $annotationGuidelineLabel->update(['shape_id' => $lineId]);
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        $response = $this->post($url, $requestDataWithGuideline);
+        $response->assertStatus(422);
+
+        // Enforcement - with correct label - correct shape
+        $annotationGuidelineLabel->update(["shape_id" => $pointId]);
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+    }
+
     public function testStoreWithFeatureVectorWithoutHNSW()
     {
         $this->beEditor();
@@ -405,6 +525,103 @@ class ImageAnnotationControllerTest extends ApiTestCase
             'labelBOTLabels' => [
                 ['id' => $differentLabel->id],
                 ['id' => $anotherDifferentLabel->id],
+            ]
+        ]);
+
+        // Now with an Annotation Guideline
+
+        // No valid label with selected shape
+        $annotationGuideline = AnnotationGuideline::create([
+            'project_id' => $this->project()->id,
+            'enforced' => true,
+            'only_shapes' => [Shape::lineId()],
+        ]);
+
+        $response = $this->json('POST', "/api/v1/images/{$this->image->id}/annotations", [
+            'shape_id' => Shape::pointId(),
+            'feature_vector' => range(1, 384),
+            'confidence' => 0.5,
+            'points' => [10, 11],
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ]);
+        $response->assertStatus(404);
+
+        // no shape selected, should be successful
+        $annotationGuideline->update(['only_shapes' => null]);
+
+        $response = $this->json('POST', "/api/v1/images/{$this->image->id}/annotations", [
+            'shape_id' => Shape::pointId(),
+            'feature_vector' => range(1, 384),
+            'confidence' => 0.5,
+            'points' => [10, 11],
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ]);
+        $response->assertSuccessful();
+
+        // only two labels in the guideline
+        $annotationGuideline->update(
+            ['only_shapes' => [Shape::lineId(), Shape::pointId()]]
+        );
+
+        AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $label->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'c796ccec-c748-308f-8009-9f1f68e2aa64',
+            ]
+        );
+        AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $differentLabel->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'c796ccec-c748-308f-8009-9f1f68e2aa62',
+            ]
+        );
+
+        $response = $this->json('POST', "/api/v1/images/{$this->image->id}/annotations", [
+            'shape_id' => Shape::pointId(),
+            'feature_vector' => range(1, 384),
+            'confidence' => 0.5,
+            'points' => [10, 11],
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ]);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'labelBOTLabels' => [
+                ['id' => $differentLabel->id],
+            ],
+            'labels' => [
+                ['label_id' => $label->id]
+            ]
+        ]);
+
+        //Add another label, but with different shapes
+        AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $anotherDifferentLabel->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => Shape::lineId(),
+                'uuid' => 'c123ccec-c748-308f-8009-9f1f68e2aa62',
+            ]
+        );
+
+        $response = $this->json('POST', "/api/v1/images/{$this->image->id}/annotations", [
+            'shape_id' => Shape::pointId(),
+            'feature_vector' => range(1, 384),
+            'confidence' => 0.5,
+            'points' => [10, 11],
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ]);
+        $response->assertSuccessful();
+        $response->assertJson([
+            'labelBOTLabels' => [
+                ['id' => $differentLabel->id],
+            ],
+            'labels' => [
+                ['label_id' => $label->id]
             ]
         ]);
     }
@@ -596,6 +813,132 @@ class ImageAnnotationControllerTest extends ApiTestCase
 
         $this->annotation->refresh();
         $this->assertSame(Shape::circleId(), $this->annotation->shape_id);
+    }
+
+    private function resetAnnotation()
+    {
+        $id = $this->annotation->id;
+        $this->annotation->points = [100, 200];
+        $this->annotation->shape_id = Shape::pointId();
+        $this->annotation->save();
+        return $id;
+    }
+
+    public function updateChangeShapeWithAnnotationGuideline($url)
+    {
+
+        $id = $this->resetAnnotation();
+
+        $label2 = LabelTest::create();
+        $this->project()->labelTrees()->attach($this->label->label_tree_id);
+        $this->project()->labelTrees()->attach($label2->label_tree_id);
+
+        $annotationGuideline = AnnotationGuideline::create([
+            'project_id' => $this->project()->id,
+        ]);
+
+        $this->beAdmin();
+        $requestData = [
+            'shape_id' => Shape::circleId(),
+            'points' => [100, 200, 300],
+        ];
+        $requestDataWithGuideline = [
+            'shape_id' => Shape::circleId(),
+            'points' => [100, 200, 300],
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ];
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(200);
+
+        $this->resetAnnotation();
+
+        // Add enforcement, but no elements
+        $annotationGuideline->update(['enforced' => true]);
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(200);
+
+        $this->resetAnnotation();
+
+        // Allow only points
+        $annotationGuideline->update(['only_shapes' => [Shape::pointId()]]);
+
+        $this->putJson("{$url}/{$id}", $requestData)
+            ->assertStatus(200);
+
+        $this->resetAnnotation();
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(422);
+
+        // Now also circles are allowed
+        $annotationGuideline->update(['only_shapes' => [Shape::pointId(), Shape::circleId()]]);
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(200);
+
+        $this->resetAnnotation();
+
+        // Add a different label to the annotation guideline
+        $annotationGuidelineLabel2 = AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $label2->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'e43f4497-489a-4401-b49c-2fab48199bf7',
+            ]
+        );
+
+        $this->putJson("{$url}/{$id}", $requestData)
+            ->assertStatus(200);
+
+        $this->resetAnnotation();
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(422);
+
+        // Add the label to the guideline
+        $annotationGuidelineLabel = AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $this->label->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'a998dab7-ae83-49b9-b432-6f63cd55d4af',
+            ]
+        );
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(200);
+
+        $this->resetAnnotation();
+
+        // Add shape to the label in the guideline
+        $annotationGuidelineLabel->update(['shape_id' => Shape::pointId()]);
+
+        $this->putJson("{$url}/{$id}", $requestData)
+            ->assertStatus(200);
+
+        $this->resetAnnotation();
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(422);
+
+        // Fix the shape
+        $annotationGuidelineLabel->update(['shape_id' => Shape::circleId()]);
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(200);
+    }
+
+    public function testUpdateChangeShapeWithGuideline()
+    {
+        $this->updateChangeShapeWithAnnotationGuideline('api/v1/image-annotations');
+    }
+
+    public function testUpdateChangeShapeWithGuidelineLegacy()
+    {
+        $this->updateChangeShapeWithAnnotationGuideline('api/v1/annotations');
     }
 
     public function testDestroy()

--- a/tests/php/Http/Controllers/Api/ImageAnnotationLabelControllerTest.php
+++ b/tests/php/Http/Controllers/Api/ImageAnnotationLabelControllerTest.php
@@ -3,10 +3,14 @@
 namespace Biigle\Tests\Http\Controllers\Api;
 
 use ApiTestCase;
+use Biigle\AnnotationGuideline;
+use Biigle\AnnotationGuidelineLabel;
 use Biigle\Events\AnnotationLabelAttached;
+use Biigle\Shape;
 use Biigle\Tests\AnnotationSessionTest;
 use Biigle\Tests\ImageAnnotationLabelTest;
 use Biigle\Tests\ImageAnnotationTest;
+use Biigle\Tests\LabelTest;
 use Cache;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Event;
@@ -258,6 +262,7 @@ class ImageAnnotationLabelControllerTest extends ApiTestCase
         $this->assertSame(0.1, $annotationLabel->fresh()->confidence);
     }
 
+    //TODO: add test for label change
     public function testDestroy()
     {
         $this->destroy('api/v1/image-annotation-labels');
@@ -354,5 +359,129 @@ class ImageAnnotationLabelControllerTest extends ApiTestCase
         $response = $this->delete("{$url}/{$id2}");
         $response->assertStatus(200);
         $this->assertNull($this->annotation->fresh());
+    }
+
+    private function cleanupAnnotationLabels()
+    {
+        $this->annotation->labels()->delete();
+    }
+
+    public function storeWithGuideline($url)
+    {
+        Event::fake();
+        $id = $this->annotation->id;
+        $this->annotation->shape_id = Shape::pointId();
+        $this->annotation->save();
+        $annotationGuideline = AnnotationGuideline::create([
+            'project_id' => $this->project()->id,
+        ]);
+
+        $requestData = [
+            'label_id' => $this->labelRoot()->id,
+            'confidence' => 0.1,
+        ];
+
+        $requestDataWithGuideline = [
+            'label_id' => $this->labelRoot()->id,
+            'confidence' => 0.1,
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ];
+
+        $this->doTestApiRoute('POST', "{$url}/{$id}/labels");
+
+        $this->beEditor();
+        $response = $this->post("{$url}/{$id}/labels", $requestData);
+        $response->assertSuccessful();
+
+        $this->cleanupAnnotationLabels();
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertSuccessful();
+
+        $this->cleanupAnnotationLabels();
+
+        // Apply enforcement but no specification
+        $annotationGuideline->update(['enforced' => true]);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestData);
+        $response->assertSuccessful();
+        $this->cleanupAnnotationLabels();
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertSuccessful();
+        $this->cleanupAnnotationLabels();
+
+        // Wrong shape
+        $annotationGuideline->update(['only_shapes' => [Shape::circleId()]]);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestData);
+        $response->assertSuccessful();
+        $this->cleanupAnnotationLabels();
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertStatus(422);
+
+        // Fix shape
+        $annotationGuideline->update(['only_shapes' => [Shape::circleId(), Shape::pointId()]]);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestData);
+        $response->assertSuccessful();
+        $this->cleanupAnnotationLabels();
+
+        // Add different label to guideline
+        AnnotationGuidelineLabel::create([
+            'annotation_guideline_id' => $annotationGuideline->id,
+            'label_id' => LabelTest::create()->id,
+            'uuid' => 'a556b10d-e46b-460b-b2b0-58ce1dd0c966',
+            'shape_id' => null,
+        ]);
+
+
+        $response = $this->post("{$url}/{$id}/labels", $requestData);
+        $response->assertSuccessful();
+        $this->cleanupAnnotationLabels();
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertStatus(422);
+
+        $annotationGuidelineLabel = AnnotationGuidelineLabel::create([
+            'annotation_guideline_id' => $annotationGuideline->id,
+            'label_id' => $this->labelRoot()->id,
+            'uuid' => 'aa0d036f-2a5a-4015-bef3-0f815f1c4bb2',
+            'shape_id' => null,
+        ]);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertSuccessful();
+        $this->cleanupAnnotationLabels();
+
+        // Set a different shape
+        $annotationGuidelineLabel->update([
+            'shape_id' => Shape::circleId(),
+        ]);
+        $response = $this->post("{$url}/{$id}/labels", $requestData);
+        $response->assertSuccessful();
+        $this->cleanupAnnotationLabels();
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertStatus(422);
+
+        $annotationGuidelineLabel->update([
+            'shape_id' => Shape::pointId(),
+        ]);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertSuccessful();
+        $this->cleanupAnnotationLabels();
+    }
+
+    public function testStoreWithGuideline()
+    {
+        $this->storeWithGuideline('api/v1/image-annotations');
+    }
+
+    public function testStoreWithGuidelineLegacy()
+    {
+        $this->storeWithGuideline('api/v1/annotations');
     }
 }

--- a/tests/php/Http/Controllers/Api/VideoAnnotationControllerTest.php
+++ b/tests/php/Http/Controllers/Api/VideoAnnotationControllerTest.php
@@ -13,7 +13,6 @@ use Biigle\Tests\LabelTest;
 use Biigle\Tests\VideoAnnotationLabelTest;
 use Biigle\Tests\VideoAnnotationTest;
 use Biigle\Tests\VideoTest;
-use Biigle\VideoAnnotation;
 use Biigle\VideoAnnotationLabelFeatureVector;
 use Cache;
 use Carbon\Carbon;
@@ -1192,124 +1191,6 @@ class VideoAnnotationControllerTest extends ApiTestCase
 
         $annotation = $annotation->fresh();
         $this->assertSame([1, 2, null, 3, 4], $annotation->frames);
-    }
-
-    private function resetAnnotation(VideoAnnotation $annotation)
-    {
-        $id = $annotation->id;
-        $annotation->points = [100, 200];
-        $annotation->shape_id = Shape::pointId();
-        $annotation->save();
-        return $id;
-    }
-
-    public function testUpdateWithAnnotationGuideline()
-    {
-        $annotation = VideoAnnotationTest::create([
-            'shape_id' => Shape::pointId(),
-            'video_id' => $this->video->id,
-            'frames' => [1.0],
-            'points' => [[10, 11]],
-        ]);
-        $url ="api/v1/video-annotations/{$annotation->id}";
-        $id = $this->resetAnnotation($annotation);
-        $label2 = LabelTest::create();
-
-        $annotationGuideline = AnnotationGuideline::create([
-            'project_id' => $this->project()->id,
-        ]);
-
-        $this->beAdmin();
-        $requestData = [
-            'shape_id' => Shape::circleId(),
-            'points' => [100, 200, 300],
-        ];
-        $requestDataWithGuideline = [
-            'shape_id' => Shape::circleId(),
-            'points' => [100, 200, 300],
-            'annotation_guideline_id' => $annotationGuideline->id,
-        ];
-
-        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
-            ->assertStatus(200);
-
-        $this->resetAnnotation($annotation);
-
-        // Add enforcement, but no elements
-        $annotationGuideline->update(['enforced' => true]);
-
-        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
-            ->assertStatus(200);
-
-        $this->resetAnnotation($annotation);
-
-        // Allow only points
-        $annotationGuideline->update(['only_shapes' => [Shape::pointId()]]);
-
-        $this->putJson("{$url}/{$id}", $requestData)
-            ->assertStatus(200);
-
-        $this->resetAnnotation($annotation);
-
-        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
-            ->assertStatus(422);
-
-        // Now also circles are allowed
-        $annotationGuideline->update(['only_shapes' => [Shape::pointId(), Shape::circleId()]]);
-
-        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
-            ->assertStatus(200);
-
-        $this->resetAnnotation($annotation);
-
-        // Add a different label to the annotation guideline
-        $annotationGuidelineLabel2 = AnnotationGuidelineLabel::create(
-            [
-                'label_id' => $label2->id,
-                'annotation_guideline_id' => $annotationGuideline->id,
-                'shape_id' => null,
-                'uuid' => 'c796some-c746-308f-8009-9f1f68e2aa62',
-            ]
-        );
-
-        $this->putJson("{$url}/{$id}", $requestData)
-            ->assertStatus(200);
-
-        $this->resetAnnotation($annotation);
-
-        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
-            ->assertStatus(422);
-
-        // Add the label to the guideline
-        $annotationGuidelineLabel = AnnotationGuidelineLabel::create(
-            [
-                'label_id' => $this->label->id,
-                'annotation_guideline_id' => $annotationGuideline->id,
-                'shape_id' => null,
-                'uuid' => 'c796some-c746-308f-8009-9f1f68e2aa62',
-            ]
-        );
-
-        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
-            ->assertStatus(200);
-
-        $this->resetAnnotation($annotation);
-
-        // Add shape to the label in the guideline
-        $annotationGuidelineLabel->update(['shape_id' => Shape::pointId()]);
-
-        $this->putJson("{$url}/{$id}", $requestData)
-            ->assertStatus(200);
-
-        $this->resetAnnotation($annotation);
-
-        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
-            ->assertStatus(422);
-
-        // Fix the shape
-
-        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
-            ->assertStatus(200);
     }
 
     public function testDestroy()

--- a/tests/php/Http/Controllers/Api/VideoAnnotationControllerTest.php
+++ b/tests/php/Http/Controllers/Api/VideoAnnotationControllerTest.php
@@ -3,6 +3,8 @@
 namespace Biigle\Tests\Http\Controllers\Api;
 
 use ApiTestCase;
+use Biigle\AnnotationGuideline;
+use Biigle\AnnotationGuidelineLabel;
 use Biigle\Jobs\TrackObject;
 use Biigle\MediaType;
 use Biigle\Shape;
@@ -11,6 +13,7 @@ use Biigle\Tests\LabelTest;
 use Biigle\Tests\VideoAnnotationLabelTest;
 use Biigle\Tests\VideoAnnotationTest;
 use Biigle\Tests\VideoTest;
+use Biigle\VideoAnnotation;
 use Biigle\VideoAnnotationLabelFeatureVector;
 use Cache;
 use Carbon\Carbon;
@@ -680,7 +683,7 @@ class VideoAnnotationControllerTest extends ApiTestCase
                 'frames' => [0.0],
                 'track' => true,
             ])->assertSuccessful();
-        
+
         $this->assertSame(10, Cache::get(TrackObject::getRateLimitCacheKey($this->editor()->id)));
         $this->assertTrue($res->json()['trackingJobLimitReached']);
     }
@@ -864,6 +867,106 @@ class VideoAnnotationControllerTest extends ApiTestCase
                 ['id' => $anotherDifferentLabel->id],
             ]
         ]);
+        // Now with an Annotation Guideline
+
+        // No valid label with selected shape
+        $annotationGuideline = AnnotationGuideline::create([
+            'project_id' => $this->project()->id,
+            'enforced' => true,
+            'only_shapes' => [Shape::lineId()],
+        ]);
+
+        $response = $this->json('POST', "/api/v1/videos/{$this->video->id}/annotations", [
+            'shape_id' => Shape::pointId(),
+            'feature_vector' => range(1, 384),
+            'confidence' => 0.5,
+            'points' => [[10, 11]],
+            'frames' => [0.0],
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ]);
+        $response->assertStatus(404);
+
+        // no shape selected, should be successful
+        $annotationGuideline->update(['only_shapes' => null]);
+
+        $response = $this->json('POST', "/api/v1/videos/{$this->video->id}/annotations", [
+            'shape_id' => Shape::pointId(),
+            'feature_vector' => range(1, 384),
+            'confidence' => 0.5,
+            'points' => [[10, 11]],
+            'frames' => [0.0],
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ]);
+        $response->assertSuccessful();
+
+        // only two labels in the guideline
+        $annotationGuideline->update(
+            ['only_shapes' => [Shape::lineId(), Shape::pointId()]]
+        );
+
+        AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $label->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'c796ccec-c748-308f-8009-9f1f68e2aa64',
+            ]
+        );
+        AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $differentLabel->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'c796ccec-c748-308f-8009-9f1f68e2aa62',
+            ]
+        );
+
+        $response = $this->json('POST', "/api/v1/videos/{$this->video->id}/annotations", [
+            'shape_id' => Shape::pointId(),
+            'feature_vector' => range(1, 384),
+            'confidence' => 0.5,
+            'points' => [[10, 11]],
+            'frames' => [0.0],
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ]);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'labelBOTLabels' => [
+                ['id' => $differentLabel->id],
+            ],
+            'labels' => [
+                ['label_id' => $label->id]
+            ]
+        ]);
+
+        //Add another label, but with different shapes
+        AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $anotherDifferentLabel->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => Shape::lineId(),
+                'uuid' => 'c123ccec-c748-308f-8009-9f1f68e2aa62',
+            ]
+        );
+
+        $response = $this->json('POST', "/api/v1/videos/{$this->video->id}/annotations", [
+            'shape_id' => Shape::pointId(),
+            'feature_vector' => range(1, 384),
+            'confidence' => 0.5,
+            'points' => [[10, 11]],
+            'frames' => [0.0],
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ]);
+        $response->assertSuccessful();
+        $response->assertJson([
+            'labelBOTLabels' => [
+                ['id' => $differentLabel->id],
+            ],
+            'labels' => [
+                ['label_id' => $label->id]
+            ]
+        ]);
     }
 
     public function testStoreWithFeatureVectorIgnoreLabelTrees()
@@ -910,6 +1013,97 @@ class VideoAnnotationControllerTest extends ApiTestCase
         $response->assertSuccessful();
         $response->assertJsonPath('labelBOTLabels.0.id', $label2->id);
         $response->assertJsonMissingPath('labelBOTLabels.1');
+    }
+
+    public function testStoreWithAnnotationGuideline()
+    {
+        $label = LabelTest::create();
+        $label2 = LabelTest::create();
+        $this->project()->labelTrees()->attach($label->label_tree_id);
+        $this->project()->labelTrees()->attach($label2->label_tree_id);
+
+        $lineId = Shape::lineId();
+        $pointId = Shape::pointId();
+
+        $annotationGuideline = AnnotationGuideline::create([
+            'project_id' => $this->project()->id,
+        ]);
+        $url = "/api/v1/videos/{$this->video->id}/annotations";
+        $requestData = [
+            'shape_id' => Shape::pointId(),
+            'label_id' => $label->id,
+            'confidence' => 0.5,
+            'points' => [[10, 11]],
+            'frames' => [0.0],
+        ];
+
+        $this->doTestApiRoute('POST', "/api/v1/videos/{$this->video->id}/annotations");
+
+        $this->beEditor();
+
+        #No enforcement
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        #Enforcement - No shapes
+        $annotationGuideline->update(['enforced' => true]);
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        #Enforcement - one shape - wrong shape but no guideline specified
+        $annotationGuideline->update(["only_shapes" => [$lineId]]);
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        $requestData['annotation_guideline_id'] = $annotationGuideline->id;
+
+        #Enforcement - one shape - wrong shape
+        $annotationGuideline->update(["only_shapes" => [$lineId]]);
+        $response = $this->post($url, $requestData);
+        $response->assertStatus(422);
+
+        #Enforcement - one shape - correct shape
+        $annotationGuideline->update(["only_shapes" => [$pointId]]);
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        #Enforcement - with wrong label - no shape specified
+        $annotationGuideline->update(["only_shapes" => [$lineId, $pointId]]);
+        $annotationGuidelineLabel2 = AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $label2->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'c796ccec-c746-308f-8009-9f1f68e2aa62',
+            ]
+        );
+
+        $response = $this->post($url, $requestData);
+        $response->assertStatus(422);
+
+        #Enforcement - with correct label - no shape specified
+        $annotationGuidelineLabel = AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $label->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'c796ccec-c748-308f-8009-9f1f68e2aa62',
+            ]
+        );
+
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
+        #Enforcement - with correct label - wrong shape
+        $annotationGuidelineLabel->update(['shape_id' => $lineId]);
+        $response = $this->post($url, $requestData);
+        $response->assertStatus(422);
+
+        #Enforcement - with correct label - correct shape
+        $annotationGuidelineLabel->update(["shape_id" => $pointId]);
+        $response = $this->post($url, $requestData);
+        $response->assertSuccessful();
+
     }
 
     public function testUpdate()
@@ -998,6 +1192,124 @@ class VideoAnnotationControllerTest extends ApiTestCase
 
         $annotation = $annotation->fresh();
         $this->assertSame([1, 2, null, 3, 4], $annotation->frames);
+    }
+
+    private function resetAnnotation(VideoAnnotation $annotation)
+    {
+        $id = $annotation->id;
+        $annotation->points = [100, 200];
+        $annotation->shape_id = Shape::pointId();
+        $annotation->save();
+        return $id;
+    }
+
+    public function testUpdateWithAnnotationGuideline()
+    {
+        $annotation = VideoAnnotationTest::create([
+            'shape_id' => Shape::pointId(),
+            'video_id' => $this->video->id,
+            'frames' => [1.0],
+            'points' => [[10, 11]],
+        ]);
+        $url ="api/v1/video-annotations/{$annotation->id}";
+        $id = $this->resetAnnotation($annotation);
+        $label2 = LabelTest::create();
+
+        $annotationGuideline = AnnotationGuideline::create([
+            'project_id' => $this->project()->id,
+        ]);
+
+        $this->beAdmin();
+        $requestData = [
+            'shape_id' => Shape::circleId(),
+            'points' => [100, 200, 300],
+        ];
+        $requestDataWithGuideline = [
+            'shape_id' => Shape::circleId(),
+            'points' => [100, 200, 300],
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ];
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(200);
+
+        $this->resetAnnotation($annotation);
+
+        // Add enforcement, but no elements
+        $annotationGuideline->update(['enforced' => true]);
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(200);
+
+        $this->resetAnnotation($annotation);
+
+        // Allow only points
+        $annotationGuideline->update(['only_shapes' => [Shape::pointId()]]);
+
+        $this->putJson("{$url}/{$id}", $requestData)
+            ->assertStatus(200);
+
+        $this->resetAnnotation($annotation);
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(422);
+
+        // Now also circles are allowed
+        $annotationGuideline->update(['only_shapes' => [Shape::pointId(), Shape::circleId()]]);
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(200);
+
+        $this->resetAnnotation($annotation);
+
+        // Add a different label to the annotation guideline
+        $annotationGuidelineLabel2 = AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $label2->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'c796some-c746-308f-8009-9f1f68e2aa62',
+            ]
+        );
+
+        $this->putJson("{$url}/{$id}", $requestData)
+            ->assertStatus(200);
+
+        $this->resetAnnotation($annotation);
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(422);
+
+        // Add the label to the guideline
+        $annotationGuidelineLabel = AnnotationGuidelineLabel::create(
+            [
+                'label_id' => $this->label->id,
+                'annotation_guideline_id' => $annotationGuideline->id,
+                'shape_id' => null,
+                'uuid' => 'c796some-c746-308f-8009-9f1f68e2aa62',
+            ]
+        );
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(200);
+
+        $this->resetAnnotation($annotation);
+
+        // Add shape to the label in the guideline
+        $annotationGuidelineLabel->update(['shape_id' => Shape::pointId()]);
+
+        $this->putJson("{$url}/{$id}", $requestData)
+            ->assertStatus(200);
+
+        $this->resetAnnotation($annotation);
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(422);
+
+        // Fix the shape
+
+        $this->putJson("{$url}/{$id}", $requestDataWithGuideline)
+            ->assertStatus(200);
     }
 
     public function testDestroy()

--- a/tests/php/Http/Controllers/Api/VideoAnnotationLabelControllerTest.php
+++ b/tests/php/Http/Controllers/Api/VideoAnnotationLabelControllerTest.php
@@ -3,8 +3,11 @@
 namespace Biigle\Tests\Http\Controllers\Api;
 
 use ApiTestCase;
+use Biigle\AnnotationGuideline;
+use Biigle\AnnotationGuidelineLabel;
 use Biigle\Events\AnnotationLabelAttached;
 use Biigle\MediaType;
+use Biigle\Shape;
 use Biigle\Tests\LabelTest;
 use Biigle\Tests\VideoAnnotationLabelTest;
 use Biigle\Tests\VideoAnnotationTest;
@@ -72,6 +75,133 @@ class VideoAnnotationLabelControllerTest extends ApiTestCase
             ])
             // Label is already attached.
             ->assertStatus(422);
+    }
+
+    private function cleanupAnnotationLabels($annotation)
+    {
+        $annotation->labels()->delete();
+    }
+
+    public function testStoreWithGuideline()
+    {
+
+        Event::fake();
+        $annotation = VideoAnnotationTest::create(['video_id' => $this->video->id]);
+        $id = $annotation->id;
+        $annotation->shape_id = Shape::pointId();
+        $annotation->save();
+
+        $url = "api/v1/video-annotations";
+
+        $annotationGuideline = AnnotationGuideline::create([
+            'project_id' => $this->project()->id,
+        ]);
+
+        $requestData = [
+            'label_id' => $this->labelRoot()->id,
+            'confidence' => 0.1,
+        ];
+
+        $requestDataWithGuideline = [
+            'label_id' => $this->labelRoot()->id,
+            'confidence' => 0.1,
+            'annotation_guideline_id' => $annotationGuideline->id,
+        ];
+
+        $this->doTestApiRoute('POST', "{$url}/{$id}/labels");
+
+        $this->beEditor();
+        $response = $this->post("{$url}/{$id}/labels", $requestData);
+        $response->assertSuccessful();
+
+        $this->cleanupAnnotationLabels($annotation);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertSuccessful();
+
+        $this->cleanupAnnotationLabels($annotation);
+
+        // Apply enforcement but no specification
+        $annotationGuideline->update(['enforced' => true]);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestData);
+        $response->assertSuccessful();
+
+        $this->cleanupAnnotationLabels($annotation);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertSuccessful();
+
+        $this->cleanupAnnotationLabels($annotation);
+
+        // Wrong shape
+        $annotationGuideline->update(['only_shapes' => [Shape::circleId()]]);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestData);
+        $response->assertSuccessful();
+
+        $this->cleanupAnnotationLabels($annotation);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertStatus(422);
+
+        // Fix shape
+        $annotationGuideline->update(['only_shapes' => [Shape::circleId(), Shape::pointId()]]);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestData);
+        $response->assertSuccessful();
+
+        $this->cleanupAnnotationLabels($annotation);
+
+        // Add different label to guideline
+        AnnotationGuidelineLabel::create([
+            'annotation_guideline_id' => $annotationGuideline->id,
+            'label_id' => LabelTest::create()->id,
+            'uuid' => 'a556b10d-e46b-460b-b2b0-58ce1dd0c966',
+            'shape_id' => null,
+        ]);
+
+
+        $response = $this->post("{$url}/{$id}/labels", $requestData);
+        $response->assertSuccessful();
+
+        $this->cleanupAnnotationLabels($annotation);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertStatus(422);
+
+        $annotationGuidelineLabel = AnnotationGuidelineLabel::create([
+            'annotation_guideline_id' => $annotationGuideline->id,
+            'label_id' => $this->labelRoot()->id,
+            'uuid' => 'aa0d036f-2a5a-4015-bef3-0f815f1c4bb2',
+            'shape_id' => null,
+        ]);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertSuccessful();
+
+        $this->cleanupAnnotationLabels($annotation);
+
+
+        // Set a different shape
+        $annotationGuidelineLabel->update([
+            'shape_id' => Shape::circleId(),
+        ]);
+        $response = $this->post("{$url}/{$id}/labels", $requestData);
+        $response->assertSuccessful();
+
+        $this->cleanupAnnotationLabels($annotation);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertStatus(422);
+
+        $annotationGuidelineLabel->update([
+            'shape_id' => Shape::pointId(),
+        ]);
+
+        $response = $this->post("{$url}/{$id}/labels", $requestDataWithGuideline);
+        $response->assertSuccessful();
+        $this->cleanupAnnotationLabels($annotation);
     }
 
     public function testDestroy()


### PR DESCRIPTION
This PR adds, as specified in PR #1390, a validate method for `AnnotationGuideline` as well as the backend for `AnnotationsControllers` and `AnnotationLabelControllers`. Adds tests for each of them, multiple edge cases.