### PR TITLE
Increase max volume URL length to 512

### DIFF
--- a/app/Http/Requests/StoreVolume.php
+++ b/app/Http/Requests/StoreVolume.php
@@ -72,7 +72,7 @@ class StoreVolume extends FormRequest
         return [
             'name' => 'required|max:512',
             'media_type' => ['filled', Rule::in(array_keys(MediaType::INSTANCES))],
-            'url' => ['bail', 'required', 'string', 'max:256', new VolumeUrl],
+            'url' => ['bail', 'required', 'string', 'max:512', new VolumeUrl],
             'files' => [
                 'required',
                 'array',

--- a/app/Http/Requests/UpdatePendingVolume.php
+++ b/app/Http/Requests/UpdatePendingVolume.php
@@ -29,7 +29,7 @@ class UpdatePendingVolume extends FormRequest
     {
         return [
             'name' => 'required|max:512',
-            'url' => ['required', 'string', 'max:256', new VolumeUrl],
+            'url' => ['bail', 'required', 'string', 'max:512', new VolumeUrl],
             'files' => ['required', 'array', 'min:1'],
             'handle' => ['nullable', 'max:256', new Handle],
             'import_annotations' => 'bool',

--- a/app/Http/Requests/UpdateVolume.php
+++ b/app/Http/Requests/UpdateVolume.php
@@ -38,7 +38,7 @@ class UpdateVolume extends FormRequest
     {
         return [
             'name' => 'filled|max:512',
-            'url' => ['bail', 'filled', 'string', 'max:256', new VolumeUrl],
+            'url' => ['bail', 'filled', 'string', 'max:512', new VolumeUrl],
             'handle' => ['bail', 'nullable', 'string', 'max:256', new Handle],
         ];
     }

--- a/database/migrations/2026_08_06_082522_increase_volume_url_size.php
+++ b/database/migrations/2026_08_06_082522_increase_volume_url_size.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2026_08_06_082522_increase_volume_url_size.php
+++ b/database/migrations/2026_08_06_082522_increase_volume_url_size.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('volumes', function (Blueprint $table) {
+            $table->string('url', 512)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('volumes', function (Blueprint $table) {
+            $table->string('url', 256)->change();
+        });
+    }
+};

--- a/tests/php/Http/Controllers/Api/PendingVolumeControllerTest.php
+++ b/tests/php/Http/Controllers/Api/PendingVolumeControllerTest.php
@@ -463,6 +463,15 @@ class PendingVolumeControllerTest extends ApiTestCase
             'files' => ['1.jpg', '2.jpg'],
         ])->assertStatus(422);
 
+        // invalid url (>512 characters)
+        $response = $this->putJson("/api/v1/pending-volumes/{$id}", [
+            'name' => 'my volume no. 1',
+            'url' => 'test://'.str_repeat('a', 513),
+            'files' => ['1.jpg', '2.jpg'],
+        ])->assertStatus(422);
+
+        $this->assertSame('The url must not be greater than 512 characters.', $response->exception->getMessage());
+
         // images directory dows not exist in storage disk
         $this->putJson("/api/v1/pending-volumes/{$id}", [
             'name' => 'my volume no. 1',

--- a/tests/php/Http/Controllers/Api/ProjectVolumeControllerTest.php
+++ b/tests/php/Http/Controllers/Api/ProjectVolumeControllerTest.php
@@ -166,6 +166,40 @@ class ProjectVolumeControllerTest extends ApiTestCase
                 in_array('2.jpg', $job->filenames));
     }
 
+    public function testStoreUrlMaxLength()
+    {
+        $id = $this->project()->id;
+        $this->beAdmin();
+
+        // invalid url (>512 characters)
+        $response = $this->json('POST', "/api/v1/projects/{$id}/volumes", [
+            'name' => 'my volume no. 1',
+            'url' => 'test://'.str_repeat('a', 506),
+            'media_type' => 'image',
+            'files' => '1.jpg',
+        ])->assertStatus(422);
+
+        $this->assertSame('The url must not be greater than 512 characters.', $response->exception->getMessage());
+
+        // Split the path in two parts because a single path segment is limited to 255
+        // characters by the filesystem.
+        $path = str_repeat('a', 252).'/'.str_repeat('b', 252);
+        Storage::disk('test')->put($path.'/1.jpg', 'abc');
+
+        // valid url (exactly 512 characters)
+        $url = 'test://'.$path;
+        $this->assertSame(512, strlen($url));
+
+        $this->json('POST', "/api/v1/projects/{$id}/volumes", [
+            'name' => 'my volume no. 1',
+            'url' => $url,
+            'media_type' => 'image',
+            'files' => '1.jpg',
+        ])->assertStatus(201);
+
+        $this->assertSame($url, Volume::orderBy('id', 'desc')->first()->url);
+    }
+
     public function testStoreHandle()
     {
         Storage::disk('test')->makeDirectory('images');

--- a/tests/php/Http/Controllers/Api/VolumeControllerTest.php
+++ b/tests/php/Http/Controllers/Api/VolumeControllerTest.php
@@ -240,18 +240,39 @@ class VolumeControllerTest extends ApiTestCase
         $volume = $this->volume();
 
         config(['volumes.admin_storage_disks' => ['admin-test']]);
-        $disk = Storage::fake('admin-test');
-        $disk->put('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/file.txt', 'abc');
 
         $this->beGlobalAdmin();
-        
-        // invalid url (>256 characters)
+
+        // invalid url (>512 characters)
         $response = $this->json('PUT', '/api/v1/volumes/'.$volume->id, [
-            'url' => 'admin-test://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'url' => 'admin-test://'.str_repeat('a', 513),
         ])->assertStatus(422);
-        
-        $this->assertSame('The url must not be greater than 256 characters.', $response->exception->getMessage());
+
+        $this->assertSame('The url must not be greater than 512 characters.', $response->exception->getMessage());
         Queue::assertNothingPushed();
+    }
+
+    public function testUpdateUrlMaxLength()
+    {
+        $volume = $this->volume();
+
+        config(['volumes.admin_storage_disks' => ['admin-test']]);
+        $disk = Storage::fake('admin-test');
+        // Split the path in two parts because a single path segment is limited to 255
+        // characters by the filesystem.
+        $path = str_repeat('a', 249).'/'.str_repeat('b', 249);
+        $disk->put($path.'/file.txt', 'abc');
+
+        $this->beGlobalAdmin();
+
+        // valid url (exactly 512 characters)
+        $url = 'admin-test://'.$path;
+        $this->assertSame(512, strlen($url));
+
+        $this->json('PUT', '/api/v1/volumes/'.$volume->id, ['url' => $url])
+            ->assertStatus(200);
+
+        $this->assertSame($url, $volume->fresh()->url);
     }
 
     public function testUpdateUrlProviderDenylist()


### PR DESCRIPTION
Some users had issues with arcane storage locations that had very long paths.