### PR TITLE
Fixed LabelBOT with video polygon brush

### DIFF
--- a/resources/assets/js/videos/components/videoScreen/polygonBrushInteractions.vue
+++ b/resources/assets/js/videos/components/videoScreen/polygonBrushInteractions.vue
@@ -44,7 +44,7 @@ export default {
             if (this.isUsingPolygonBrush) {
                 this.resetInteractionMode();
                 this.currentInteraction = null;
-            } else if (!this.hasSelectedLabel) {
+            } else if (!this.hasSelectedLabel && !this.labelbotIsActive) {
                 this.requireSelectedLabel();
             } else if (this.canAdd) {
                 this.interactionMode = 'polygonBrush';
@@ -70,7 +70,7 @@ export default {
             if (!isUsingPolygonBrush) {
                 this.polygonBrushRadius = this.polygonBrushInteraction.getBrushRadius();
                 this.map.removeInteraction(this.polygonBrushInteraction);
-            } else if (this.hasSelectedLabel) {
+            } else if (this.hasSelectedLabel || this.labelbotIsActive) {
                 this.polygonBrushInteraction = new PolygonBrushInteraction({
                     source: this.pendingAnnotationSource,
                     style: Styles.editing,


### PR DESCRIPTION
fixes #1410.

## Changes

- Allow the video polygon brush to be activated without a selected label when LabelBOT is active.
- Create the polygon brush interaction when either a label is selected or LabelBOT is active.
- Preserve the existing selected-label requirement when LabelBOT is disabled.