### PR TITLE
Use new attribute for deleteWhenMissingModels

### DIFF
--- a/app/Events/ObjectTrackingFailed.php
+++ b/app/Events/ObjectTrackingFailed.php
@@ -8,8 +8,10 @@ use Biigle\VideoAnnotation;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\SerializesModels;
 
+#[DeleteWhenMissingModels]
 class ObjectTrackingFailed implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
@@ -27,13 +29,6 @@ class ObjectTrackingFailed implements ShouldBroadcastNow
      * @var VideoAnnotation
      */
     public $annotation;
-
-    /**
-     * Ignore this event if the annotation does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * Create a new event instance.

--- a/app/Events/ObjectTrackingSucceeded.php
+++ b/app/Events/ObjectTrackingSucceeded.php
@@ -8,8 +8,10 @@ use Biigle\VideoAnnotation;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\SerializesModels;
 
+#[DeleteWhenMissingModels]
 class ObjectTrackingSucceeded implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
@@ -27,13 +29,6 @@ class ObjectTrackingSucceeded implements ShouldBroadcastNow
      * @var VideoAnnotation
      */
     public $annotation;
-
-    /**
-     * Ignore this event if the annotation does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * Create a new event instance.

--- a/app/Events/VolumeFilesProcessed.php
+++ b/app/Events/VolumeFilesProcessed.php
@@ -7,8 +7,10 @@ use Biigle\Volume;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\SerializesModels;
 
+#[DeleteWhenMissingModels]
 class VolumeFilesProcessed implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
@@ -19,13 +21,6 @@ class VolumeFilesProcessed implements ShouldBroadcastNow
      * @var Volume
      */
     public $volume;
-
-    /**
-     * Ignore this event if the volume does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * Create a new event instance.

--- a/app/Jobs/CloneImageThumbnails.php
+++ b/app/Jobs/CloneImageThumbnails.php
@@ -4,10 +4,12 @@ namespace Biigle\Jobs;
 
 use Biigle\Image;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Storage;
 
+#[DeleteWhenMissingModels]
 class CloneImageThumbnails extends Job implements ShouldQueue
 {
     use InteractsWithQueue, SerializesModels;
@@ -30,13 +32,6 @@ class CloneImageThumbnails extends Job implements ShouldQueue
      * @var Image
      */
     public $image;
-
-    /**
-     * Ignore this job if the image does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     public function __construct(Image $img, String $prefix)
     {

--- a/app/Jobs/CloneImagesOrVideos.php
+++ b/app/Jobs/CloneImagesOrVideos.php
@@ -17,12 +17,14 @@ use Biigle\VideoLabel;
 use Biigle\Volume;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Http\Request;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Ramsey\Uuid\Uuid;
 
+#[DeleteWhenMissingModels]
 class CloneImagesOrVideos extends Job implements ShouldQueue
 {
     use InteractsWithQueue, SerializesModels;
@@ -84,13 +86,6 @@ class CloneImagesOrVideos extends Job implements ShouldQueue
      * @var array
      */
     protected $uuidMap;
-
-    /**
-     * Ignore this job if the project or volume does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * Create a new job instance.

--- a/app/Jobs/CloneVideoThumbnails.php
+++ b/app/Jobs/CloneVideoThumbnails.php
@@ -4,10 +4,12 @@ namespace Biigle\Jobs;
 
 use Biigle\Video;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Storage;
 
+#[DeleteWhenMissingModels]
 class CloneVideoThumbnails extends Job implements ShouldQueue
 {
     use InteractsWithQueue, SerializesModels;
@@ -30,13 +32,6 @@ class CloneVideoThumbnails extends Job implements ShouldQueue
      * @var Video
      */
     public $video;
-
-    /**
-     * Ignore this job if the video does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     public function __construct(Video $video, String $prefix)
     {

--- a/app/Jobs/CopyAnnotationFeatureVector.php
+++ b/app/Jobs/CopyAnnotationFeatureVector.php
@@ -5,19 +5,14 @@ namespace Biigle\Jobs;
 use Biigle\AnnotationLabel;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\QueryException;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 
+#[DeleteWhenMissingModels]
 abstract class CopyAnnotationFeatureVector extends Job
 {
     use SerializesModels, InteractsWithQueue;
-
-    /**
-     * Ignore this job if the annotation does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * Copy the feature vector of the annotation associated with the annotation label

--- a/app/Jobs/ImportVolumeMetadata.php
+++ b/app/Jobs/ImportVolumeMetadata.php
@@ -11,10 +11,12 @@ use Biigle\VideoAnnotationLabel;
 use Biigle\VideoLabel;
 use Biigle\VolumeFile;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\DB;
 
+#[DeleteWhenMissingModels]
 class ImportVolumeMetadata extends Job implements ShouldQueue
 {
     use SerializesModels, InteractsWithQueue;
@@ -25,13 +27,6 @@ class ImportVolumeMetadata extends Job implements ShouldQueue
      * @var integer
      */
     public static $insertChunkSize = 5000;
-
-    /**
-     * Ignore this job if the pending volume does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * The number of times the job may be attempted.

--- a/app/Jobs/ProcessAnnotatedFile.php
+++ b/app/Jobs/ProcessAnnotatedFile.php
@@ -13,6 +13,7 @@ use Exception;
 use FileCache;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\File;
@@ -30,6 +31,7 @@ use SVG\Nodes\Structures\SVGGroup;
 use SVG\Nodes\SVGNodeContainer;
 use SVG\SVG;
 
+#[DeleteWhenMissingModels]
 abstract class ProcessAnnotatedFile extends GenerateFeatureVectors
 {
     use SerializesModels, InteractsWithQueue;
@@ -54,13 +56,6 @@ abstract class ProcessAnnotatedFile extends GenerateFeatureVectors
      * @var int
      */
     public $tries = 3;
-
-    /**
-     * Ignore this job if the annotation does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * Create a new job instance.

--- a/app/Jobs/ProcessCloneVolumeFiles.php
+++ b/app/Jobs/ProcessCloneVolumeFiles.php
@@ -6,9 +6,11 @@ use Biigle\Image;
 use Biigle\Video;
 use Biigle\Volume;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 
+#[DeleteWhenMissingModels]
 class ProcessCloneVolumeFiles extends Job implements ShouldQueue
 {
     use InteractsWithQueue, SerializesModels;
@@ -34,13 +36,6 @@ class ProcessCloneVolumeFiles extends Job implements ShouldQueue
      * @var array
      */
     protected $uuidMap;
-
-    /**
-     * Ignore this job if the volume does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * Create a new job instance.

--- a/app/Jobs/ProcessNewImage.php
+++ b/app/Jobs/ProcessNewImage.php
@@ -10,12 +10,14 @@ use Exception;
 use File;
 use FileCache;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Storage;
 use Jcupitt\Vips\Image as VipsImage;
 use Log;
 
+#[DeleteWhenMissingModels]
 class ProcessNewImage extends Job implements ShouldQueue
 {
     use SerializesModels, InteractsWithQueue;
@@ -26,13 +28,6 @@ class ProcessNewImage extends Job implements ShouldQueue
      * @var int
      */
     public $tries = 2;
-
-    /**
-     * Ignore this job if the image does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * The image to process

--- a/app/Jobs/ProcessNewVideo.php
+++ b/app/Jobs/ProcessNewVideo.php
@@ -10,6 +10,7 @@ use FFMpeg\FFMpeg;
 use FFMpeg\FFProbe;
 use FileCache;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\File;
@@ -20,6 +21,7 @@ use Jcupitt\Vips\Image as VipsImage;
 use Log;
 use Throwable;
 
+#[DeleteWhenMissingModels]
 class ProcessNewVideo extends Job implements ShouldQueue
 {
     use SerializesModels, InteractsWithQueue;
@@ -49,13 +51,6 @@ class ProcessNewVideo extends Job implements ShouldQueue
      * @var FFProbe|null
      */
     protected $ffprobe;
-
-    /**
-     * Ignore this job if the video does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * Create a new instance.

--- a/app/Jobs/ProcessNewVolumeFiles.php
+++ b/app/Jobs/ProcessNewVolumeFiles.php
@@ -5,9 +5,11 @@ namespace Biigle\Jobs;
 use Biigle\Video;
 use Biigle\Volume;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 
+#[DeleteWhenMissingModels]
 class ProcessNewVolumeFiles extends Job implements ShouldQueue
 {
     use InteractsWithQueue, SerializesModels;
@@ -26,13 +28,6 @@ class ProcessNewVolumeFiles extends Job implements ShouldQueue
      * @var array
      */
     protected $only;
-
-    /**
-     * Ignore this job if the volume does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * Create a new job instance.

--- a/app/Jobs/TileSingleImage.php
+++ b/app/Jobs/TileSingleImage.php
@@ -11,6 +11,7 @@ use FilesystemIterator;
 use GuzzleHttp\Promise\Each;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Filesystem\AwsS3V3Adapter;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Storage;
@@ -19,6 +20,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Symfony\Component\HttpFoundation\File\Exception\UploadException;
 
+#[DeleteWhenMissingModels]
 class TileSingleImage extends Job implements ShouldQueue
 {
     use InteractsWithQueue, SerializesModels;
@@ -36,13 +38,6 @@ class TileSingleImage extends Job implements ShouldQueue
      * @var string
      */
     public $tempPath;
-
-    /**
-     * Ignore this job if the image does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * Create a new job instance.

--- a/app/Jobs/UpdateFederatedSearchIndex.php
+++ b/app/Jobs/UpdateFederatedSearchIndex.php
@@ -14,10 +14,12 @@ use DB;
 use Exception;
 use GuzzleHttp\Client;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 
+#[DeleteWhenMissingModels]
 class UpdateFederatedSearchIndex extends Job implements ShouldQueue
 {
     use SerializesModels;
@@ -28,13 +30,6 @@ class UpdateFederatedSearchIndex extends Job implements ShouldQueue
      * @var FederatedSearchInstance
      */
     public $instance;
-
-    /**
-     * Ignore this job if the volume does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * Retry a failed job after 5 minutes.

--- a/app/Jobs/UpdateVolumeMetadata.php
+++ b/app/Jobs/UpdateVolumeMetadata.php
@@ -5,18 +5,13 @@ namespace Biigle\Jobs;
 use Biigle\Video;
 use Biigle\Volume;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\SerializesModels;
 
+#[DeleteWhenMissingModels]
 class UpdateVolumeMetadata extends Job implements ShouldQueue
 {
     use SerializesModels;
-
-    /**
-     * Ignore this job if the project or volume does not exist any more.
-     *
-     * @var bool
-     */
-    protected $deleteWhenMissingModels = true;
 
     /**
      * Create a new job instance.


### PR DESCRIPTION
The protected property no longer worked with Laravel 13. Only public would have worked but we switch to the new attribute.