### PR TITLE
Largo filter annotation date

### DIFF
--- a/app/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelController.php
@@ -7,7 +7,6 @@ use Biigle\Http\Requests\FilterProjectAnnotationsRequest;
 use Biigle\ImageAnnotation;
 use Biigle\Project;
 use Biigle\Traits\CompileFilters;
-use Illuminate\Http\Request;
 
 class FilterImageAnnotationsByLabelController extends Controller
 {
@@ -60,7 +59,7 @@ class FilterImageAnnotationsByLabelController extends Controller
             })
             ->when(!is_null($take), fn ($query) => $query->take($take))
             ->where('image_annotation_labels.label_id', $lid)
-            ->when(!empty($filters), fn ($query) => $this->compileFilterConditions($query, $union, $filters))
+            ->when(!empty($filters), fn ($query) => $this->compileFilterConditions('image', $query, $union, $filters))
             ->select('images.uuid', 'image_annotations.id')
             ->distinct()
             ->orderBy('image_annotations.id', 'desc')

--- a/app/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelController.php
@@ -3,6 +3,7 @@
 namespace Biigle\Http\Controllers\Api\Projects;
 
 use Biigle\Http\Controllers\Api\Controller;
+use Biigle\Http\Requests\FilterProjectAnnotationsRequest;
 use Biigle\ImageAnnotation;
 use Biigle\Project;
 use Biigle\Traits\CompileFilters;
@@ -25,39 +26,27 @@ class FilterImageAnnotationsByLabelController extends Controller
      * @apiParam (Optional arguments) {Array} user_id Array of user ids to use to filter values
      * @apiParam (Optional arguments) {Array} filename Array of filename patterns to use to filter annotations
      * @apiParam (Optional arguments) {Array} volume_id Array of volume ids to use to filter annotations
+     * @apiParam (Optional arguments) {Array} created_at Array containing objects mapping field names (annotation, annotation_label) to date operators (gt, gte, eq, lt, lte) and date Y-m-d values. Example: [{"annotation": {"gt": "2026-01-01"}}] means an annotation created after 2026-01-01
+     * @apiParam (Optional arguments) {Array} updated_at Array containing objects mapping field names (annotation, annotation_label) to date operators (gt, gte, eq, lt, lte) and date Y-m-d values. Example: [{"annotation": {"gt": "2026-01-01"}}] means an annotation updated after 2026-01-01
      * @apiParam (Optional arguments) {Boolean} union Whether the filters should be considered inclusive (OR) or exclusive (AND)
      * @apiPermission projectMember
      * @apiDescription Returns a map of image annotation IDs to their image UUIDs.
      *
-     * @param Request $request
-     * @param  int  $pid Project ID
+     * @param FilterProjectAnnotationsRequest $request
      * @param int $lid Label ID
      * @return \Illuminate\Support\Collection
      */
-    public function index(Request $request, $pid, $lid)
+    public function index(FilterProjectAnnotationsRequest $request, $lid)
     {
-        $project = Project::findOrFail($pid);
-        $this->authorize('access', $project);
-
-        $this->validate($request, [
-            'take' => 'integer',
-            'shape_id' => 'array',
-            'shape_id.*' => 'integer',
-            'user_id' => 'array',
-            'user_id.*' => 'integer',
-            'filename' => 'array',
-            'filename.*' => 'string',
-            'volume_id' => 'array',
-            'volume_id.*' => 'integer',
-            'union' => 'boolean',
-        ]);
-
+        $pid = $request->project->id;
         $take = $request->input('take');
         $filters = [
             'shape_id' => $request->input('shape_id'),
             'user_id' => $request->input('user_id'),
             'filename' => $request->input('filename'),
             'volume_id' => $request->input('volume_id'),
+            'created_at' => $request->input('created_at'),
+            'updated_at' => $request->input('updated_at'),
         ];
         $filters = array_filter($filters);
         $union = $request->input('union', false);

--- a/app/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelController.php
@@ -59,7 +59,8 @@ class FilterImageAnnotationsByLabelController extends Controller
             })
             ->when(!is_null($take), fn ($query) => $query->take($take))
             ->where('image_annotation_labels.label_id', $lid)
-            ->when(!empty($filters), fn ($query) => $this->compileFilterConditions('image', $query, $union, $filters)) ->select('images.uuid', 'image_annotations.id')
+            ->when(!empty($filters), fn ($query) => $this->compileFilterConditions('image', $query, $union, $filters))
+            ->select('images.uuid', 'image_annotations.id')
             ->distinct()
             ->orderBy('image_annotations.id', 'desc')
             ->pluck('images.uuid', 'image_annotations.id');

--- a/app/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelController.php
@@ -32,12 +32,12 @@ class FilterImageAnnotationsByLabelController extends Controller
      * @apiDescription Returns a map of image annotation IDs to their image UUIDs.
      *
      * @param FilterProjectAnnotationsRequest $request
-     * @param int $lid Label ID
      * @return \Illuminate\Support\Collection
      */
-    public function index(FilterProjectAnnotationsRequest $request, $lid)
+    public function index(FilterProjectAnnotationsRequest $request)
     {
         $pid = $request->project->id;
+        $lid = $request->labelId;
         $take = $request->input('take');
         $filters = [
             'shape_id' => $request->input('shape_id'),
@@ -59,8 +59,7 @@ class FilterImageAnnotationsByLabelController extends Controller
             })
             ->when(!is_null($take), fn ($query) => $query->take($take))
             ->where('image_annotation_labels.label_id', $lid)
-            ->when(!empty($filters), fn ($query) => $this->compileFilterConditions('image', $query, $union, $filters))
-            ->select('images.uuid', 'image_annotations.id')
+            ->when(!empty($filters), fn ($query) => $this->compileFilterConditions('image', $query, $union, $filters)) ->select('images.uuid', 'image_annotations.id')
             ->distinct()
             ->orderBy('image_annotations.id', 'desc')
             ->pluck('images.uuid', 'image_annotations.id');

--- a/app/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelController.php
@@ -25,8 +25,8 @@ class FilterImageAnnotationsByLabelController extends Controller
      * @apiParam (Optional arguments) {Array} user_id Array of user ids to use to filter values
      * @apiParam (Optional arguments) {Array} filename Array of filename patterns to use to filter annotations
      * @apiParam (Optional arguments) {Array} volume_id Array of volume ids to use to filter annotations
-     * @apiParam (Optional arguments) {Array} created_at Array containing objects mapping field names (annotation, annotation_label) to date operators (gt, gte, eq, lt, lte) and date Y-m-d values. Example: [{"annotation": {"gt": "2026-01-01"}}] means an annotation created after 2026-01-01
-     * @apiParam (Optional arguments) {Array} updated_at Array containing objects mapping field names (annotation, annotation_label) to date operators (gt, gte, eq, lt, lte) and date Y-m-d values. Example: [{"annotation": {"gt": "2026-01-01"}}] means an annotation updated after 2026-01-01
+     * @apiParam (Optional arguments) {Array} created_at Array containing objects mapping field names (annotation, annotation_label) to date logical operators (gt, eq, neq, lt) and date Y-m-d values. Example: [{"ref" :"annotation", "operator": "gt", "date": "2026-01-01"}}] means an annotation created after 2026-01-01
+     * @apiParam (Optional arguments) {Array} updated_at Array containing objects mapping field names (annotation, annotation_label) to date logical operators (gt, eq, neq, lt) and date Y-m-d values. Example: [{"ref" :"annotation", "operator": "gt", "date": "2026-01-01"}}] means an annotation updated after 2026-01-01
      * @apiParam (Optional arguments) {Boolean} union Whether the filters should be considered inclusive (OR) or exclusive (AND)
      * @apiPermission projectMember
      * @apiDescription Returns a map of image annotation IDs to their image UUIDs.

--- a/app/Http/Controllers/Api/Projects/FilterVideoAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Projects/FilterVideoAnnotationsByLabelController.php
@@ -7,7 +7,6 @@ use Biigle\Http\Requests\FilterProjectAnnotationsRequest;
 use Biigle\Project;
 use Biigle\Traits\CompileFilters;
 use Biigle\VideoAnnotation;
-use Illuminate\Http\Request;
 
 class FilterVideoAnnotationsByLabelController extends Controller
 {
@@ -31,13 +30,12 @@ class FilterVideoAnnotationsByLabelController extends Controller
      * @apiDescription Returns a map of video annotation IDs to their video UUIDs.
      *
      * @param FilterProjectAnnotationsRequest $request
-     * @param  int  $pid Project ID
-     * @param int $lid Label ID
      * @return \Illuminate\Support\Collection
      */
-    public function index(FilterProjectAnnotationsRequest $request, $pid, $lid)
+    public function index(FilterProjectAnnotationsRequest $request)
     {
         $pid = $request->project->id;
+        $lid = $request->labelId;
 
         $take = $request->input('take');
         $filters = [

--- a/app/Http/Controllers/Api/Projects/FilterVideoAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Projects/FilterVideoAnnotationsByLabelController.php
@@ -49,6 +49,10 @@ class FilterVideoAnnotationsByLabelController extends Controller
             'filename.*' => 'string',
             'volume_id' => 'array',
             'volume_id.*' => 'integer',
+            'date_before' => 'array',
+            'date_before.*' => 'date:Y-m-d',
+            'date_after' => 'array',
+            'date_after.*' => 'date:Y-m-d',
             'union' => 'boolean',
         ]);
 
@@ -58,6 +62,8 @@ class FilterVideoAnnotationsByLabelController extends Controller
             'user_id' => $request->input('user_id'),
             'filename' => $request->input('filename'),
             'volume_id' => $request->input('volume_id'),
+            'date_before' => $request->input('date_before'),
+            'date_after' => $request->input('date_after'),
         ];
         $filters = array_filter($filters);
         $union = $request->input('union', false);

--- a/app/Http/Controllers/Api/Projects/FilterVideoAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Projects/FilterVideoAnnotationsByLabelController.php
@@ -3,6 +3,7 @@
 namespace Biigle\Http\Controllers\Api\Projects;
 
 use Biigle\Http\Controllers\Api\Controller;
+use Biigle\Http\Requests\FilterProjectAnnotationsRequest;
 use Biigle\Project;
 use Biigle\Traits\CompileFilters;
 use Biigle\VideoAnnotation;
@@ -29,32 +30,14 @@ class FilterVideoAnnotationsByLabelController extends Controller
      * @apiPermission projectMember
      * @apiDescription Returns a map of video annotation IDs to their video UUIDs.
      *
-     * @param Request $request
+     * @param FilterProjectAnnotationsRequest $request
      * @param  int  $pid Project ID
      * @param int $lid Label ID
      * @return \Illuminate\Support\Collection
      */
-    public function index(Request $request, $pid, $lid)
+    public function index(FilterProjectAnnotationsRequest $request, $pid, $lid)
     {
-        $project = Project::findOrFail($pid);
-        $this->authorize('access', $project);
-
-        $this->validate($request, [
-            'take' => 'integer',
-            'shape_id' => 'array',
-            'shape_id.*' => 'integer',
-            'user_id' => 'array',
-            'user_id.*' => 'integer',
-            'filename' => 'array',
-            'filename.*' => 'string',
-            'volume_id' => 'array',
-            'volume_id.*' => 'integer',
-            'date_before' => 'array',
-            'date_before.*' => 'date:Y-m-d',
-            'date_after' => 'array',
-            'date_after.*' => 'date:Y-m-d',
-            'union' => 'boolean',
-        ]);
+        $pid = $request->project->id;
 
         $take = $request->input('take');
         $filters = [
@@ -62,8 +45,8 @@ class FilterVideoAnnotationsByLabelController extends Controller
             'user_id' => $request->input('user_id'),
             'filename' => $request->input('filename'),
             'volume_id' => $request->input('volume_id'),
-            'date_before' => $request->input('date_before'),
-            'date_after' => $request->input('date_after'),
+            'created_at' => $request->input('created_at'),
+            'updated_at' => $request->input('updated_at'),
         ];
         $filters = array_filter($filters);
         $union = $request->input('union', false);
@@ -76,7 +59,7 @@ class FilterVideoAnnotationsByLabelController extends Controller
                     ->where('project_id', $pid);
             })
             ->where('video_annotation_labels.label_id', $lid)
-            ->when(!empty($filters), fn ($query) => $this->compileFilterConditions($query, $union, $filters))
+            ->when(!empty($filters), fn ($query) => $this->compileFilterConditions('video', $query, $union, $filters))
             ->when(!is_null($take), fn ($query) => $query->take($take))
             ->select('videos.uuid', 'video_annotations.id')
             ->distinct()

--- a/app/Http/Controllers/Api/Projects/FilterVideoAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Projects/FilterVideoAnnotationsByLabelController.php
@@ -25,6 +25,8 @@ class FilterVideoAnnotationsByLabelController extends Controller
      * @apiParam (Optional arguments) {Array} user_id Array of user ids to use to filter values
      * @apiParam (Optional arguments) {Array} filename Array of filename patterns to use to filter annotations
      * @apiParam (Optional arguments) {Array} volume_id Array of volume ids to use to filter annotations
+     * @apiParam (Optional arguments) {Array} created_at Array containing objects mapping field names (annotation, annotation_label) to date logical operators (gt, eq, neq, lt) and date Y-m-d values. Example: [{"ref" :"annotation", "operator": "gt", "date": "2026-01-01"}}] means an annotation created after 2026-01-01
+     * @apiParam (Optional arguments) {Array} updated_at Array containing objects mapping field names (annotation, annotation_label) to date logical operators (gt, eq, neq, lt) and date Y-m-d values. Example: [{"ref" :"annotation", "operator": "gt", "date": "2026-01-01"}}] means an annotation updated after 2026-01-01
      * @apiParam (Optional arguments) {Boolean} union Whether the filters should be considered inclusive (OR) or exclusive (AND)
      * @apiPermission projectMember
      * @apiDescription Returns a map of video annotation IDs to their video UUIDs.

--- a/app/Http/Controllers/Api/Volumes/FilterImageAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Volumes/FilterImageAnnotationsByLabelController.php
@@ -30,7 +30,7 @@ class FilterImageAnnotationsByLabelController extends Controller
      * @apiPermission projectMember
      * @apiDescription Returns a map of image annotation IDs to their image UUIDs. If there is an active annotation session, annotations hidden by the session are not returned. Only available for image volumes.
      *
-     * @param Request $request
+     * @param FilterVolumeAnnotationsRequest $request
      * @param int $lid Label ID
      * @return \Illuminate\Support\Collection
      */

--- a/app/Http/Controllers/Api/Volumes/FilterImageAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Volumes/FilterImageAnnotationsByLabelController.php
@@ -6,7 +6,6 @@ use Biigle\Http\Requests\FilterVolumeAnnotationsRequest;
 use Biigle\ImageAnnotation;
 use Biigle\Traits\CompileFilters;
 use Biigle\Volume;
-use Illuminate\Http\Request;
 
 class FilterImageAnnotationsByLabelController extends Controller
 {
@@ -31,12 +30,12 @@ class FilterImageAnnotationsByLabelController extends Controller
      * @apiDescription Returns a map of image annotation IDs to their image UUIDs. If there is an active annotation session, annotations hidden by the session are not returned. Only available for image volumes.
      *
      * @param FilterVolumeAnnotationsRequest $request
-     * @param int $lid Label ID
      * @return \Illuminate\Support\Collection
      */
-    public function index(FilterVolumeAnnotationsRequest $request, $lid)
+    public function index(FilterVolumeAnnotationsRequest $request)
     {
         $vid = $request->volume->id;
+        $lid = $request->labelId;
 
         $take = $request->input('take');
 

--- a/app/Http/Controllers/Api/Volumes/FilterImageAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Volumes/FilterImageAnnotationsByLabelController.php
@@ -23,8 +23,8 @@ class FilterImageAnnotationsByLabelController extends Controller
      * @apiParam (Optional arguments) {Array} shape_id Array of shape ids to use to filter images
      * @apiParam (Optional arguments) {Array} user_id Array of user ids to use to filter values
      * @apiParam (Optional arguments) {Array} filename Array of filename patterns to use to filter annotations
-     * @apiParam (Optional arguments) {Array} created_at Array containing objects mapping field names (annotation, annotation_label) to date operators (gt, gte, eq, lt, lte) and date Y-m-d values. Example: [{"annotation": {"gt": "2026-01-01"}}] means an annotation created after 2026-01-01
-     * @apiParam (Optional arguments) {Array} updated_at Array containing objects mapping field names (annotation, annotation_label) to date operators (gt, gte, eq, lt, lte) and date Y-m-d values. Example: [{"annotation": {"gt": "2026-01-01"}}] means an annotation updated after 2026-01-01
+     * @apiParam (Optional arguments) {Array} created_at Array containing objects mapping field names (annotation, annotation_label) to date logical operators (gt, eq, neq, lt) and date Y-m-d values. Example: [{"ref" :"annotation", "operator": "gt", "date": "2026-01-01"}}] means an annotation created after 2026-01-01
+     * @apiParam (Optional arguments) {Array} updated_at Array containing objects mapping field names (annotation, annotation_label) to date logical operators (gt, eq, neq, lt) and date Y-m-d values. Example: [{"ref" :"annotation", "operator": "gt", "date": "2026-01-01"}}] means an annotation updated after 2026-01-01
      * @apiParam (Optional arguments) {Boolean} union Whether the filters should be considered inclusive (OR) or exclusive (AND)
      * @apiPermission projectMember
      * @apiDescription Returns a map of image annotation IDs to their image UUIDs. If there is an active annotation session, annotations hidden by the session are not returned. Only available for image volumes.

--- a/app/Http/Controllers/Api/Volumes/FilterImageAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Volumes/FilterImageAnnotationsByLabelController.php
@@ -2,6 +2,7 @@
 namespace Biigle\Http\Controllers\Api\Volumes;
 
 use Biigle\Http\Controllers\Api\Controller;
+use Biigle\Http\Requests\FilterVolumeAnnotationsRequest;
 use Biigle\ImageAnnotation;
 use Biigle\Traits\CompileFilters;
 use Biigle\Volume;
@@ -23,30 +24,19 @@ class FilterImageAnnotationsByLabelController extends Controller
      * @apiParam (Optional arguments) {Array} shape_id Array of shape ids to use to filter images
      * @apiParam (Optional arguments) {Array} user_id Array of user ids to use to filter values
      * @apiParam (Optional arguments) {Array} filename Array of filename patterns to use to filter annotations
+     * @apiParam (Optional arguments) {Array} created_at Array containing objects mapping field names (annotation, annotation_label) to date operators (gt, gte, eq, lt, lte) and date Y-m-d values. Example: [{"annotation": {"gt": "2026-01-01"}}] means an annotation created after 2026-01-01
+     * @apiParam (Optional arguments) {Array} updated_at Array containing objects mapping field names (annotation, annotation_label) to date operators (gt, gte, eq, lt, lte) and date Y-m-d values. Example: [{"annotation": {"gt": "2026-01-01"}}] means an annotation updated after 2026-01-01
      * @apiParam (Optional arguments) {Boolean} union Whether the filters should be considered inclusive (OR) or exclusive (AND)
      * @apiPermission projectMember
      * @apiDescription Returns a map of image annotation IDs to their image UUIDs. If there is an active annotation session, annotations hidden by the session are not returned. Only available for image volumes.
      *
      * @param Request $request
-     * @param  int  $vid Volume ID
      * @param int $lid Label ID
      * @return \Illuminate\Support\Collection
      */
-    public function index(Request $request, $vid, $lid)
+    public function index(FilterVolumeAnnotationsRequest $request, $lid)
     {
-        $volume = Volume::findOrFail($vid);
-        $this->authorize('access', $volume);
-
-        $this->validate($request, [
-            'take' => 'integer',
-            'shape_id' => 'array',
-            'shape_id.*' => 'integer',
-            'user_id' => 'array',
-            'user_id.*' => 'integer',
-            'filename' => 'array',
-            'filename.*' => 'string',
-            'union' => 'boolean',
-        ]);
+        $vid = $request->volume->id;
 
         $take = $request->input('take');
 
@@ -54,11 +44,13 @@ class FilterImageAnnotationsByLabelController extends Controller
             'shape_id' => $request->input('shape_id'),
             'user_id' => $request->input('user_id'),
             'filename' => $request->input('filename'),
+            'created_at' => $request->input('created_at'),
+            'updated_at' => $request->input('updated_at'),
         ];
         $filters = array_filter($filters);
         $union = $request->input('union', false);
 
-        $session = $volume->getActiveAnnotationSession($request->user());
+        $session = $request->volume->getActiveAnnotationSession($request->user());
 
         if ($session) {
             $query = ImageAnnotation::allowedBySession($session, $request->user());
@@ -71,7 +63,7 @@ class FilterImageAnnotationsByLabelController extends Controller
             ->where('images.volume_id', $vid)
             ->where('image_annotation_labels.label_id', $lid)
             ->when(!is_null($take), fn ($query) => $query->take($take))
-            ->when(!empty($filters), fn ($query) => $this->compileFilterConditions($query, $union, $filters))
+            ->when(!empty($filters), fn ($query) => $this->compileFilterConditions('image', $query, $union, $filters))
             ->when($session, function ($query) use ($session, $request) {
                 if ($session->hide_other_users_annotations) {
                     $query->where('image_annotation_labels.user_id', $request->user()->id);

--- a/app/Http/Controllers/Api/Volumes/FilterVideoAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Volumes/FilterVideoAnnotationsByLabelController.php
@@ -24,8 +24,8 @@ class FilterVideoAnnotationsByLabelController extends Controller
      * @apiParam (Optional arguments) {Array} user_id Array of user ids to use to filter values
      * @apiParam (Optional arguments) {Array} filename Array of filename patterns to use to filter annotations
      * @apiParam (Optional arguments) {Array} created_at Array containing objects mapping field names (annotation, annotation_label) to date operators (gt, gte, eq, lt, lte) and date Y-m-d values. Example: [{"annotation": {"gt": "2026-01-01"}}] means an annotation created after 2026-01-01
-     * @apiParam (Optional arguments) {Array} updated_at Array containing objects mapping field names (annotation, annotation_label) to date operators (gt, gte, eq, lt, lte) and date Y-m-d values. Example: [{"annotation": {"gt": "2026-01-01"}}] means an annotation updated after 2026-01-01
-     * @apiParam (Optional arguments) {Boolean} union Whether the filters should be considered inclusive (OR) or exclusive (AND)
+     * @apiParam (Optional arguments) {Array} created_at Array containing objects mapping field names (annotation, annotation_label) to date logical operators (gt, eq, neq, lt) and date Y-m-d values. Example: [{"ref" :"annotation", "operator": "gt", "date": "2026-01-01"}}] means an annotation created after 2026-01-01
+     * @apiParam (Optional arguments) {Array} updated_at Array containing objects mapping field names (annotation, annotation_label) to date logical operators (gt, eq, neq, lt) and date Y-m-d values. Example: [{"ref" :"annotation", "operator": "gt", "date": "2026-01-01"}}] means an annotation updated after 2026-01-01
      * @apiPermission projectMember
      * @apiDescription Returns a map of video annotation IDs to their video UUIDs. If there is an active annotation session, annotations hidden by the session are not returned. Only available for video volumes.
      *

--- a/app/Http/Controllers/Api/Volumes/FilterVideoAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Volumes/FilterVideoAnnotationsByLabelController.php
@@ -24,8 +24,8 @@ class FilterVideoAnnotationsByLabelController extends Controller
      * @apiParam (Optional arguments) {Array} user_id Array of user ids to use to filter values
      * @apiParam (Optional arguments) {Array} filename Array of filename patterns to use to filter annotations
      * @apiParam (Optional arguments) {Array} created_at Array containing objects mapping field names (annotation, annotation_label) to date operators (gt, gte, eq, lt, lte) and date Y-m-d values. Example: [{"annotation": {"gt": "2026-01-01"}}] means an annotation created after 2026-01-01
-     * @apiParam (Optional arguments) {Array} created_at Array containing objects mapping field names (annotation, annotation_label) to date logical operators (gt, eq, neq, lt) and date Y-m-d values. Example: [{"ref" :"annotation", "operator": "gt", "date": "2026-01-01"}}] means an annotation created after 2026-01-01
      * @apiParam (Optional arguments) {Array} updated_at Array containing objects mapping field names (annotation, annotation_label) to date logical operators (gt, eq, neq, lt) and date Y-m-d values. Example: [{"ref" :"annotation", "operator": "gt", "date": "2026-01-01"}}] means an annotation updated after 2026-01-01
+     * @apiParam (Optional arguments) {Boolean} union Whether the filters should be considered inclusive (OR) or exclusive (AND)
      * @apiPermission projectMember
      * @apiDescription Returns a map of video annotation IDs to their video UUIDs. If there is an active annotation session, annotations hidden by the session are not returned. Only available for video volumes.
      *

--- a/app/Http/Controllers/Api/Volumes/FilterVideoAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Volumes/FilterVideoAnnotationsByLabelController.php
@@ -6,7 +6,6 @@ use Biigle\Http\Controllers\Api\Controller;
 use Biigle\Http\Requests\FilterVolumeAnnotationsRequest;
 use Biigle\Traits\CompileFilters;
 use Biigle\VideoAnnotation;
-use Illuminate\Http\Request;
 
 class FilterVideoAnnotationsByLabelController extends Controller
 {
@@ -31,12 +30,12 @@ class FilterVideoAnnotationsByLabelController extends Controller
      * @apiDescription Returns a map of video annotation IDs to their video UUIDs. If there is an active annotation session, annotations hidden by the session are not returned. Only available for video volumes.
      *
      * @param FilterVolumeAnnotationsRequest $request
-     * @param int $lid Label ID
      * @return \Illuminate\Support\Collection
      */
-    public function index(FilterVolumeAnnotationsRequest $request, $lid)
+    public function index(FilterVolumeAnnotationsRequest $request)
     {
         $vid = $request->volume->id;
+        $lid = $request->labelId;
 
         $take = $request->input('take');
         $filters = [

--- a/app/Http/Controllers/Api/Volumes/FilterVideoAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Volumes/FilterVideoAnnotationsByLabelController.php
@@ -30,7 +30,7 @@ class FilterVideoAnnotationsByLabelController extends Controller
      * @apiPermission projectMember
      * @apiDescription Returns a map of video annotation IDs to their video UUIDs. If there is an active annotation session, annotations hidden by the session are not returned. Only available for video volumes.
      *
-     * @param Request $request
+     * @param FilterVolumeAnnotationsRequest $request
      * @param int $lid Label ID
      * @return \Illuminate\Support\Collection
      */
@@ -62,7 +62,7 @@ class FilterVideoAnnotationsByLabelController extends Controller
             ->join('videos', 'video_annotations.video_id', '=', 'videos.id')
             ->where('videos.volume_id', $vid)
             ->where('video_annotation_labels.label_id', $lid)
-            ->when(!empty($filters), fn ($query) => $this->compileFilterConditions($query, $union, $filters))
+            ->when(!empty($filters), fn ($query) => $this->compileFilterConditions('video', $query, $union, $filters))
             ->when($session, function ($query) use ($session, $request) {
                 if ($session->hide_other_users_annotations) {
                     $query->where('video_annotation_labels.user_id', $request->user()->id);

--- a/app/Http/Controllers/Api/Volumes/FilterVideoAnnotationsByLabelController.php
+++ b/app/Http/Controllers/Api/Volumes/FilterVideoAnnotationsByLabelController.php
@@ -3,9 +3,9 @@
 namespace Biigle\Http\Controllers\Api\Volumes;
 
 use Biigle\Http\Controllers\Api\Controller;
+use Biigle\Http\Requests\FilterVolumeAnnotationsRequest;
 use Biigle\Traits\CompileFilters;
 use Biigle\VideoAnnotation;
-use Biigle\Volume;
 use Illuminate\Http\Request;
 
 class FilterVideoAnnotationsByLabelController extends Controller
@@ -24,41 +24,33 @@ class FilterVideoAnnotationsByLabelController extends Controller
      * @apiParam (Optional arguments) {Array} shape_id Array of shape ids to use to filter videos
      * @apiParam (Optional arguments) {Array} user_id Array of user ids to use to filter values
      * @apiParam (Optional arguments) {Array} filename Array of filename patterns to use to filter annotations
+     * @apiParam (Optional arguments) {Array} created_at Array containing objects mapping field names (annotation, annotation_label) to date operators (gt, gte, eq, lt, lte) and date Y-m-d values. Example: [{"annotation": {"gt": "2026-01-01"}}] means an annotation created after 2026-01-01
+     * @apiParam (Optional arguments) {Array} updated_at Array containing objects mapping field names (annotation, annotation_label) to date operators (gt, gte, eq, lt, lte) and date Y-m-d values. Example: [{"annotation": {"gt": "2026-01-01"}}] means an annotation updated after 2026-01-01
      * @apiParam (Optional arguments) {Boolean} union Whether the filters should be considered inclusive (OR) or exclusive (AND)
      * @apiPermission projectMember
      * @apiDescription Returns a map of video annotation IDs to their video UUIDs. If there is an active annotation session, annotations hidden by the session are not returned. Only available for video volumes.
      *
      * @param Request $request
-     * @param  int  $vid Volume ID
      * @param int $lid Label ID
      * @return \Illuminate\Support\Collection
      */
-    public function index(Request $request, $vid, $lid)
+    public function index(FilterVolumeAnnotationsRequest $request, $lid)
     {
-        $volume = Volume::findOrFail($vid);
-        $this->authorize('access', $volume);
-
-        $this->validate($request, [
-            'take' => 'integer',
-            'shape_id' => 'array',
-            'shape_id.*' => 'integer',
-            'user_id' => 'array',
-            'user_id.*' => 'integer',
-            'filename' => 'array',
-            'filename.*' => 'string',
-            'union' => 'boolean',
-        ]);
+        $vid = $request->volume->id;
 
         $take = $request->input('take');
         $filters = [
             'shape_id' => $request->input('shape_id'),
             'user_id' => $request->input('user_id'),
             'filename' => $request->input('filename'),
+            'created_at' => $request->input('created_at'),
+            'updated_at' => $request->input('updated_at'),
         ];
+
         $filters = array_filter($filters);
         $union = $request->input('union', false);
 
-        $session = $volume->getActiveAnnotationSession($request->user());
+        $session = $request->volume->getActiveAnnotationSession($request->user());
 
         if ($session) {
             $query = VideoAnnotation::allowedBySession($session, $request->user());

--- a/app/Http/Requests/FilterAnnotationsRequest.php
+++ b/app/Http/Requests/FilterAnnotationsRequest.php
@@ -7,6 +7,13 @@ use \Illuminate\Foundation\Http\FormRequest;
 class FilterAnnotationsRequest extends FormRequest
 {
     /**
+     * ID of the label to filter annotations.
+     *
+     * @var int
+     */
+    public $labelId;
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array
@@ -14,23 +21,24 @@ class FilterAnnotationsRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'take' => 'integer',
-            'shape_id' => 'array',
-            'shape_id.*' => 'integer',
-            'user_id' => 'array',
-            'user_id.*' => 'integer',
-            'filename' => 'array',
-            'filename.*' => 'string',
-            'created_at' => 'array',
-            'created_at.*' => 'array:ref,operator,date',
-            'created_at.ref' => 'string:annotation,annotation_label',
-            'created_at.operator' => 'string:gt,eq,lt',
-            'created_at.date' => 'date_format:Y-m-d',
-            'updated_at.*' => 'array:ref,operator,date',
-            'updated_at.ref' => 'string:annotation,annotation_label',
-            'updated_at.operator' => 'string:gt,eq,neq,lt',
-            'updated_at.date' => 'date_format:Y-m-d',
-            'union' => 'boolean',
+            'take' => 'nullable|integer',
+            'shape_id' => 'nullable|array',
+            'shape_id.*' => 'nullable|integer',
+            'user_id' => 'nullable|array',
+            'user_id.*' => 'nullable|integer',
+            'filename' => 'nullable|array',
+            'filename.*' => 'nullable|string',
+            'created_at' => 'nullable|array',
+            'created_at.*' => 'nullable|array',
+            'created_at.*.ref' => 'required_with:created_at|string|alpha_dash|max:50',
+            'created_at.*.operator' => 'required_with:created_at|string|in:eq,neq,gt,lt',
+            'created_at.*.date' => 'required_with:created_at|date_format:Y-m-d',
+            'updated_at' => 'nullable|array',
+            'updated_at.*' => 'nullable|array',
+            'updated_at.*.ref' => 'required_with:updated_at|string|alpha_dash|max:50',
+            'updated_at.*.operator' => 'required_with:updated_at|string|in:eq,neq,gt,lt',
+            'updated_at.*.date' => 'required_with:updated_at|date_format:Y-m-d',
+            'union' => 'nullable|boolean',
         ];
     }
 }

--- a/app/Http/Requests/FilterAnnotationsRequest.php
+++ b/app/Http/Requests/FilterAnnotationsRequest.php
@@ -4,7 +4,7 @@ namespace Biigle\Http\Requests;
 
 use \Illuminate\Foundation\Http\FormRequest;
 
-class FilterAnnotationsRequest extends FormRequest
+abstract class FilterAnnotationsRequest extends FormRequest
 {
     /**
      * ID of the label to filter annotations.

--- a/app/Http/Requests/FilterAnnotationsRequest.php
+++ b/app/Http/Requests/FilterAnnotationsRequest.php
@@ -28,7 +28,7 @@ class FilterAnnotationsRequest extends FormRequest
             'created_at.date' => 'date_format:Y-m-d',
             'updated_at.*' => 'array:ref,operator,date',
             'updated_at.ref' => 'string:annotation,annotation_label',
-            'updated_at.operator' => 'string:gt,eq,lt',
+            'updated_at.operator' => 'string:gt,eq,neq,lt',
             'updated_at.date' => 'date_format:Y-m-d',
             'union' => 'boolean',
         ];

--- a/app/Http/Requests/FilterAnnotationsRequest.php
+++ b/app/Http/Requests/FilterAnnotationsRequest.php
@@ -6,6 +6,11 @@ use \Illuminate\Foundation\Http\FormRequest;
 
 class FilterAnnotationsRequest extends FormRequest
 {
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules(): array
     {
         return [
@@ -27,7 +32,5 @@ class FilterAnnotationsRequest extends FormRequest
             'updated_at.date' => 'date_format:Y-m-d',
             'union' => 'boolean',
         ];
-;
     }
 }
-

--- a/app/Http/Requests/FilterAnnotationsRequest.php
+++ b/app/Http/Requests/FilterAnnotationsRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Biigle\Http\Requests;
+
+use \Illuminate\Foundation\Http\FormRequest;
+
+class FilterAnnotationsRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'take' => 'integer',
+            'shape_id' => 'array',
+            'shape_id.*' => 'integer',
+            'user_id' => 'array',
+            'user_id.*' => 'integer',
+            'filename' => 'array',
+            'filename.*' => 'string',
+            'created_at' => 'array',
+            'created_at.*' => 'array:ref,operator,date',
+            'created_at.ref' => 'string:annotation,annotation_label',
+            'created_at.operator' => 'string:gt,eq,lt',
+            'created_at.date' => 'date_format:Y-m-d',
+            'updated_at.*' => 'array:ref,operator,date',
+            'updated_at.ref' => 'string:annotation,annotation_label',
+            'updated_at.operator' => 'string:gt,eq,lt',
+            'updated_at.date' => 'date_format:Y-m-d',
+            'union' => 'boolean',
+        ];
+;
+    }
+}
+

--- a/app/Http/Requests/FilterProjectAnnotationsRequest.php
+++ b/app/Http/Requests/FilterProjectAnnotationsRequest.php
@@ -2,7 +2,6 @@
 
 namespace Biigle\Http\Requests;
 
-use Biigle\Http\Requests\FilterAnnotationsRequest;
 use Biigle\Project;
 
 class FilterProjectAnnotationsRequest extends FilterAnnotationsRequest
@@ -21,11 +20,12 @@ class FilterProjectAnnotationsRequest extends FilterAnnotationsRequest
      */
     public function authorize()
     {
-        $this->project = Project::findOrFail($this->route('pid'));
+        $this->project = Project::findOrFail($this->route('id'));
 
         return $this->user()->can('access', $this->project);
     }
-/**
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array
@@ -37,5 +37,4 @@ class FilterProjectAnnotationsRequest extends FilterAnnotationsRequest
             'volume_id.*' => 'integer',
         ]);
     }
-
 }

--- a/app/Http/Requests/FilterProjectAnnotationsRequest.php
+++ b/app/Http/Requests/FilterProjectAnnotationsRequest.php
@@ -21,6 +21,7 @@ class FilterProjectAnnotationsRequest extends FilterAnnotationsRequest
     public function authorize()
     {
         $this->project = Project::findOrFail($this->route('id'));
+        $this->labelId = intval($this->route('id2'));
 
         return $this->user()->can('access', $this->project);
     }
@@ -33,7 +34,7 @@ class FilterProjectAnnotationsRequest extends FilterAnnotationsRequest
     public function rules(): array
     {
         return array_merge(parent::rules(), [
-            'volume_id' => 'array',
+            'volume_id' => 'nullable|array',
             'volume_id.*' => 'integer',
         ]);
     }

--- a/app/Http/Requests/FilterProjectAnnotationsRequest.php
+++ b/app/Http/Requests/FilterProjectAnnotationsRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Biigle\Http\Requests;
+
+use Biigle\Http\Requests\FilterAnnotationsRequest;
+use Biigle\Project;
+
+class FilterProjectAnnotationsRequest extends FilterAnnotationsRequest
+{
+    /**
+     * To which project the annotations are being filtered.
+     *
+     * @var Project
+     */
+    public $project;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        $this->project = Project::findOrFail($this->route('pid'));
+
+        return $this->user()->can('access', $this->project);
+    }
+/**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return array_merge(parent::rules(), [
+            'volume_id' => 'array',
+            'volume_id.*' => 'integer',
+        ]);
+    }
+
+}

--- a/app/Http/Requests/FilterVolumeAnnotationsRequest.php
+++ b/app/Http/Requests/FilterVolumeAnnotationsRequest.php
@@ -7,7 +7,7 @@ use Biigle\Volume;
 class FilterVolumeAnnotationsRequest extends FilterAnnotationsRequest
 {
     /**
-     * To which project the annotations are being filtered.
+     * To which volume the annotations are being filtered.
      *
      * @var Volume
      */

--- a/app/Http/Requests/FilterVolumeAnnotationsRequest.php
+++ b/app/Http/Requests/FilterVolumeAnnotationsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Biigle\Http\Requests;
+
+use Biigle\Http\Requests\FilterAnnotationsRequest;
+use Biigle\Volume;
+
+class FilterVolumeAnnotationsRequest extends FilterAnnotationsRequest
+{
+    /**
+     * To which project the annotations are being filtered.
+     *
+     * @var Volume
+     */
+    public $volume;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        $this->volume = Volume::findOrFail($this->route('vid'));
+
+        return $this->user()->can('access', $this->volume);
+    }
+}

--- a/app/Http/Requests/FilterVolumeAnnotationsRequest.php
+++ b/app/Http/Requests/FilterVolumeAnnotationsRequest.php
@@ -2,7 +2,6 @@
 
 namespace Biigle\Http\Requests;
 
-use Biigle\Http\Requests\FilterAnnotationsRequest;
 use Biigle\Volume;
 
 class FilterVolumeAnnotationsRequest extends FilterAnnotationsRequest
@@ -21,7 +20,7 @@ class FilterVolumeAnnotationsRequest extends FilterAnnotationsRequest
      */
     public function authorize()
     {
-        $this->volume = Volume::findOrFail($this->route('vid'));
+        $this->volume = Volume::findOrFail($this->route('id'));
 
         return $this->user()->can('access', $this->volume);
     }

--- a/app/Http/Requests/FilterVolumeAnnotationsRequest.php
+++ b/app/Http/Requests/FilterVolumeAnnotationsRequest.php
@@ -21,6 +21,7 @@ class FilterVolumeAnnotationsRequest extends FilterAnnotationsRequest
     public function authorize()
     {
         $this->volume = Volume::findOrFail($this->route('id'));
+        $this->labelId = intval($this->route('id2'));
 
         return $this->user()->can('access', $this->volume);
     }

--- a/app/Traits/CompileFilters.php
+++ b/app/Traits/CompileFilters.php
@@ -107,29 +107,28 @@ trait CompileFilters
     private function normalizeDateFilter(string $annotationType, string $filterName, array $value, bool $isNegated): array
     {
         $dateValue = match ($value['operator']) {
-            'gt' => Carbon::createFromFormat('Y-m-d', $value['date'])->startOfDay(),
-            'lt' => Carbon::createFromFormat('Y-m-d', $value['date'])->endOfDay(),
-            'eq' => Carbon::createFromFormat('Y-m-d', $value['date'])->startOfDay(),
+            'gt' => Carbon::createFromFormat('Y-m-d', $value['date'])->endOfDay()->toDateTimeString(),
+            'lt' => Carbon::createFromFormat('Y-m-d', $value['date'])->startOfDay()->toDateTimeString(),
+            'eq' => $value['date'],
+            'neq' => $value['date'],
+            default => throw new \Exception('Operator not recognized'),
         };
 
-        // Using ::date means that pgsql will convert all dates to date, making queries slower.
-        // Use it only for equality.
-        $field = match ($value['operator']) {
-            'eq' => $annotationType."_{$value['ref']}s.{$filterName}::date",
-            default => $annotationType."_{$value['ref']}s.{$filterName}",
-        };
+        $field = $annotationType."_{$value['ref']}s.{$filterName}";
 
         $operator = match ($value['operator']) {
             'gt' => '>',
             'lt' => '<',
             'eq' => '=',
+            'neq' => '!=',
         };
 
         return [
             'field' => $field,
             'operator' => $operator,
-            'value' => $dateValue->toDateTimeString(),
+            'value' => $dateValue,
             'negated' => $isNegated,
+            'exact_date' => str_contains($operator, '='),
         ];
     }
 
@@ -179,9 +178,17 @@ trait CompileFilters
     private function applyFilterCondition($q, array $filter, string $boolean): void
     {
         if ($filter['negated']) {
-            $q->whereNot($filter['field'], $filter['operator'], $filter['value'], $boolean);
+            if (isset($filter['exact_date']) && $filter['exact_date']) {
+                $q->whereNot(fn ($query) => $query->whereDate($filter['field'], $filter['operator'], $filter['value'], $boolean));
+            } else {
+                $q->whereNot($filter['field'], $filter['operator'], $filter['value'], $boolean);
+            }
         } else {
-            $q->where($filter['field'], $filter['operator'], $filter['value'], $boolean);
+            if (isset($filter['exact_date']) && $filter['exact_date']) {
+                $q->whereDate($filter['field'], $filter['operator'], $filter['value'], $boolean);
+            } else {
+                $q->where($filter['field'], $filter['operator'], $filter['value'], $boolean);
+            }
         }
     }
 }

--- a/app/Traits/CompileFilters.php
+++ b/app/Traits/CompileFilters.php
@@ -1,6 +1,7 @@
 <?php
 namespace Biigle\Traits;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 
 trait CompileFilters
@@ -11,40 +12,176 @@ trait CompileFilters
     * @param bool $union Whether filters are considered inclusive (OR) or exclusive (AND)
     * @param array $filters Array of filters to add to the query in the form `filterName => filterValue`
     */
-    protected function compileFilterConditions(Builder $query, bool $union, array $filters): void
+    protected function compileFilterConditions(string $annotationType, Builder $query, bool $union, array $filters): void
     {
         $boolean = $union ? 'or' : 'and';
 
-        $query->where(function ($q) use ($filters, $boolean) {
+        $query->where(function ($q) use ($annotationType, $filters, $boolean) {
             foreach ($filters as $filterName => $filterValues) {
-                if ($filterName === 'filename') {
-                    $operator = 'ilike';
-                    $filterValues = array_map(fn ($v) => str_replace('*', '%', $v), $filterValues);
-                } elseif ($filterName === 'created_at' || $filterName === 'updated_at') {
-                    $filterName = "$filterValues->ref.$filterName::date";
-                    $operator = match($filterValues->operator) {
-                        'gt' => '>',
-                        'lt' => '<',
-                        'eq' => '=',
-                    };
-                    $filterValues = match($operator) {
-                        '>' => $filterValues->endOfDay(),
-                        '<' => $filterValues->startOfDay(),
-                        '=' => $filterValues,
-                    };
-                }
-                else {
-                    $operator = '=';
-                }
+                $filterValues = $this->normalizeFilterValues($annotationType, $filterName, $filterValues);
 
-                foreach ($filterValues as $value) {
-                    if (str_starts_with($value, '-')) {
-                        $q->whereNot($filterName, $operator, substr($value, 1), $boolean);
-                    } else {
-                        $q->where($filterName, $operator, $value, $boolean);
-                    }
+                foreach ($filterValues as $normalizedFilter) {
+                    $this->applyFilterCondition($q, $normalizedFilter, $boolean);
                 }
             }
         });
+    }
+
+    /**
+     * Normalize filter values based on the filter type.
+     *
+     * Handles different filter types (filename, dates, default) and extracts negation prefixes.
+     * Returns an array of normalized filter arrays suitable for query application.
+     *
+     * @param string $filterName The name of the filter to apply
+     * @param array<mixed> $filterValues The raw filter values from the request
+     *
+     * @return array<int, array<string, mixed>> An array of normalized filter arrays with keys:
+     *                                           - field: The database field name
+     *                                           - operator: The SQL operator (=, >, <, ilike, etc.)
+     *                                           - value: The filter value
+     *                                           - negated: Whether the filter should be negated
+     */
+    private function normalizeFilterValues(string $annotationType, string $filterName, array $filterValues): array
+    {
+        return array_map(function ($value) use ($filterName, $annotationType) {
+            $isNegated = is_string($value) && str_starts_with($value, '-');
+
+            return match ($filterName) {
+                'filename' => $this->normalizeFilenameFilter($value, $isNegated),
+                'created_at', 'updated_at' => $this->normalizeDateFilter($annotationType, $filterName, $value, $isNegated),
+                default => $this->normalizeDefaultFilter($filterName, $value, $isNegated),
+            };
+        }, $filterValues);
+    }
+
+    /**
+     * Normalize a filename filter with wildcard support.
+     *
+     * Converts asterisks (*) to SQL LIKE wildcards (%) and prepares the filter for case-insensitive
+     * matching using the ILIKE operator.
+     *
+     * @param mixed $value The raw filter value, optionally prefixed with '-' for negation
+     * @param bool $isNegated Whether the filter value was prefixed with '-'
+     *
+     * @return array<string, mixed> A normalized filter array with keys:
+     *                              - field: 'filename'
+     *                              - operator: 'ilike'
+     *                              - value: The filename pattern with * converted to %
+     *                              - negated: Whether the filter should be negated
+     */
+    private function normalizeFilenameFilter($value, bool $isNegated): array
+    {
+        $actualValue = $isNegated ? substr($value, 1) : $value;
+
+        return [
+            'field' => 'filename',
+            'operator' => 'ilike',
+            'value' => str_replace('*', '%', $actualValue),
+            'negated' => $isNegated,
+        ];
+    }
+
+    /**
+     * Normalize a date filter with operator and time boundary handling.
+     *
+     * Handles date comparison operators (gt, lt, eq) and applies appropriate time boundaries:
+     * - 'gt' (greater than): uses end of day
+     * - 'lt' (less than): uses start of day
+     * - 'eq' (equals): uses the exact date value
+     *
+     * @param string $filterName The date field name ('created_at' or 'updated_at')
+     * @param array $value An array with keys:
+     *                      - operator: The comparison operator ('gt', 'lt', 'eq')
+     *                      - ref: The table/column reference prefix
+     *                      - The value itself should be a Carbon/DateTime instance with
+     *                        startOfDay() and endOfDay() methods
+     * @param bool $isNegated Whether the filter should be negated
+     *
+     * @return array<string, mixed> A normalized filter array with keys:
+     *                              - field: The fully qualified field name with ::date cast
+     *                              - operator: The SQL comparison operator (>, <, =)
+     *                              - value: The date value with appropriate time boundaries
+     *                              - negated: Whether the filter should be negated
+     */
+    private function normalizeDateFilter(string $annotationType, string $filterName, array $value, bool $isNegated): array
+    {
+        $dateValue = match ($value['operator']) {
+            'gt' => Carbon::createFromFormat('Y-m-d', $value['date'])->startOfDay(),
+            'lt' => Carbon::createFromFormat('Y-m-d', $value['date'])->endOfDay(),
+            'eq' => Carbon::createFromFormat('Y-m-d', $value['date'])->startOfDay(),
+        };
+
+        // Using ::date means that pgsql will convert all dates to date, making queries slower.
+        // Use it only for equality.
+        $field = match ($value['operator']) {
+            'eq' => $annotationType."_{$value['ref']}s.{$filterName}::date",
+            default => $annotationType."_{$value['ref']}s.{$filterName}",
+        };
+
+        $operator = match ($value['operator']) {
+            'gt' => '>',
+            'lt' => '<',
+            'eq' => '=',
+        };
+
+        return [
+            'field' => $field,
+            'operator' => $operator,
+            'value' => $dateValue->toDateTimeString(),
+            'negated' => $isNegated,
+        ];
+    }
+
+    /**
+     * Normalize a default filter.
+     *
+     * Handles generic filters that use exact equality matching. Extracts negation prefix if present.
+     *
+     * @param string $filterName The field to query
+     * @param string $value The raw filter value, optionally prefixed with '-' for negation
+     * @param bool $isNegated Whether the filter value was prefixed with '-'
+     *
+     * @return array<string, mixed> A normalized filter array with keys:
+     *                              - field: The database field name
+     *                              - operator: '='
+     *                              - value: The filter value without negation prefix
+     *                              - negated: Whether the filter should be negated
+     */
+    private function normalizeDefaultFilter(string $filterName, string $value, bool $isNegated): array
+    {
+        $actualValue = $isNegated ? substr($value, 1) : $value;
+
+        return [
+            'field' => $filterName,
+            'operator' => '=',
+            'value' => $actualValue,
+            'negated' => $isNegated,
+        ];
+    }
+
+    /**
+     * Apply a single normalized filter condition to the query builder.
+     *
+     * Adds either a where() or whereNot() clause depending on the negated flag.
+     *
+     * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder $q
+     *        The query builder instance to apply the filter to
+     * @param array<string, mixed> $filter A normalized filter array with keys:
+     *                                     - field: The database field name
+     *                                     - operator: The SQL operator
+     *                                     - value: The filter value
+     *                                     - negated: Whether to use whereNot instead of where
+     * @param string $boolean The boolean operator for combining conditions ('and' or 'or')
+     *
+     * @return void
+     */
+    private function applyFilterCondition($q, array $filter, string $boolean): void
+    {
+        if ($filter['negated']) {
+            $q->whereNot($filter['field'], $filter['operator'], $filter['value'], $boolean);
+        } else {
+            $q->where($filter['field'], $filter['operator'], $filter['value'], $boolean);
+        }
     }
 }

--- a/app/Traits/CompileFilters.php
+++ b/app/Traits/CompileFilters.php
@@ -8,6 +8,7 @@ trait CompileFilters
 {
     /**
     * Compile Largo filter(s) that were requested and add them to the query
+    * @param string $annotationType 'video' or 'image' depending on the nature of the support of the request
     * @param Builder $query Query to add filters to
     * @param bool $union Whether filters are considered inclusive (OR) or exclusive (AND)
     * @param array $filters Array of filters to add to the query in the form `filterName => filterValue`
@@ -34,13 +35,13 @@ trait CompileFilters
      * Returns an array of normalized filter arrays suitable for query application.
      *
      * @param string $filterName The name of the filter to apply
-     * @param array<mixed> $filterValues The raw filter values from the request
+     * @param array $filterValues The raw filter values from the request
      *
-     * @return array<int, array<string, mixed>> An array of normalized filter arrays with keys:
-     *                                           - field: The database field name
-     *                                           - operator: The SQL operator (=, >, <, ilike, etc.)
-     *                                           - value: The filter value
-     *                                           - negated: Whether the filter should be negated
+     * @return array An array of normalized filter arrays with keys:
+     *                - field: The database field name
+     *                - operator: The SQL operator (=, >, <, ilike, etc.)
+     *                - value: The filter value
+     *                - negated: Whether the filter should be negated
      */
     private function normalizeFilterValues(string $annotationType, string $filterName, array $filterValues): array
     {
@@ -64,11 +65,11 @@ trait CompileFilters
      * @param mixed $value The raw filter value, optionally prefixed with '-' for negation
      * @param bool $isNegated Whether the filter value was prefixed with '-'
      *
-     * @return array<string, mixed> A normalized filter array with keys:
-     *                              - field: 'filename'
-     *                              - operator: 'ilike'
-     *                              - value: The filename pattern with * converted to %
-     *                              - negated: Whether the filter should be negated
+     * @return array A normalized filter array with keys:
+     *                - field: 'filename'
+     *                - operator: 'ilike'
+     *                - value: The filename pattern with * converted to %
+     *                - negated: Whether the filter should be negated
      */
     private function normalizeFilenameFilter($value, bool $isNegated): array
     {
@@ -89,20 +90,21 @@ trait CompileFilters
      * - 'gt' (greater than): uses end of day
      * - 'lt' (less than): uses start of day
      * - 'eq' (equals): uses the exact date value
+     * - 'neq' (not equals): uses the exact date value
      *
      * @param string $filterName The date field name ('created_at' or 'updated_at')
      * @param array $value An array with keys:
-     *                      - operator: The comparison operator ('gt', 'lt', 'eq')
-     *                      - ref: The table/column reference prefix
-     *                      - The value itself should be a Carbon/DateTime instance with
-     *                        startOfDay() and endOfDay() methods
+     *                      - operator: The comparison operator ('gt', 'lt', 'eq', neq)
+     *                      - ref: The table/column reference
+     *                      - date: The date of reference
      * @param bool $isNegated Whether the filter should be negated
      *
-     * @return array<string, mixed> A normalized filter array with keys:
-     *                              - field: The fully qualified field name with ::date cast
-     *                              - operator: The SQL comparison operator (>, <, =)
-     *                              - value: The date value with appropriate time boundaries
-     *                              - negated: Whether the filter should be negated
+     * @return array A normalized filter array with keys:
+     *                 - field: The fully qualified field name with ::date cast
+     *                 - operator: The SQL comparison operator (>, <, =, !=)
+     *                 - value: The date value string with appropriate time boundaries
+     *                 - negated: not used here
+     *                 - exact_date: if using equality, will force the conversion of the dates on PostrgreSQL
      */
     private function normalizeDateFilter(string $annotationType, string $filterName, array $value, bool $isNegated): array
     {
@@ -141,11 +143,11 @@ trait CompileFilters
      * @param string $value The raw filter value, optionally prefixed with '-' for negation
      * @param bool $isNegated Whether the filter value was prefixed with '-'
      *
-     * @return array<string, mixed> A normalized filter array with keys:
-     *                              - field: The database field name
-     *                              - operator: '='
-     *                              - value: The filter value without negation prefix
-     *                              - negated: Whether the filter should be negated
+     * @return array A normalized filter array with keys:
+     *               - field: The database field name
+     *               - operator: '='
+     *               - value: The filter value without negation prefix
+     *               - negated: Whether the filter should be negated
      */
     private function normalizeDefaultFilter(string $filterName, string $value, bool $isNegated): array
     {
@@ -166,11 +168,11 @@ trait CompileFilters
      *
      * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder $q
      *        The query builder instance to apply the filter to
-     * @param array<string, mixed> $filter A normalized filter array with keys:
-     *                                     - field: The database field name
-     *                                     - operator: The SQL operator
-     *                                     - value: The filter value
-     *                                     - negated: Whether to use whereNot instead of where
+     * @param array $filter A normalized filter array with keys:
+     *                      - field: The database field name
+     *                      - operator: The SQL operator
+     *                      - value: The filter value
+     *                      - negated: Whether to use whereNot instead of where
      * @param string $boolean The boolean operator for combining conditions ('and' or 'or')
      *
      * @return void

--- a/app/Traits/CompileFilters.php
+++ b/app/Traits/CompileFilters.php
@@ -20,7 +20,20 @@ trait CompileFilters
                 if ($filterName === 'filename') {
                     $operator = 'ilike';
                     $filterValues = array_map(fn ($v) => str_replace('*', '%', $v), $filterValues);
-                } else {
+                } elseif ($filterName === 'created_at' || $filterName === 'updated_at') {
+                    $filterName = "$filterValues->ref.$filterName::date";
+                    $operator = match($filterValues->operator) {
+                        'gt' => '>',
+                        'lt' => '<',
+                        'eq' => '=',
+                    };
+                    $filterValues = match($operator) {
+                        '>' => $filterValues->endOfDay(),
+                        '<' => $filterValues->startOfDay(),
+                        '=' => $filterValues,
+                    };
+                }
+                else {
                     $operator = '=';
                 }
 

--- a/resources/assets/js/largo/components/annotationFilter.vue
+++ b/resources/assets/js/largo/components/annotationFilter.vue
@@ -51,6 +51,20 @@
             </div>
             <div class="form-group largo-filter-select filter-select">
                 <select
+                    v-if="dateFilterSelected"
+                    class="form-control"
+                    v-model="dateLogicalValue"
+                    selected="true"
+                    required
+                >
+                    <option
+                        v-for="value in Object.keys(dateLogicalOptions)"
+                        :value="value"
+                        v-text="value"
+                    ></option>
+                </select>
+                <select
+                    v-else
                     class="form-control"
                     v-model="negate"
                     selected="true"
@@ -71,6 +85,10 @@
                     placeholder="Filename pattern (use * for wildcards)"
                     title="Enter a filename pattern. Use * as wildcard to match any characters."
                     >
+                <datepicker-dropdown
+                    v-else-if="dateFilterSelected"
+                    v-model="dateFilterSelectedValue"
+                    ></datepicker-dropdown>
                 <select
                     v-else
                     class="form-control"
@@ -102,8 +120,12 @@ import LargoProjectsApi from "../api/projects.js";
 import ProjectsApi from "../../core/api/projects.js";
 import VolumesApi from "../api/volumes.js";
 import { handleErrorResponse } from "@/core/messages/store.js";
+import DatepickerDropdown from '@/uiv/datepickerDropdown.vue';
 
 export default {
+    components: {
+        datepickerDropdown: DatepickerDropdown,
+    },
     emits: [
         'set-union-logic',
         'reset-filters',
@@ -123,17 +145,33 @@ export default {
             filterValues: {
                 Shape: availableShapes,
                 User: {},
-                Filename: {}
+                Filename: {},
+                'Annotation created': {},
+                'Label assigned': {},
+                'Annotation updated': {},
+                'Label updated': {},
             },
             filterToKeyMapping: {
                 Shape: "shape_id",
                 User: "user_id",
-                Filename: "filename"
+                Filename: "filename",
+                'Annotation created': "created_at",
+                'Label assigned': "created_at",
+                'Annotation updated': "updated_at",
+                'Label updated': "updated_at",
             },
             selectedFilter: "Shape",
             selectedFilterValue: null,
             filenamePattern: '',
             negate: false,
+            dateFilterSelectedValue: null,
+            dateLogicalOptions: {
+                "before": "lt",
+                "on": "eq",
+                "not on ": "neq",
+                "after": "gt",
+            },
+            dateLogicalValue: "before",
         };
 
         //Project-specific filters
@@ -154,6 +192,10 @@ export default {
                 return this.cleanFilenamePattern.length > 0;
             }
 
+            if (this.dateFilterSelected) {
+                return this.dateFilterSelectedValue !== null;
+            }
+
             return this.selectedFilterValue !== null;
         },
         cleanFilenamePattern() {
@@ -161,6 +203,10 @@ export default {
         },
         selectedFilenameFilter() {
             return this.selectedFilter === 'Filename';
+        },
+        dateFilterSelected() {
+            return this.filterToKeyMapping[this.selectedFilter].includes("created") ||
+                   this.filterToKeyMapping[this.selectedFilter].includes("updated");
         },
     },
 
@@ -234,6 +280,18 @@ export default {
                 filterValue = this.cleanFilenamePattern;
                 logicalString = this.negate ? 'does not match' : 'matches';
                 this.filenamePattern = '';
+            } else if (this.dateFilterSelected) {
+                this.negate = false;
+                let ref = this.selectedFilter.includes('Annotation') ? 'annotation' : 'annotation_label';
+                filterName = this.dateFilterSelectedValue ;
+
+                logicalString = this.dateLogicalValue;
+                filterValue = {
+                    'ref': ref,
+                    'operator': this.dateLogicalOptions[this.dateLogicalValue],
+                    'date': filterName,
+                };
+
             } else {
                 if (!this.selectedFilterValue) {
                     return;

--- a/tests/php/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelControllerTest.php
@@ -221,4 +221,75 @@ class FilterImageAnnotationsByLabelControllerTest extends ApiTestCase
         $this->get("/api/v1/projects/{$project->id}/image-annotations/filter/label/{$l1->label_id}?volume_id[]=-{$volume1->id}&volume_id[]=-{$volume2->id}")
             ->assertExactJson([$a3->id => $image3->uuid]);
     }
+
+    public function testIndexCreatedUpdatedFilter()
+    {
+        $pid = $this->project()->id;
+        $id = $this->volume()->id;
+
+        $image = ImageTest::create(['volume_id' => $id]);
+
+        $s1 = ShapeTest::create();
+
+        $a1 = ImageAnnotationTest::create(['image_id' => $image->id, 'shape_id' =>$s1->id, 'created_at' => '2025-06-11 00:01:00.000', 'updated_at' => '2025-06-11 00:01:00.000']);
+        $a2 = ImageAnnotationTest::create(['image_id' => $image->id, 'shape_id' =>$s1->id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-12 00:01:00.000']);
+        $a3 = ImageAnnotationTest::create(['image_id' => $image->id, 'shape_id' =>$s1->id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-13 00:01:00.000']);
+
+        $l1 = ImageAnnotationLabelTest::create(['annotation_id' => $a1->id, 'created_at' => '2025-06-11 00:01:00.000', 'updated_at' => '2025-06-11 00:01:00.000']);
+        $l2 = ImageAnnotationLabelTest::create(['annotation_id' => $a2->id, 'label_id' => $l1->label_id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-12 00:01:00.000']);
+        $l4 = ImageAnnotationLabelTest::create(['annotation_id' => $a3->id, 'label_id' => $l1->label_id, 'created_at' => '2025-06-13 00:01:00.000', 'updated_at' => '2025-06-14 00:01:00.000']);
+
+        $this->beEditor();
+
+        //created_at with gt, lt, eq
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=gt&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a2->id => $image->uuid, $a3->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=lt&created_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=gt&created_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a3->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=lt&created_at[0][date]=2025-06-13");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid, $a2->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=neq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a2->id => $image->uuid, $a3->id => $image->uuid], $response->json());
+
+        //updated_at
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation&updated_at[0][operator]=gt&updated_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a2->id => $image->uuid, $a3->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation&updated_at[0][operator]=lt&updated_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation&updated_at[0][operator]=eq&updated_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=gt&updated_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a3->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=lt&updated_at[0][date]=2025-06-14");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid, $a2->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=eq&updated_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=neq&updated_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid, $a3->id => $image->uuid], $response->json());
+
+        //combining
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=neq&updated_at[0][date]=2025-06-13&created_at[0][ref]=annotation_label&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=neq&updated_at[0][date]=2025-06-13&created_at[0][ref]=annotation_label&created_at[0][operator]=eq&created_at[0][date]=2025-06-11&union=1");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid, $a2->id => $image->uuid,  $a3->id => $image->uuid], $response->json());
+    }
 }

--- a/tests/php/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Projects/FilterImageAnnotationsByLabelControllerTest.php
@@ -224,10 +224,10 @@ class FilterImageAnnotationsByLabelControllerTest extends ApiTestCase
 
     public function testIndexCreatedUpdatedFilter()
     {
-        $pid = $this->project()->id;
-        $id = $this->volume()->id;
+        $id = $this->project()->id;
+        $vid = $this->volume()->id;
 
-        $image = ImageTest::create(['volume_id' => $id]);
+        $image = ImageTest::create(['volume_id' => $vid]);
 
         $s1 = ShapeTest::create();
 

--- a/tests/php/Http/Controllers/Api/Projects/FilterVideoAnnotationsByLabelControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Projects/FilterVideoAnnotationsByLabelControllerTest.php
@@ -224,10 +224,10 @@ class FilterVideoAnnotationsByLabelControllerTest extends ApiTestCase
 
     public function testIndexCreatedUpdatedFilter()
     {
-        $pid = $this->project()->id;
-        $id = $this->volume()->id;
+        $id = $this->project()->id;
+        $vid = $this->volume()->id;
 
-        $video = VideoTest::create(['volume_id' => $id]);
+        $video = VideoTest::create(['volume_id' => $vid]);
 
         $s1 = ShapeTest::create();
 

--- a/tests/php/Http/Controllers/Api/Projects/FilterVideoAnnotationsByLabelControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Projects/FilterVideoAnnotationsByLabelControllerTest.php
@@ -221,4 +221,75 @@ class FilterVideoAnnotationsByLabelControllerTest extends ApiTestCase
         $this->get("/api/v1/projects/{$project->id}/video-annotations/filter/label/{$l1->label_id}?volume_id[]=-{$volume1->id}&volume_id[]=-{$volume2->id}")
             ->assertExactJson([$a3->id => $video3->uuid]);
     }
+
+    public function testIndexCreatedUpdatedFilter()
+    {
+        $pid = $this->project()->id;
+        $id = $this->volume()->id;
+
+        $video = VideoTest::create(['volume_id' => $id]);
+
+        $s1 = ShapeTest::create();
+
+        $a1 = VideoAnnotationTest::create(['video_id' => $video->id, 'shape_id' =>$s1->id, 'created_at' => '2025-06-11 00:01:00.000', 'updated_at' => '2025-06-11 00:01:00.000']);
+        $a2 = VideoAnnotationTest::create(['video_id' => $video->id, 'shape_id' =>$s1->id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-12 00:01:00.000']);
+        $a3 = VideoAnnotationTest::create(['video_id' => $video->id, 'shape_id' =>$s1->id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-13 00:01:00.000']);
+
+        $l1 = VideoAnnotationLabelTest::create(['annotation_id' => $a1->id, 'created_at' => '2025-06-11 00:01:00.000', 'updated_at' => '2025-06-11 00:01:00.000']);
+        $l2 = VideoAnnotationLabelTest::create(['annotation_id' => $a2->id, 'label_id' => $l1->label_id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-12 00:01:00.000']);
+        $l4 = VideoAnnotationLabelTest::create(['annotation_id' => $a3->id, 'label_id' => $l1->label_id, 'created_at' => '2025-06-13 00:01:00.000', 'updated_at' => '2025-06-14 00:01:00.000']);
+
+        $this->beEditor();
+
+        //created_at with gt, lt, eq
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=gt&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a2->id => $video->uuid, $a3->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=lt&created_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=gt&created_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a3->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=lt&created_at[0][date]=2025-06-13");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid, $a2->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=neq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a2->id => $video->uuid, $a3->id => $video->uuid], $response->json());
+
+        //updated_at
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation&updated_at[0][operator]=gt&updated_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a2->id => $video->uuid, $a3->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation&updated_at[0][operator]=lt&updated_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation&updated_at[0][operator]=eq&updated_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=gt&updated_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a3->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=lt&updated_at[0][date]=2025-06-14");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid, $a2->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=eq&updated_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=neq&updated_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid, $a3->id => $video->uuid], $response->json());
+
+        //combining
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=neq&updated_at[0][date]=2025-06-13&created_at[0][ref]=annotation_label&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/projects/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=neq&updated_at[0][date]=2025-06-13&created_at[0][ref]=annotation_label&created_at[0][operator]=eq&created_at[0][date]=2025-06-11&union=1");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid, $a2->id => $video->uuid,  $a3->id => $video->uuid], $response->json());
+    }
 }

--- a/tests/php/Http/Controllers/Api/Volumes/FilterImageAnnotationsByLabelControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Volumes/FilterImageAnnotationsByLabelControllerTest.php
@@ -306,32 +306,59 @@ class FilterImageAnnotationsByLabelControllerTest extends ApiTestCase
 
         $l1 = ImageAnnotationLabelTest::create(['annotation_id' => $a1->id, 'created_at' => '2025-06-11 00:01:00.000', 'updated_at' => '2025-06-11 00:01:00.000']);
         $l2 = ImageAnnotationLabelTest::create(['annotation_id' => $a2->id, 'label_id' => $l1->label_id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-12 00:01:00.000']);
-        $l3 = ImageAnnotationLabelTest::create(['annotation_id' => $a3->id, 'label_id' => $l1->label_id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-13 00:01:00.000']);
         $l4 = ImageAnnotationLabelTest::create(['annotation_id' => $a3->id, 'label_id' => $l1->label_id, 'created_at' => '2025-06-13 00:01:00.000', 'updated_at' => '2025-06-14 00:01:00.000']);
 
         $this->beEditor();
 
         //created_at with gt, lt, eq
-        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=gt&created_at[0][date]=2025-06-12");
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=gt&created_at[0][date]=2025-06-11");
         $this->assertEqualsCanonicalizing([$a2->id => $image->uuid, $a3->id => $image->uuid], $response->json());
 
-        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=lt&created_at[0][date]=2025-06-13");
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=lt&created_at[0][date]=2025-06-12");
         $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
 
         $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
         $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
 
         $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=gt&created_at[0][date]=2025-06-12");
-        $this->assertEqualsCanonicalizing([$a2->id => $image->uuid, $a3->id => $image->uuid], $response->json());
+        $this->assertEqualsCanonicalizing([$a3->id => $image->uuid], $response->json());
 
         $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=lt&created_at[0][date]=2025-06-13");
-        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid, $a2->id => $image->uuid], $response->json());
 
         $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
         $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
 
-        //craeted
-        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=lt&created_at[0][date]=2025-06-13");
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=neq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a2->id => $image->uuid, $a3->id => $image->uuid], $response->json());
+
+        //updated_at
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation&updated_at[0][operator]=gt&updated_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a2->id => $image->uuid, $a3->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation&updated_at[0][operator]=lt&updated_at[0][date]=2025-06-12");
         $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation&updated_at[0][operator]=eq&updated_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=gt&updated_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a3->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=lt&updated_at[0][date]=2025-06-14");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid, $a2->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=eq&updated_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=neq&updated_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid, $a3->id => $image->uuid], $response->json());
+
+        //combining
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=neq&updated_at[0][date]=2025-06-13&created_at[0][ref]=annotation_label&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=neq&updated_at[0][date]=2025-06-13&created_at[0][ref]=annotation_label&created_at[0][operator]=eq&created_at[0][date]=2025-06-11&union=1");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid, $a2->id => $image->uuid,  $a3->id => $image->uuid], $response->json());
     }
 }

--- a/tests/php/Http/Controllers/Api/Volumes/FilterImageAnnotationsByLabelControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Volumes/FilterImageAnnotationsByLabelControllerTest.php
@@ -291,4 +291,47 @@ class FilterImageAnnotationsByLabelControllerTest extends ApiTestCase
         $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?filename[]=test_image_001.jpg&filename[]=another_file.png&union=1")
             ->assertExactJson([$a3->id => $image3->uuid, $a1->id => $image1->uuid]);
     }
+
+    public function testIndexCreatedUpdatedFilter()
+    {
+        $id = $this->volume()->id;
+
+        $image = ImageTest::create(['volume_id' => $id]);
+
+        $s1 = ShapeTest::create();
+
+        $a1 = ImageAnnotationTest::create(['image_id' => $image->id, 'shape_id' =>$s1->id, 'created_at' => '2025-06-11 00:01:00.000', 'updated_at' => '2025-06-11 00:01:00.000']);
+        $a2 = ImageAnnotationTest::create(['image_id' => $image->id, 'shape_id' =>$s1->id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-12 00:01:00.000']);
+        $a3 = ImageAnnotationTest::create(['image_id' => $image->id, 'shape_id' =>$s1->id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-13 00:01:00.000']);
+
+        $l1 = ImageAnnotationLabelTest::create(['annotation_id' => $a1->id, 'created_at' => '2025-06-11 00:01:00.000', 'updated_at' => '2025-06-11 00:01:00.000']);
+        $l2 = ImageAnnotationLabelTest::create(['annotation_id' => $a2->id, 'label_id' => $l1->label_id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-12 00:01:00.000']);
+        $l3 = ImageAnnotationLabelTest::create(['annotation_id' => $a3->id, 'label_id' => $l1->label_id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-13 00:01:00.000']);
+        $l4 = ImageAnnotationLabelTest::create(['annotation_id' => $a3->id, 'label_id' => $l1->label_id, 'created_at' => '2025-06-13 00:01:00.000', 'updated_at' => '2025-06-14 00:01:00.000']);
+
+        $this->beEditor();
+
+        //created_at with gt, lt, eq
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=gt&created_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a2->id => $image->uuid, $a3->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=lt&created_at[0][date]=2025-06-13");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=gt&created_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a2->id => $image->uuid, $a3->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=lt&created_at[0][date]=2025-06-13");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+
+        //craeted
+        $response = $this->get("/api/v1/volumes/{$id}/image-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=lt&created_at[0][date]=2025-06-13");
+        $this->assertEqualsCanonicalizing([$a1->id => $image->uuid], $response->json());
+    }
 }

--- a/tests/php/Http/Controllers/Api/Volumes/FilterVideoAnnotationsByLabelControllerTest.php
+++ b/tests/php/Http/Controllers/Api/Volumes/FilterVideoAnnotationsByLabelControllerTest.php
@@ -291,4 +291,74 @@ class FilterVideoAnnotationsByLabelControllerTest extends ApiTestCase
         $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?filename[]=test_video_001.mp4&filename[]=another_file.webm&union=1")
             ->assertExactJson([$a3->id => $video3->uuid, $a1->id => $video1->uuid]);
     }
+
+    public function testIndexCreatedUpdatedFilter()
+    {
+        $id = $this->volume()->id;
+
+        $video = VideoTest::create(['volume_id' => $id]);
+
+        $s1 = ShapeTest::create();
+
+        $a1 = VideoAnnotationTest::create(['video_id' => $video->id, 'shape_id' =>$s1->id, 'created_at' => '2025-06-11 00:01:00.000', 'updated_at' => '2025-06-11 00:01:00.000']);
+        $a2 = VideoAnnotationTest::create(['video_id' => $video->id, 'shape_id' =>$s1->id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-12 00:01:00.000']);
+        $a3 = VideoAnnotationTest::create(['video_id' => $video->id, 'shape_id' =>$s1->id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-13 00:01:00.000']);
+
+        $l1 = VideoAnnotationLabelTest::create(['annotation_id' => $a1->id, 'created_at' => '2025-06-11 00:01:00.000', 'updated_at' => '2025-06-11 00:01:00.000']);
+        $l2 = VideoAnnotationLabelTest::create(['annotation_id' => $a2->id, 'label_id' => $l1->label_id, 'created_at' => '2025-06-12 00:01:00.000', 'updated_at' => '2025-06-12 00:01:00.000']);
+        $l4 = VideoAnnotationLabelTest::create(['annotation_id' => $a3->id, 'label_id' => $l1->label_id, 'created_at' => '2025-06-13 00:01:00.000', 'updated_at' => '2025-06-14 00:01:00.000']);
+
+        $this->beEditor();
+
+        //created_at with gt, lt, eq
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=gt&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a2->id => $video->uuid, $a3->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=lt&created_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=gt&created_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a3->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=lt&created_at[0][date]=2025-06-13");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid, $a2->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?created_at[0][ref]=annotation_label&created_at[0][operator]=neq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a2->id => $video->uuid, $a3->id => $video->uuid], $response->json());
+
+        //updated_at
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation&updated_at[0][operator]=gt&updated_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a2->id => $video->uuid, $a3->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation&updated_at[0][operator]=lt&updated_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation&updated_at[0][operator]=eq&updated_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=gt&updated_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a3->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=lt&updated_at[0][date]=2025-06-14");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid, $a2->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=eq&updated_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=neq&updated_at[0][date]=2025-06-12");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid, $a3->id => $video->uuid], $response->json());
+
+        //combining
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=neq&updated_at[0][date]=2025-06-13&created_at[0][ref]=annotation_label&created_at[0][operator]=eq&created_at[0][date]=2025-06-11");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid], $response->json());
+
+        $response = $this->get("/api/v1/volumes/{$id}/video-annotations/filter/label/{$l1->label_id}?updated_at[0][ref]=annotation_label&updated_at[0][operator]=neq&updated_at[0][date]=2025-06-13&created_at[0][ref]=annotation_label&created_at[0][operator]=eq&created_at[0][date]=2025-06-11&union=1");
+        $this->assertEqualsCanonicalizing([$a1->id => $video->uuid, $a2->id => $video->uuid,  $a3->id => $video->uuid], $response->json());
+    }
 }


### PR DESCRIPTION
Resolves #1166 
Creates a `created_at` and `updated_at` filter for Largo. It was not straightforward as an implementation. The solution I found was to use an array 
```
[
  created_at => [
    ref => 'annotation'
    operator => 'gt'
    date=>'2025-01-02'
]
]
```
with ref as `annotation` or `annotation_label`,  'gt', 'lt', 'eq', 'neq' to explain whether the annotation is after, before, on a day or not on a day. For `updated_at` is the same.