### PR TITLE
Fixed validation for concurrent metadata imports

### DIFF
--- a/app/Http/Controllers/Api/PendingVolumeController.php
+++ b/app/Http/Controllers/Api/PendingVolumeController.php
@@ -7,11 +7,11 @@ use Biigle\Http\Requests\StorePendingVolumeFromVolume;
 use Biigle\Http\Requests\UpdatePendingVolume;
 use Biigle\Jobs\CreateNewImagesOrVideos;
 use Biigle\PendingVolume;
-use Biigle\Project;
-use Biigle\Role;
 use Biigle\Volume;
 use DB;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 use Queue;
 use Storage;
 
@@ -86,20 +86,20 @@ class PendingVolumeController extends Controller
      */
     public function storeVolume(StorePendingVolumeFromVolume $request)
     {
-        $project = Project::inCommon($request->user(), $request->volume->id, [Role::adminId()])->first();
-
-        // Delete individually to trigger deletion of metadata files.
-        $project->pendingVolumes()->where('user_id', $request->user()->id)
-            ->eachById(fn ($pv) => $pv->delete());
-
-        $pv = $project->pendingVolumes()->create([
-            'volume_id' => $request->volume->id,
-            'media_type_id' => $request->volume->media_type_id,
-            'user_id' => $request->user()->id,
-            'metadata_parser' => $request->volume->metadata_parser,
-            'import_annotations' => $request->input('import_annotations', false),
-            'import_file_labels' => $request->input('import_file_labels', false),
-        ]);
+        try {
+            $pv = $request->project->pendingVolumes()->create([
+                'volume_id' => $request->volume->id,
+                'media_type_id' => $request->volume->media_type_id,
+                'user_id' => $request->user()->id,
+                'metadata_parser' => $request->volume->metadata_parser,
+                'import_annotations' => $request->input('import_annotations', false),
+                'import_file_labels' => $request->input('import_file_labels', false),
+            ]);
+        } catch (UniqueConstraintViolationException) {
+            throw ValidationException::withMessages([
+                'id' => StorePendingVolumeFromVolume::PENDING_VOLUME_EXISTS_MESSAGE,
+            ]);
+        }
 
         $pv->update([
             'metadata_file_path' => $pv->id.'.'.pathinfo($request->volume->metadata_file_path, PATHINFO_EXTENSION),

--- a/app/Http/Controllers/Api/PendingVolumeController.php
+++ b/app/Http/Controllers/Api/PendingVolumeController.php
@@ -7,6 +7,8 @@ use Biigle\Http\Requests\StorePendingVolumeFromVolume;
 use Biigle\Http\Requests\UpdatePendingVolume;
 use Biigle\Jobs\CreateNewImagesOrVideos;
 use Biigle\PendingVolume;
+use Biigle\Project;
+use Biigle\Role;
 use Biigle\Volume;
 use DB;
 use Illuminate\Database\UniqueConstraintViolationException;
@@ -86,18 +88,26 @@ class PendingVolumeController extends Controller
      */
     public function storeVolume(StorePendingVolumeFromVolume $request)
     {
+        $project = Project::inCommon($request->user(), $request->volume->id, [Role::adminId()])->first();
+
         try {
-            $pv = $request->project->pendingVolumes()->create([
-                'volume_id' => $request->volume->id,
-                'media_type_id' => $request->volume->media_type_id,
-                'user_id' => $request->user()->id,
-                'metadata_parser' => $request->volume->metadata_parser,
-                'import_annotations' => $request->input('import_annotations', false),
-                'import_file_labels' => $request->input('import_file_labels', false),
-            ]);
+            $pv = DB::transaction(function () use ($project, $request) {
+                // Delete individually to trigger deletion of metadata files.
+                $project->pendingVolumes()->where('user_id', $request->user()->id)
+                    ->eachById(fn ($pv) => $pv->delete());
+
+                return $project->pendingVolumes()->create([
+                    'volume_id' => $request->volume->id,
+                    'media_type_id' => $request->volume->media_type_id,
+                    'user_id' => $request->user()->id,
+                    'metadata_parser' => $request->volume->metadata_parser,
+                    'import_annotations' => $request->input('import_annotations', false),
+                    'import_file_labels' => $request->input('import_file_labels', false),
+                ]);
+            });
         } catch (UniqueConstraintViolationException) {
             throw ValidationException::withMessages([
-                'id' => StorePendingVolumeFromVolume::PENDING_VOLUME_EXISTS_MESSAGE,
+                'id' => 'Only one metadata import can be performed at a time.',
             ]);
         }
 

--- a/app/Http/Requests/StorePendingVolumeFromVolume.php
+++ b/app/Http/Requests/StorePendingVolumeFromVolume.php
@@ -2,11 +2,15 @@
 
 namespace Biigle\Http\Requests;
 
+use Biigle\Project;
+use Biigle\Role;
 use Biigle\Volume;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StorePendingVolumeFromVolume extends FormRequest
 {
+    public const PENDING_VOLUME_EXISTS_MESSAGE = 'Only one metadata import can be performed at a time for each project and user.';
+
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -14,7 +18,13 @@ class StorePendingVolumeFromVolume extends FormRequest
     {
         $this->volume = Volume::findOrFail($this->route('id'));
 
-        return $this->user()->can('update', $this->volume);
+        if (!$this->user()->can('update', $this->volume)) {
+            return false;
+        }
+
+        $this->project = Project::inCommon($this->user(), $this->volume->id, [Role::adminId()])->first();
+
+        return !is_null($this->project);
     }
 
     /**
@@ -44,6 +54,15 @@ class StorePendingVolumeFromVolume extends FormRequest
             }
 
             if ($validator->errors()->isNotEmpty()) {
+                return;
+            }
+
+            $exists = $this->project->pendingVolumes()
+                ->where('user_id', $this->user()->id)
+                ->exists();
+
+            if ($exists) {
+                $validator->errors()->add('id', self::PENDING_VOLUME_EXISTS_MESSAGE);
                 return;
             }
 

--- a/app/Http/Requests/StorePendingVolumeFromVolume.php
+++ b/app/Http/Requests/StorePendingVolumeFromVolume.php
@@ -2,15 +2,11 @@
 
 namespace Biigle\Http\Requests;
 
-use Biigle\Project;
-use Biigle\Role;
 use Biigle\Volume;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StorePendingVolumeFromVolume extends FormRequest
 {
-    public const PENDING_VOLUME_EXISTS_MESSAGE = 'Only one metadata import can be performed at a time for each project and user.';
-
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -18,13 +14,7 @@ class StorePendingVolumeFromVolume extends FormRequest
     {
         $this->volume = Volume::findOrFail($this->route('id'));
 
-        if (!$this->user()->can('update', $this->volume)) {
-            return false;
-        }
-
-        $this->project = Project::inCommon($this->user(), $this->volume->id, [Role::adminId()])->first();
-
-        return !is_null($this->project);
+        return $this->user()->can('update', $this->volume);
     }
 
     /**
@@ -54,15 +44,6 @@ class StorePendingVolumeFromVolume extends FormRequest
             }
 
             if ($validator->errors()->isNotEmpty()) {
-                return;
-            }
-
-            $exists = $this->project->pendingVolumes()
-                ->where('user_id', $this->user()->id)
-                ->exists();
-
-            if ($exists) {
-                $validator->errors()->add('id', self::PENDING_VOLUME_EXISTS_MESSAGE);
                 return;
             }
 

--- a/resources/views/volumes/edit/metadata.blade.php
+++ b/resources/views/volumes/edit/metadata.blade.php
@@ -39,7 +39,7 @@
             <input type="hidden" name="import_annotations" v-model="importForm.importAnnotations">
             <input type="hidden" name="import_file_labels" v-model="importForm.importFileLabels">
         </form>
-        @if ($errors->hasAny(['import_annotations', 'import_file_labels']))
+        @if ($errors->hasAny(['id', 'import_annotations', 'import_file_labels']))
             <p class="text-danger">
                 {{ $errors->first() }}
             </p>

--- a/tests/php/Http/Controllers/Api/PendingVolumeControllerTest.php
+++ b/tests/php/Http/Controllers/Api/PendingVolumeControllerTest.php
@@ -371,11 +371,12 @@ class PendingVolumeControllerTest extends ApiTestCase
 
         $this->json('POST', "/api/v1/volumes/{$id}/pending-volumes", [
             'import_annotations' => true,
-        ])->assertStatus(201);
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('id')
+            ->assertJsonPath('errors.id.0', 'Only one metadata import can be performed at a time for each project and user.');
 
-        $pv = PendingVolume::where('volume_id', $id)->first();
-        $this->assertNotSame($old->id, $pv->id);
-        $this->assertNull($old->fresh());
+        $this->assertNotNull($old->fresh());
+        $this->assertSame(1, PendingVolume::count());
     }
 
     public function testStoreVolumeTwiceDifferentVolumes()
@@ -419,11 +420,11 @@ class PendingVolumeControllerTest extends ApiTestCase
 
         $this->json('POST', "/api/v1/volumes/{$id}/pending-volumes", [
             'import_annotations' => true,
-        ])->assertStatus(201);
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('id');
 
-        $pv = PendingVolume::where('volume_id', $id)->first();
-        $this->assertNotSame($old->id, $pv->id);
-        $this->assertNull($old->fresh());
+        $this->assertNotNull($old->fresh());
+        $this->assertSame(1, PendingVolume::count());
     }
 
     public function testUpdateImages()

--- a/tests/php/Http/Controllers/Api/PendingVolumeControllerTest.php
+++ b/tests/php/Http/Controllers/Api/PendingVolumeControllerTest.php
@@ -18,6 +18,7 @@ use Biigle\Shape;
 use Biigle\Volume;
 use Exception;
 use FileCache;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Queue;
@@ -371,12 +372,11 @@ class PendingVolumeControllerTest extends ApiTestCase
 
         $this->json('POST', "/api/v1/volumes/{$id}/pending-volumes", [
             'import_annotations' => true,
-        ])->assertStatus(422)
-            ->assertJsonValidationErrors('id')
-            ->assertJsonPath('errors.id.0', 'Only one metadata import can be performed at a time for each project and user.');
+        ])->assertStatus(201);
 
-        $this->assertNotNull($old->fresh());
-        $this->assertSame(1, PendingVolume::count());
+        $pv = PendingVolume::where('volume_id', $id)->first();
+        $this->assertNotSame($old->id, $pv->id);
+        $this->assertNull($old->fresh());
     }
 
     public function testStoreVolumeTwiceDifferentVolumes()
@@ -420,8 +420,67 @@ class PendingVolumeControllerTest extends ApiTestCase
 
         $this->json('POST', "/api/v1/volumes/{$id}/pending-volumes", [
             'import_annotations' => true,
+        ])->assertStatus(201);
+
+        $pv = PendingVolume::where('volume_id', $id)->first();
+        $this->assertNotSame($old->id, $pv->id);
+        $this->assertNull($old->fresh());
+    }
+
+    public function testStoreVolumeConcurrently()
+    {
+        config([
+            'volumes.metadata_storage_disk' => 'metadata',
+            'volumes.pending_metadata_storage_disk' => 'pending-metadata',
+        ]);
+        $metaDisk = Storage::fake('metadata');
+        $metaDisk->put('metadata.csv', 'abc');
+        Storage::fake('pending-metadata');
+
+        $id = $this->volume()->id;
+        $old = PendingVolume::factory()->create([
+            'project_id' => $this->project()->id,
+            'user_id' => $this->admin()->id,
+        ]);
+
+        $this->beAdmin();
+        $this->volume()->update([
+            'metadata_file_path' => 'metadata.csv',
+            'metadata_parser' => ImageCsvParser::class,
+        ]);
+
+        $metadata = new VolumeMetadata;
+        $file = new ImageMetadata('1.jpg');
+        $metadata->addFile($file);
+        $label = new Label(123, 'my label');
+        $user = new User(321, 'joe user');
+        $lau = new LabelAndUser($label, $user);
+        $annotation = new ImageAnnotation(
+            shape: Shape::point(),
+            points: [10, 10],
+            labels: [$lau],
+        );
+        $file->addAnnotation($annotation);
+        Cache::store('array')->put('metadata-metadata-metadata.csv', $metadata);
+
+        $throw = true;
+        PendingVolume::creating(function () use (&$throw) {
+            if ($throw) {
+                $throw = false;
+                throw new UniqueConstraintViolationException(
+                    'testing',
+                    'insert into pending_volumes',
+                    [],
+                    new Exception('duplicate'),
+                );
+            }
+        });
+
+        $this->json('POST', "/api/v1/volumes/{$id}/pending-volumes", [
+            'import_annotations' => true,
         ])->assertStatus(422)
-            ->assertJsonValidationErrors('id');
+            ->assertJsonValidationErrors('id')
+            ->assertJsonPath('errors.id.0', 'Only one metadata import can be performed at a time.');
 
         $this->assertNotNull($old->fresh());
         $this->assertSame(1, PendingVolume::count());


### PR DESCRIPTION
## Changes

- Wrap pending-volume deletion and creation in a database transaction.
- Preserve the existing sequential replacement behavior.
- Convert concurrent unique-constraint violations into a validation
  response.
- Display the validation message on the volume metadata page.
- Add regression coverage for sequential and concurrent requests.

Closes #1256