### PR TITLE
added shortcuts modal hotkeys

### DIFF
--- a/resources/assets/js/annotations/components/shortcutsButton.vue
+++ b/resources/assets/js/annotations/components/shortcutsButton.vue
@@ -28,6 +28,7 @@ export default {
     },
     data() {
         return {
+            keyboardOffCallbacks: [],
             showKeyboardShortcutsModal: false,
         };
     },
@@ -45,7 +46,14 @@ export default {
             }
         }
     },
+    created() {
+        this.keyboardOffCallbacks.push(
+            Keyboard.on('F1', this.openKeyboardShortcutsModal),
+            Keyboard.on('q', this.openKeyboardShortcutsModal),
+        );
+    },
     beforeUnmount() {
+        this.keyboardOffCallbacks.forEach(off => off());
         Keyboard.enable();
     }
 };

--- a/resources/views/partials/image-annotation-shortcuts.blade.php
+++ b/resources/views/partials/image-annotation-shortcuts.blade.php
@@ -13,7 +13,7 @@
     <tbody>
         <tr>
             <td><kbd>F1</kbd>, <kbd>Q</kbd></td>
-            <td>Show keyboard shortcuts</td>
+            <td>Show available keyboard shortcuts</td>
         </tr>
         <tr>
             <td><kbd>Arrow left</kbd></td>

--- a/resources/views/partials/image-annotation-shortcuts.blade.php
+++ b/resources/views/partials/image-annotation-shortcuts.blade.php
@@ -12,6 +12,10 @@
     </thead>
     <tbody>
         <tr>
+            <td><kbd>F1</kbd>, <kbd>Q</kbd></td>
+            <td>Show keyboard shortcuts</td>
+        </tr>
+        <tr>
             <td><kbd>Arrow left</kbd></td>
             <td>Previous image</td>
         </tr>

--- a/resources/views/partials/largo-shortcuts.blade.php
+++ b/resources/views/partials/largo-shortcuts.blade.php
@@ -12,7 +12,7 @@
     <tbody>
         <tr>
             <td><kbd>F1</kbd>, <kbd>Q</kbd></td>
-            <td>Show keyboard shortcuts</td>
+            <td>Show available keyboard shortcuts</td>
         </tr>
         <tr>
             <td><kbd>X</kbd></td>

--- a/resources/views/partials/largo-shortcuts.blade.php
+++ b/resources/views/partials/largo-shortcuts.blade.php
@@ -11,6 +11,10 @@
     </thead>
     <tbody>
         <tr>
+            <td><kbd>F1</kbd>, <kbd>Q</kbd></td>
+            <td>Show keyboard shortcuts</td>
+        </tr>
+        <tr>
             <td><kbd>X</kbd></td>
             <td>Sort annotation patches by creation time</td>
         </tr>

--- a/resources/views/partials/video-annotation-shortcuts.blade.php
+++ b/resources/views/partials/video-annotation-shortcuts.blade.php
@@ -11,6 +11,10 @@
     </thead>
     <tbody>
         <tr>
+            <td><kbd>F1</kbd>, <kbd>Q</kbd></td>
+            <td>Show keyboard shortcuts</td>
+        </tr>
+        <tr>
             <td><kbd>Arrow left</kbd></td>
             <td>Previous video</td>
         </tr>

--- a/resources/views/partials/video-annotation-shortcuts.blade.php
+++ b/resources/views/partials/video-annotation-shortcuts.blade.php
@@ -12,7 +12,7 @@
     <tbody>
         <tr>
             <td><kbd>F1</kbd>, <kbd>Q</kbd></td>
-            <td>Show keyboard shortcuts</td>
+            <td>Show available keyboard shortcuts</td>
         </tr>
         <tr>
             <td><kbd>Arrow left</kbd></td>


### PR DESCRIPTION
## Changes

- Added `F1` and `Q` shortcuts to open the keyboard shortcuts modal.
- the new shortcuts works in image annotation, video annotation, and Largo shortcut tables

Closes #1446.