### PR TITLE
Disallow own domain for remote volumes

### DIFF
--- a/app/Rules/VolumeUrl.php
+++ b/app/Rules/VolumeUrl.php
@@ -78,6 +78,12 @@ class VolumeUrl implements Rule
     {
         $client = App::make(Client::class);
 
+        if ($this->isOwnDomain($value)) {
+            $this->message = "The application's own domain cannot be used in volume URLs.";
+
+            return false;
+        }
+
         if ($this->isDeniedProvider($value)) {
             $this->message = 'Personal storage providers such as Dropbox, OneDrive or Google Drive are not supported as remote locations.';
 
@@ -185,6 +191,21 @@ class VolumeUrl implements Rule
         }
 
         return false;
+    }
+
+    /**
+     * Determine if the remote volume URL points to this application.
+     *
+     * @param string $value
+     *
+     * @return boolean
+     */
+    protected function isOwnDomain($value)
+    {
+        $ownDomain = parse_url(config('app.url'), PHP_URL_HOST);
+        $domain = parse_url($value, PHP_URL_HOST);
+
+        return $ownDomain && $domain && strcasecmp($ownDomain, $domain) === 0;
     }
 
     /**

--- a/tests/php/Rules/VolumeUrlTest.php
+++ b/tests/php/Rules/VolumeUrlTest.php
@@ -214,10 +214,6 @@ class VolumeUrlTest extends TestCase
     public function testRemoteOwnDomain()
     {
         $mock = new MockHandler([
-            new Response(200),
-            new Response(200),
-            new Response(200),
-            new Response(200),
         ]);
 
         $handler = HandlerStack::create($mock);

--- a/tests/php/Rules/VolumeUrlTest.php
+++ b/tests/php/Rules/VolumeUrlTest.php
@@ -44,6 +44,7 @@ class VolumeUrlTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+        config(['app.url' => 'https://biigle.de']);
         config(['volumes.editor_storage_disks' => ['test']]);
         $this->user = User::factory()->make(['role_id' => Role::editorId()]);
         $this->be($this->user);
@@ -147,7 +148,7 @@ class VolumeUrlTest extends TestCase
         $client = new Client(['handler' => $handler]);
         app()->bind(Client::class, fn () => $client);
         $validator = new VolumeUrl;
-        $this->assertFalse($validator->passes(null, 'http://localhost'));
+        $this->assertFalse($validator->passes(null, 'http://example.com'));
         $this->assertStringContainsString('The remote volume URL does not seem to exist', $validator->message());
     }
 
@@ -159,11 +160,11 @@ class VolumeUrlTest extends TestCase
         $client = new Client(['handler' => $handler]);
         app()->bind(Client::class, fn () => $client);
         $validator = new VolumeUrl;
-        $this->assertFalse($validator->passes(null, 'http://localhost'));
+        $this->assertFalse($validator->passes(null, 'http://example.com'));
         $this->assertStringContainsString('The remote volume URL returned an error response', $validator->message());
     }
 
-    public function testRemoteOk()
+    public function testRemoteSubdomainOk()
     {
         $mock = new MockHandler([
             new Response(404),
@@ -179,11 +180,11 @@ class VolumeUrlTest extends TestCase
         app()->bind(Client::class, fn () => $client);
 
         $validator = new VolumeUrl;
-        $this->assertTrue($validator->passes(null, 'http://localhost'));
+        $this->assertTrue($validator->passes(null, 'http://files.biigle.de'));
 
         $request = $container[0]['request'];
         $this->assertSame('HEAD', $request->getMethod());
-        $this->assertSame('http://localhost', (string) $request->getUri());
+        $this->assertSame('http://files.biigle.de', (string) $request->getUri());
     }
 
     public function testRemoteOfflineMode()
@@ -210,6 +211,33 @@ class VolumeUrlTest extends TestCase
         $this->assertFalse($validator->passes(null, 'https://drive.google.com'));
     }
 
+    public function testRemoteOwnDomain()
+    {
+        $mock = new MockHandler([
+            new Response(200),
+            new Response(200),
+            new Response(200),
+            new Response(200),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        app()->bind(Client::class, fn () => $client);
+
+        $urls = [
+            'https://biigle.de',
+            'http://biigle.de',
+            'https://biigle.de:8000/volumes/1',
+            'https://BIIGLE.DE/volumes/1',
+        ];
+
+        foreach ($urls as $url) {
+            $validator = new VolumeUrl;
+            $this->assertFalse($validator->passes(null, $url));
+            $this->assertStringContainsString('own domain', $validator->message());
+        }
+    }
+
     public function testRemoteProviderTraversals()
     {
         $mock = new MockHandler([
@@ -227,11 +255,11 @@ class VolumeUrlTest extends TestCase
 
         $validator = new VolumeUrl;
         foreach ($this->traversalAttempts as $attempt) {
-            $this->assertFalse($validator->passes(null, 'http://localhost/'.$attempt));
+            $this->assertFalse($validator->passes(null, 'http://example.com/'.$attempt));
             $this->assertStringContainsString('Volume URLs with path traversal instructions are not allowed.', $validator->message());
         }
         foreach ($this->validPathAttempts as $attempt) {
-            $this->assertFalse($validator::pathHasDirectoryTraversal(null, 'http://localhost/'.$attempt));
+            $this->assertFalse($validator::pathHasDirectoryTraversal(null, 'http://example.com/'.$attempt));
         }
     }
 }


### PR DESCRIPTION
## Summary

- Rejects remote volume URLs that use the hostname configured in `APP_URL`.
- Compare hostnames case-insensitively and independently of scheme, port, and path.
- Keep external domains and subdomains valid.
- Added regression tests for own-domain URLs.
